### PR TITLE
A changelog that keeps itself up to date across releases

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,63 @@
+name: changelog
+
+# A changelog rots when people forget it, and nobody notices until a release
+# is being cut and the section is empty. This asks at the only moment the
+# author still has the change in their head.
+#
+# It is a prompt, not a gate: a PR that genuinely needs no entry gets the
+# `no-changelog` label and moves on. The point is that skipping it is a
+# decision someone made, rather than something that happened.
+
+on:
+  pull_request:
+    branches: [main]
+    # labeled/unlabeled too, so adding the label re-runs and clears the check
+    # instead of leaving a red mark that has to be ignored.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Does this change need a changelog entry?
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+
+          # Shipped code only, in the four areas that publish artifacts. Tests,
+          # docs, the website and build plumbing change constantly and mean
+          # nothing to someone deciding whether to upgrade — asking for an
+          # entry there would train people to ignore this check, which is the
+          # one failure mode that matters.
+          USER_FACING=$(echo "$CHANGED" \
+            | grep -E '^(agents|workflow|taskqueue|common)/.*/src/main/.*\.java$' || true)
+
+          if [ -z "$USER_FACING" ]; then
+            echo "No shipped code changed — no entry needed."
+            exit 0
+          fi
+          if echo "$CHANGED" | grep -qx 'CHANGELOG.md'; then
+            echo "CHANGELOG.md was updated."
+            exit 0
+          fi
+
+          echo "::error::This PR changes shipped code but not CHANGELOG.md."
+          echo "Add a line under '## [Unreleased]' saying what is different for"
+          echo "someone using the libraries or running the apps — or label the PR"
+          echo "'no-changelog' if there is genuinely nothing to tell them."
+          echo
+          echo "Changed:"
+          echo "$USER_FACING" | sed 's/^/  /'
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ on:
         description: 'Next dev version incl. -SNAPSHOT (blank = bump patch)'
         required: false
         default: ''
+      allowEmptyChangelog:
+        description: 'Release even though CHANGELOG.md has nothing under [Unreleased]'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write   # push the version-bump commits and the tag
@@ -93,6 +98,28 @@ jobs:
           | xargs -0 perl -0777 -pi -e
           's|(<artifactId>mc-[^<]+</artifactId>\s*<version>)[^<]+(</version>)|${1}$ENV{RELEASE}${2}|g'
 
+      # Before the upload, deliberately: an empty [Unreleased] means someone
+      # forgot, and finding that out after a push to Central is too late —
+      # a released version can never be taken back.
+      - name: Freeze the changelog into this version
+        env:
+          RELEASE: ${{ steps.v.outputs.release }}
+          ALLOW_EMPTY: ${{ inputs.allowEmptyChangelog }}
+        run: |
+          set -euo pipefail
+          if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [Unreleased]' heading to release."
+            exit 1
+          fi
+          # Everything between [Unreleased] and the next version heading.
+          BODY=$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
+          if [ -z "$(echo "$BODY" | tr -d '[:space:]')" ] && [ "$ALLOW_EMPTY" != "true" ]; then
+            echo "::error::[Unreleased] is empty. Write what changed, or re-run with allowEmptyChangelog."
+            exit 1
+          fi
+          printf '%s\n' "$BODY" > /tmp/release-notes.md
+          sed -i "s|^## \[Unreleased\]$|## [$RELEASE] - $(date -u +%Y-%m-%d)|" CHANGELOG.md
+
       # The `release` profile (mc-java-parent) attaches sources + javadoc,
       # signs with GPG and hands the deploy to the central-publishing plugin.
       - name: Build & publish to Maven Central
@@ -110,17 +137,36 @@ jobs:
       - name: Open next development version
         run: find . -name pom.xml -exec sed -i "s|<version>${{ steps.v.outputs.release }}</version>|<version>${{ steps.v.outputs.next }}</version>|g" {} +
 
