### PR TITLE
Snapshot-Builds als GitHub-Release (manuell getriggert)

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,107 @@
+name: snapshot
+
+# Snapshot builds for the desktop clients — manual only. You pick the moment;
+# this builds the runnable jars from the branch you trigger on and puts them
+# behind a rolling `snapshot` pre-release, so the download URLs never change:
+#
+#   .../releases/download/snapshot/mc-agent-admin-ui-app-exec.jar
+#   .../releases/download/snapshot/mc-agent-cli-exec.jar
+#   .../releases/download/snapshot/snapshot.txt   (version, commit, build time)
+#
+# Nothing here touches Maven Central or the version in the POMs — that stays
+# the job of release.yml.
+on:
+  workflow_dispatch:
+    inputs:
+      modules:
+        description: 'What to publish'
+        type: choice
+        options: [both, admin-ui-app, cli]
+        default: both
+
+permissions:
+  contents: write   # move the `snapshot` tag and write its release
+
+concurrency:
+  group: snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # The agents reactor consumes workflow artifacts it does not build
+      # itself, and needs the base parent as an installed artifact — the same
+      # prerequisites build.yml sets up for the agents area.
+      - name: Install parent + workflow artifacts
+        run: |
+          mvn -B -ntp -N -f mc-java-parent/pom.xml install
+          mvn -B -ntp -f workflow/pom.xml clean install -DskipTests
+
+      - name: Build the executable jars
+        run: |
+          set -euo pipefail
+          case "${{ inputs.modules }}" in
+            admin-ui-app) pl="server/mc-agent-admin-ui-app" ;;
+            cli)          pl="client/mc-agent-cli" ;;
+            *)            pl="server/mc-agent-admin-ui-app,client/mc-agent-cli" ;;
+          esac
+          mvn -B -ntp -f agents/pom.xml clean install -DskipTests -pl "$pl" -am
+
+      # Stable asset names: no version in them, so a client can hard-code the
+      # URL. What you actually got is in snapshot.txt next to them.
+      - name: Collect the assets
+        run: |
+          set -euo pipefail
+          mkdir -p snapshot-assets
+          ver=$(mvn -B -q -ntp -DforceStdout help:evaluate -Dexpression=project.version)
+          for m in server/mc-agent-admin-ui-app:mc-agent-admin-ui-app \
+                   client/mc-agent-cli:mc-agent-cli; do
+            jar="agents/${m%%:*}/target/${m##*:}-${ver}-exec.jar"
+            if [ -f "$jar" ]; then
+              cp "$jar" "snapshot-assets/${m##*:}-exec.jar"
+              echo "collected $jar"
+            fi
+          done
+          printf '%s\n' \
+            "version: $ver" \
+            "commit:  ${GITHUB_SHA::7}" \
+            "branch:  $GITHUB_REF_NAME" \
+            "built:   $(date -u +%Y-%m-%dT%H:%MZ)" \
+            > snapshot-assets/snapshot.txt
+          cat snapshot-assets/snapshot.txt
+          ls -lh snapshot-assets
+
+      # `gh release create` will not move an existing tag, so the rolling
+      # release is replaced rather than edited. The assets are gone for the few
+      # seconds in between — a snapshot channel can afford that, a stable
+      # download URL is what it cannot do without.
+      - name: Replace the rolling snapshot release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release delete snapshot --yes --cleanup-tag || true
+          gh release create snapshot snapshot-assets/* \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "Snapshot $(date -u +%Y-%m-%d)" \
+            --notes "Built from \`$GITHUB_REF_NAME\` at ${GITHUB_SHA::7}.
+
+          Not a release: these assets are replaced in place, under the same URLs. For something stable, take a version from [Maven Central](https://central.sonatype.com/namespace/ai.mindconnect) or a tagged release.
+
+          Run either jar with a JDK 21:
+
+          \`\`\`bash
+          java -jar mc-agent-admin-ui-app-exec.jar
+          \`\`\`"

--- a/agents/client/mc-agent-cli/pom.xml
+++ b/agents/client/mc-agent-cli/pom.xml
@@ -56,6 +56,18 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals><goal>repackage</goal></goals>
+                        <configuration>
+                            <!-- The plain jar stays the main artifact (that is
+                                 what goes to Central); the runnable one rides
+                                 along as -exec.jar, for `java -jar` without a
+                                 Maven around it. -->
+                            <classifier>exec</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -130,6 +130,18 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals><goal>repackage</goal></goals>
+                        <configuration>
+                            <!-- The plain jar stays the main artifact (that is
+                                 what goes to Central); the runnable one rides
+                                 along as -exec.jar, which is what the desktop
+                                 launcher downloads and starts. -->
+                            <classifier>exec</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Snapshot-Builds für die Desktop-Clients — manuell getriggert, feste Download-Adresse.

## Warum

Die Clients (Admin-Launcher, JavaFX-Chat) holen den Server heute von Maven Central. Dort liegen aber nur Releases, und nur das schlanke Jar ohne `Main-Class` — der Launcher fällt deshalb auf Maven-Dependency-Resolution zurück und lädt 343 MB in Hunderten Einzeldateien.

## Was drin ist

**Startbare Jars** (je 12 Zeilen in zwei POMs): `spring-boot:repackage` mit Classifier `exec`. Das schlanke Jar bleibt das Hauptartefakt, am Central-Deploy ändert sich nichts — und `java -jar target/…-exec.jar` funktioniert auch nach einem normalen lokalen Build.

**`.github/workflows/snapshot.yml`**, nur `workflow_dispatch` (Auswahl `both` / `admin-ui-app` / `cli`): baut aus dem Branch, aus dem getriggert wird, und legt die Jars unter dem rollenden Pre-Release `snapshot` ab.

```
.../releases/download/snapshot/mc-agent-admin-ui-app-exec.jar
.../releases/download/snapshot/mc-agent-cli-exec.jar
.../releases/download/snapshot/snapshot.txt
```

Die Asset-Namen tragen keine Version, damit die URL stabil bleibt; was tatsächlich drin ist, steht in `snapshot.txt` daneben (Version, Commit, Branch, Bauzeit).

## Zwei bewusste Entscheidungen

Der Tag wandert per Delete-und-Neuanlegen, weil `gh release create` einen bestehenden Tag nicht verschiebt. Für ein paar Sekunden sind die Assets weg — ein Snapshot-Kanal kann sich das leisten, eine stabile URL nicht entbehren.

Maven Central und die Versionen in den POMs bleiben unberührt; das ist weiterhin allein Sache von `release.yml`.

## Getestet

Die Schrittfolge des Workflows lokal komplett durchgefahren (Parent installieren, workflow-Area installieren, dann `-pl server/mc-agent-admin-ui-app,client/mc-agent-cli -am`). Beide Exec-Jars entstehen mit korrekter `Start-Class`, die schlanken Jars bleiben unverändert bei 68 KB / 93 KB.

Nach dem Merge erscheint der „Run workflow"-Knopf — vorher zeigt GitHub ihn nicht, weil der Workflow dafür auf dem Default-Branch liegen muss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
