### PR TITLE
Doku: REST-API samt Stream und Approvals, plus Start ohne Build

### DIFF
--- a/website/docs/agents/getting-started.md
+++ b/website/docs/agents/getting-started.md
@@ -13,6 +13,31 @@ sidebar_position: 1
 That's it for local use — **no Docker, no Keycloak, no database** are needed to
 run the Admin UI in its default mode.
 
+## Run it without building
+
+If you only want to *use* the Admin UI, take a runnable jar instead of a
+checkout. The `snapshot` pre-release carries the current development build of
+main as a single self-contained file:
+
+```bash
+curl -LO https://github.com/mindconnect-ai/mindconnect/releases/download/snapshot/mc-agent-admin-ui-app-0.0.3-SNAPSHOT-exec.jar
+export MINDCONNECT_ENCRYPTION_SECRET_KEY="change-me-to-a-32-char-secret!!!"
+java -jar mc-agent-admin-ui-app-0.0.3-SNAPSHOT-exec.jar
+```
+
+The file name carries the version, so it changes when a release opens the next
+one. `snapshot.txt` next to it names the current build (version, commit, build
+time) — that is the file to read before assembling a URL.
+
+These are development builds, replaced in place whenever the snapshot workflow
+runs. Released versions live on [Maven
+Central](https://central.sonatype.com/namespace/ai.mindconnect).
+
+Prefer not to touch a terminal at all? The [desktop
+launcher](https://github.com/mindconnect-ai/mc-clients/releases/latest)
+downloads either channel, edits the environment and starts and stops the
+server for you.
+
 ## Build
 
 ```bash

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -1,0 +1,150 @@
+---
+title: REST API
+sidebar_position: 8
+---
+
+# REST API
+
+The agent server (`mc-agent-api-app`) exposes the same use cases the Admin UI
+runs on, as a plain JSON API under `/api`. It is what the desktop chat client
+talks to, and what your own front end would talk to.
+
+```bash
+mvn -f agents/server/mc-agent-api-app/pom.xml spring-boot:run
+```
+
+Interactive documentation ships with the server: **http://localhost:8080/swagger-ui.html**,
+generated from the same annotations the endpoints carry. The pages below cover
+the parts that need more explanation than a signature.
+
+## Agents and sessions
+
+| | |
+|---|---|
+| `POST /api/agents` | create an agent in a namespace |
+| `GET /api/agents?namespace=` | list them |
+| `GET /api/agents/{id}?namespace=` | one agent |
+| `PUT /api/agents/{id}?namespace=` | partial update — absent fields keep their value |
+| `PUT /api/agents/{id}/tools?namespace=` | replace the tool list |
+| `POST /api/agents/{id}/copy?namespace=` | duplicate as `{name}-copy` |
+| `DELETE /api/agents/{id}?namespace=` | delete |
+| `POST /api/sessions` | start a session — body `{agentId, namespace, userId}` |
+| `GET /api/sessions?agentId=&namespace=&userId=` | a user's sessions for one agent |
+| `GET /api/sessions/{id}/history` | the persisted messages |
+| `DELETE /api/sessions/{id}` | delete the session |
+
+## Chat
+
+A turn is streamed, not awaited. `POST` the user's message and read
+Server-Sent Events until `done`:
+
+```bash
+curl -N -X POST http://localhost:8080/api/sessions/$SESSION/chat \
+     -H 'Content-Type: text/plain' -d 'Which of our tools can read files?'
+```
+
+Each event is one JSON frame with a `type`:
+
+| type | carries |
+|---|---|
+| `token` | `text` — a piece of the answer as it is generated |
+| `asking_llm` | the loop is waiting on the model |
+| `tool_call_started` | `toolName`, `arguments` |
+| `tool_call_result` | `toolName`, `result`, `durationMs` |
+| `tool_call_failed` | `toolName`, `error`, `durationMs` |
+| `sub_agent_started` / `sub_agent_event` / `sub_agent_done` / `sub_agent_error` | `agentName`, `taskId`, `subSessionId`; `sub_agent_event` wraps the sub-agent's own frame in `inner` |
+| `reviewing` / `reviewer_decision` / `response_revised` | the response-reviewer chain |
+| `approval_requested` | a tool is waiting for a human — see below |
+| `done` | the turn ended |
+| `error` | the turn failed; `text` is the message. Only on this endpoint — it is the chat stream's way of reporting a broken turn, not a runtime event |
+
+`DELETE /api/sessions/{id}/chat` cancels a running turn cooperatively: 204 when
+a turn was signalled, 404 when none is running. The stream still ends with its
+normal `done` once the loop reaches the next cancel check.
+
+## Reconnecting: the session stream
+
+A dropped connection used to mean a lost turn — the events had nowhere to go
+back to. The session now carries the stream, and a client can attach to it at
+any point, with or without a turn running:
+
+```bash
+curl -N "http://localhost:8080/api/sessions/$SESSION/stream?afterSeq=0"
+```
+
+The first frame is always the `attached` frame:
+
+```json
+{"type":"attached","firstBufferedSeq":1,"latestSeq":128,
+ "liveTurnId":"6f1c…","liveRun":0}
+```
+
+It says what the buffer still holds and whether a turn is running
+(`liveTurnId` is `null` when the session is idle). Then the buffered events
+replay and the stream continues live, each frame carrying its cursor and turn
+coordinates:
+
+```json
+{"seq":129,"turnId":"6f1c…","run":0,"event":{"type":"token","text":"…"}}
+```
+
+Three rules make a client robust:
+
+**Remember `seq`.** It is what you hand back as `afterSeq` after a
+disconnect. Everything after it is replayed.
+
+**Check for a gap.** The buffer is finite. If `firstBufferedSeq` is greater
+than your `afterSeq + 1`, events were evicted before you came back — reload
+`GET /api/sessions/{id}/history` instead of trusting the tail.
+
+**Filter by `turnId`** if you care about one turn only. The stream is the
+session's, so it spans turns; it stays open across them until you disconnect
+or the emitter times out. Reattaching with the last seen `seq` is the intended
+loop, not an error path.
+
+## Approvals
+
+A tool marked "needs approval" suspends its task and the turn stops, waiting
+for a human. The request arrives on the stream as `approval_requested` — but
+only in the moment it is raised, so a client that connects later has to ask:
+
+```bash
+curl "http://localhost:8080/api/sessions/$SESSION/approvals"
+```
+
+That returns the still-open questions, oldest first — the ones raised by the
+agent's own tools and the ones bubbled up from sub-agents alike. Each entry
+carries the `callId` (the identity of the question), the `toolName`, and the
+call JSON in `content`.
+
+Answering is one call:
+
+```bash
+curl -X POST "http://localhost:8080/api/sessions/$SESSION/approvals/$CALL_ID?approved=true&scope=once"
+```
+
+`scope=once` allows exactly this call; `scope=session` makes it a standing
+rule for that tool in this conversation, which also releases sibling calls of
+the same tool that are already parked. 204 means the decision was delivered,
+404 means the card was stale and its task is gone.
+
+There is no new stream to open afterwards: the turn never ended. It is
+suspended on the parked tool task and continues on its original stream the
+moment the answer arrives — which is exactly why attaching first and then
+loading the open approvals is the right order for a client.
+
+## Working memory
+
+| | |
+|---|---|
+| `GET /api/sessions/{id}/memory` | the prompt-assembly view: which messages are live, compressed or truncated, plus token accounting |
+| `POST /api/sessions/{id}/compress` | summarise older turns to reclaim context |
+| `DELETE /api/sessions/{id}/messages?fromSeq=&toSeq=` | drop a range of messages |
+
+See [working memory](./memory.md) for what the strategies do.
+
+## Beyond chat
+
+The same server exposes LLM configurations, the file store, session
+attachments and the vector stores under `/api` as well. Those follow plain
+CRUD shapes and are best read in the Swagger UI.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -24,6 +24,7 @@ const sidebars = {
           ],
         },
         'agents/cli',
+        'agents/rest-api',
         'agents/llm-gateway',
         {
           type: 'category',


### PR DESCRIPTION
Zwei Luecken in der Docs-Site, die der Session-Stream und der Snapshot-Kanal hinterlassen haben.

## Neu: `agents/rest-api.md`

Es gab keine Seite zur REST-API — weder zu den alten Endpunkten noch zu dem, was gerade dazugekommen ist. Die Seite deckt ab:

- Agenten und Sessions als kompakte Tabelle (fuer alles Weitere die Swagger-UI, die der Server ohnehin mitbringt).
- Den Chat-Stream mit allen Frame-Typen.
- **Das Wiederandocken**: `attached`-Frame, `seq` als Cursor, und die Luecken-Regel — ist `firstBufferedSeq` groesser als `afterSeq + 1`, wurden Events verdraengt und der Client laedt die History neu statt dem Tail zu trauen.
- **Approvals**: `once` gegen `session`, und warum erst andocken und dann die offenen Approvals laden die richtige Reihenfolge ist (das Event existiert nur im Moment des Fragens).

## `getting-started.md`: "Run it without building"

Die Seite begann mit einem Maven-Build. Wer die Admin-UI nur benutzen will, holt jetzt das exec-Jar aus dem Snapshot-Kanal, setzt den Key und startet es — drei Zeilen. Mit dem Hinweis, dass der Dateiname die Version traegt und `snapshot.txt` den aktuellen Build nennt, plus dem Desktop-Launcher als terminalfreier Weg.

## Gegen den Code geprueft

Nicht aus dem Gedaechtnis geschrieben: Frame-Typen gegen `StreamEventFrame` (`sub_agent_error` fehlte mir, und `error` gibt es nur auf dem Chat-Endpunkt, weil es dort im Controller entsteht statt im Runtime), Query-Parameter gegen den Controller (`/sessions` braucht auch `namespace`), Port 8080 gegen `application.yaml`.

Der Docusaurus-Build laeuft durch — MDX hatte anfangs `{name}` als JSX-Ausdruck gelesen, das steht jetzt in Backticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