+      # In the same commit as the version bump, so main always has somewhere to
+      # write the next entry — the moment it does not, people stop writing them.
+      - name: Open a fresh Unreleased section
+        env:
+          RELEASE: ${{ steps.v.outputs.release }}
+        run: |
+          set -euo pipefail
+          # index(), not a regex match: the heading contains [0.0.3], which as a
+          # pattern is a character class and would never match the line it came
+          # from — silently leaving main with nowhere to write the next entry.
+          awk -v rel="## [$RELEASE]" '
+            index($0, rel) == 1 && !done { print "## [Unreleased]"; print ""; done = 1 }
+            { print }
+          ' CHANGELOG.md > /tmp/changelog.md && mv /tmp/changelog.md CHANGELOG.md
+          grep -q '^## \[Unreleased\]' CHANGELOG.md \
+            || { echo "::error::failed to reopen [Unreleased]"; exit 1; }
+
       - name: Commit next version and push
         run: |
           git commit -am "chore: start ${{ steps.v.outputs.next }} [skip ci]"
           git push origin HEAD:${{ github.ref_name }} --follow-tags
 
-      # Turn the pushed tag into a proper Release entry with auto-generated notes,
-      # so it shows under Releases (not just Tags).
+      # The changelog entry is the release note. Two sources would drift, and
+      # the hand-written one is the one aimed at a reader deciding whether to
+      # upgrade; --generate-notes is appended under it for the commit detail.
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
           gh release create "v${{ steps.v.outputs.release }}"
           --title "v${{ steps.v.outputs.release }}"
+          --notes-file /tmp/release-notes.md
           --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 First release on Maven Central. Everything before this line lives in the
 [commit history][releases].
+
+### Added
+
+- Admin UI to execute Chat, configure Agents, LLM Configs, Vector Stores, Migrations
+- CLI interface to execute agents
+- Rest Layer to manage the agent runtime including the chat session
+- Tool approvals in the Admin UI
+- OpenAI Responses API compatible library to use the agent runtime or switch to OpenAI directly
+- Agent execution and tool execution is run on the TaskQueue and Channels to easily let tasks run distributed and persistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+What changed, in the words of someone who has to decide whether to upgrade.
+
+This is not the commit log — [the releases page][releases] has that, generated.
+An entry here earns its place by telling a reader who *uses* this repo what is
+different for them: a new endpoint, a behaviour that changed, a bug whose
+symptom they may have been living with. The four areas — agents, workflow,
+taskqueue, common — release together under one version, so say which one an
+entry belongs to when it is not obvious.
+
+The format is [Keep a Changelog][keepachangelog]; this project follows
+[semantic versioning][semver], with the caveat that it is pre-1.0 and breaking
+changes may land in a minor.
+
+**Adding an entry:** put it under `## [Unreleased]`, in the section that fits.
+The release workflow renames that heading to the version being cut and opens a
+fresh empty one, so nothing has to be moved by hand at release time.
+
+[releases]: https://github.com/mindconnect-ai/mindconnect/releases
+[keepachangelog]: https://keepachangelog.com/en/1.1.0/
+[semver]: https://semver.org/spec/v2.0.0.html
+
+## [Unreleased]
+
+### Added
+
+- **A chat client can reattach to a running turn.** The event stream now
+  belongs to the session rather than to a single turn:
+  `GET /api/sessions/{id}/stream?afterSeq=N` replays what the buffer still
+  holds and then continues live. The first frame says whether a turn is
+  running and where the buffer starts, so a client that lost its connection
+  can tell the difference between "carry on" and "reload the history".
+- **Approvals can be answered through the REST API.**
+  `POST /api/sessions/{id}/approvals/{callId}?approved=&scope=once|session`
+  delivers the decision to the parked tool task;
+  `GET /api/sessions/{id}/approvals` lists the still-open questions, which is
+  what a client needs after connecting late — the request event exists only in
+  the moment it is raised. Before this, a client outside the admin UI could
+  show an approval card but never answer it.
+- **Runnable jars.** `mc-agent-admin-ui-app` and `mc-agent-cli` now also build
+  a Spring Boot executable jar (classifier `exec`). The plain jar stays the
+  main artifact, so nothing about the Maven Central publication changes.
+- **A snapshot channel.** A manually triggered workflow publishes those jars
+  to a rolling `snapshot` pre-release, which is the quickest way to run the
+  admin UI without a checkout — see
+  [Getting started](https://mindconnect-ai.github.io/mindconnect/agents/getting-started).
+
+### Changed
+
+- `TurnChannels` is now `SessionChannels`, keyed by session, and events travel
+  as `SessionEvent(turnId, run, event)`. Code that subscribed to a turn keeps
+  working through `subscribeTurn(...)`; the turn is a coordinate in the
+  envelope now, not a channel of its own.
+
+### Documentation
+
+- The REST API has a page of its own, including the stream and the approvals:
+  <https://mindconnect-ai.github.io/mindconnect/agents/rest-api>.
+
+## [0.0.2] - 2026-08-27
+
+First release on Maven Central. Everything before this line lives in the
+[commit history][releases].

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,4 +191,19 @@ mvn -f agents/client/mc-agent-cli/pom.xml spring-boot:run
 - Build parent POMs and shared/core modules before the modules that depend on them.
 - Manual regression tests live in `agents/manual-tests/` — human/LLM-executable
   scripts with per-step expectations; update `last-verified` stamps only on PASS.
+- **Everything written is in English** — code comments, javadoc, documentation,
+  commit messages, PR titles and descriptions, issue replies. This is an open
+  source project; a German commit message or PR body shuts out most of the
+  people who might read it. Conversation with the maintainer can be in German,
+  but nothing that lands in the repository or on GitHub.
 - Git commits: do **not** add a `Co-Authored-By` trailer.
+- **Before committing a user-facing change, add a line to `CHANGELOG.md`**
+  under `## [Unreleased]`. User-facing means someone using the libraries or
+  running the apps would want to know: a new endpoint, a changed behaviour, a
+  fixed bug whose symptom they may have been living with. Refactorings, tests,
+  docs and build plumbing do not need one — write the entry for a reader
+  deciding whether to upgrade, not for the commit log, which the releases page
+  already has. A PR that touches shipped Java without touching the changelog
+  fails the `changelog` check; label it `no-changelog` when that is the right
+  answer. The release workflow renames `[Unreleased]` to the version being cut
+  and opens a fresh one, so nothing is moved by hand.


### PR DESCRIPTION
The changelog mechanism from `mc-semantic-ui`, brought over here. Three parts that together keep the file from rotting.

## `CHANGELOG.md`

Keep a Changelog format with an open `## [Unreleased]` section. The header says what an entry is for: someone deciding whether to upgrade — not a second commit log. One adaptation to this repository: because four areas ship under *one* version here, an entry says which one it belongs to when that is not obvious.

Pre-filled with what has landed on `main` since 0.0.2 — the session stream with reattach, approvals over the REST API, the executable jars and the snapshot channel. The next release therefore has a real note from the start.

## `.github/workflows/changelog.yml`

Asks in the pull request, at the one moment the author still has the change in their head. **A prompt, not a gate**: the `no-changelog` label silences it, which turns skipping into a decision someone made rather than something that just happened.

The path filter is adapted to this repository and only fires on shipped Java in the four areas:

```
^(agents|workflow|taskqueue|common)/.*/src/main/.*\.java$
```

Tests, docs, the website and build plumbing do not trigger it. That is deliberate: a check that is red for no reason teaches people to ignore it, and that is the one failure mode that matters.

## `release.yml`

- **Before** the upload: `[Unreleased]` is frozen into the version (`## [0.0.3] - 2026-08-29`) and its content becomes the release note. An empty section stops the run unless the new `allowEmptyChangelog` input is set. The order is deliberate — a published Central version can never be taken back.
- **After** the version bump: a fresh `[Unreleased]` in the same commit, so `main` always has somewhere to write the next entry.
- The GitHub release note now comes from the changelog (`--notes-file`) with `--generate-notes` appended below it for commit detail. Two sources would drift.

`CLAUDE.md` names the rule under Conventions, and now also states that everything written in this repository is in English — comments, documentation, commit messages, pull request bodies. Without either note, both habits quietly disappear again.

## Verified

Not just the YAML syntax; the logic was rehearsed locally. `awk` lifts 35 lines of release notes out of `[Unreleased]`, the heading is renamed correctly, and a fresh empty `[Unreleased]` sits above it afterwards. Of five sample paths (main source, test, documentation page, workflow file, POM) the filter lets exactly the main source file through.

The new check runs on this pull request itself — it touches no shipped Java, so it should stay quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
