### PR TITLE
Workspace files are readable over the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **The workspace files an agent wrote are readable over the API.**
+  `GET /api/workspaces/session/{id}/files`, `/api/workspaces/agent/{agentId}/user/{userId}/files`
+  and `/api/workspaces/user/{userId}/files` list them, and appending
+  `/{name}` returns the content. The scope is in the path because it decides
+  which identifiers the request needs at all: a session workspace is addressed
+  by its session, an agent workspace by agent and user, the user workspace by
+  the user alone. Until now only the admin UI could see these files, by
+  reaching into the store directly.
 - **A chat client can reattach to a running turn.** The event stream now
   belongs to the session rather than to a single turn:
   `GET /api/sessions/{id}/stream?afterSeq=N` replays what the buffer still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
   working through `subscribeTurn(...)`; the turn is a coordinate in the
   envelope now, not a channel of its own.
 
+### Fixed
+
+- **The agent server starts again.** `mc-agent-api-app` failed at startup with
+  `required a bean of type 'ai.mindconnect.common.Namespace'`: the workflow
+  tools resolve agents by name and need the namespace, which only the admin UI
+  app defined. The agent server now declares it too.
+- **Swagger on the agent server lists the REST API only.** The workflow
+  admin's page controller arrives on the classpath with the workflow tools and
+  mapped 40 `/workflow-admin` routes into the OpenAPI document. Those are
+  server-rendered UI, not API, and their recursive `UiNode` schemas made
+  Swagger UI crawl. The document is now scoped to `/api/**`.
+
 ### Documentation
 
 - The REST API has a page of its own, including the stream and the approvals:

--- a/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/AgentApplication.java
+++ b/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/AgentApplication.java
@@ -2,6 +2,7 @@ package ai.mindconnect.agentapp;
 
 import ai.mindconnect.agent.adapter.config.DefaultAgentRuntimeConfig;
 import ai.mindconnect.agent.adapter.config.TodoToolsConfig;
+import ai.mindconnect.common.Namespace;
 import ai.mindconnect.common.util.encryption.EncryptionHelper;
 import ai.mindconnect.llm.adapter.anthropic.ClaudeGateway;
 import ai.mindconnect.llm.adapter.file.EncryptingLlmConfigRepository;
@@ -44,6 +45,15 @@ public class AgentApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(AgentApplication.class, args);
+    }
+
+    /**
+     * The namespace every request runs in. The server serves one installation,
+     * so it is fixed; the workflow tools need it to resolve agents by name.
+     */
+    @Bean
+    Namespace namespace() {
+        return new Namespace("local");
     }
 
     @Bean

--- a/agents/server/mc-agent-api-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-api-app/src/main/resources/application.yaml
@@ -23,6 +23,13 @@ mindconnect:
   memory:
     storage-dir: data/memory
 
+springdoc:
+  # Scope the OpenAPI document to the REST API. The workflow admin's page
+  # controller comes in with mc-workflow-admin-rest and maps 40 /workflow-admin
+  # routes that return recursive UiNode trees — server-rendered UI, not API,
+  # and schemas that freeze Swagger UI's example renderer.
+  paths-to-match: /api/**
+
 logging:
   level:
     ai.mindconnect: INFO

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/WorkspaceApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/WorkspaceApiController.java
@@ -1,0 +1,121 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.service.AgentSessionService;
+import ai.mindconnect.agent.tools.workspace.WorkspaceScope;
+import ai.mindconnect.agent.tools.workspace.WorkspaceStore;
+import io.swagger.v3.oas.annotations.Operation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The files an agent wrote, per workspace scope. A scope is a place, and the
+ * three of them differ in how long what is written there lives:
+ *
+ * <ul>
+ *   <li>{@code session} — the scratch space of one conversation</li>
+ *   <li>{@code agent}   — what an agent remembers about one user across sessions</li>
+ *   <li>{@code user}    — the user's own space, shared by every agent</li>
+ * </ul>
+ *
+ * <p>The scope is in the path rather than a parameter because it decides which
+ * identifiers the request even needs: a session workspace is addressed by its
+ * session (agent and user follow from it), an agent workspace by agent and
+ * user, and the user workspace by the user alone.
+ */
+@RestController
+@RequestMapping("/api/workspaces")
+public class WorkspaceApiController {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkspaceApiController.class);
+
+    /** One file in a workspace. Size is what a listing needs; content is a second call. */
+    public record WorkspaceFile(String name, long size) {}
+
+    private final WorkspaceStore store;
+    private final AgentSessionService sessionService;
+
+    public WorkspaceApiController(WorkspaceStore store, AgentSessionService sessionService) {
+        this.store = store;
+        this.sessionService = sessionService;
+    }
+
+    // ── Session scope ───────────────────────────────────────────────────────
+
+    @Operation(tags = "Workspaces", summary = "Files in a session's workspace",
+            description = "The scratch space of one conversation — what the agent wrote while "
+                    + "answering. Agent and user are taken from the session.")
+    @GetMapping("/session/{sessionId}/files")
+    public List<WorkspaceFile> sessionFiles(@PathVariable UUID sessionId) {
+        return list(sessionScope(sessionId));
+    }
+
+    @Operation(tags = "Workspaces", summary = "Read a file from a session's workspace")
+    @GetMapping(value = "/session/{sessionId}/files/{name}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> sessionFile(@PathVariable UUID sessionId,
+                                              @PathVariable String name) {
+        return read(sessionScope(sessionId), name);
+    }
+
+    // ── Agent + user scope ──────────────────────────────────────────────────
+
+    @Operation(tags = "Workspaces", summary = "Files in an agent's workspace for one user",
+            description = "What this agent keeps about this user across conversations.")
+    @GetMapping("/agent/{agentId}/user/{userId}/files")
+    public List<WorkspaceFile> agentFiles(@PathVariable UUID agentId, @PathVariable String userId) {
+        return list(WorkspaceScope.agentUser(agentId, userId));
+    }
+
+    @Operation(tags = "Workspaces", summary = "Read a file from an agent's workspace")
+    @GetMapping(value = "/agent/{agentId}/user/{userId}/files/{name}",
+            produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> agentFile(@PathVariable UUID agentId, @PathVariable String userId,
+                                            @PathVariable String name) {
+        return read(WorkspaceScope.agentUser(agentId, userId), name);
+    }
+
+    // ── User scope ──────────────────────────────────────────────────────────
+
+    @Operation(tags = "Workspaces", summary = "Files in a user's own workspace",
+            description = "The user's space, shared by every agent that works for them.")
+    @GetMapping("/user/{userId}/files")
+    public List<WorkspaceFile> userFiles(@PathVariable String userId) {
+        return list(WorkspaceScope.user(userId));
+    }
+
+    @Operation(tags = "Workspaces", summary = "Read a file from a user's workspace")
+    @GetMapping(value = "/user/{userId}/files/{name}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> userFile(@PathVariable String userId, @PathVariable String name) {
+        return read(WorkspaceScope.user(userId), name);
+    }
+
+    // ── The two things every scope does ─────────────────────────────────────
+
+    private WorkspaceScope sessionScope(UUID sessionId) {
+        AgentSession session = sessionService.findSession(sessionId);
+        return WorkspaceScope.session(session.agentDefinitionId(), session.userId(), session.id());
+    }
+
+    private List<WorkspaceFile> list(WorkspaceScope scope) {
+        List<WorkspaceFile> files = store.list(scope).stream()
+                .map(name -> new WorkspaceFile(name, store.sizeOf(scope, name).orElse(0L)))
+                .toList();
+        log.info("GET workspace files scope={} → {} file(s)", scope.type(), files.size());
+        return files;
+    }
+
+    private ResponseEntity<String> read(WorkspaceScope scope, String name) {
+        return store.read(scope, name)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}


### PR DESCRIPTION
Only the admin UI could see what an agent wrote into a workspace: it reaches into the `WorkspaceStore` directly and renders a dialog. Any other client — the desktop chat, or someone else's front end — had no way to ask.

## The shape

The scope sits in the path rather than in a parameter, because it decides which identifiers the request needs at all:

```
GET /api/workspaces/session/{sessionId}/files
GET /api/workspaces/agent/{agentId}/user/{userId}/files
GET /api/workspaces/user/{userId}/files
```

A session workspace is addressed by its session — agent and user follow from it, the same way `WorkspacePage` derives them. An agent workspace needs agent *and* user, because that is what "what this agent remembers about this person" means. The user workspace needs only the user.

Appending `/{name}` to any of the three returns the file as `text/plain`, or 404 when it is not there. Listing returns name and size; content is deliberately a second call, so a listing stays cheap when a workspace holds a large file.

## Verified

Against a running server, with one file placed in each of the three scopes: every listing returns its own file with the right size, reading returns the content, and a missing name gives 404.

The first run came back empty, which was the test's fault and worth recording: the fixture wrote into `data/agent-storage`, while the store roots at `data` (`mindconnect.data.base-dir`). The endpoint had it right.

## Note on the second commit

This branch also carries `The agent server starts, and its Swagger shows only the API`, which landed on `main` separately as #6. Its content is identical, so it contributes nothing to this merge — the diff against `main` is the workspace controller and one changelog entry.

## Not in here

No write or delete. The agent writes through its tools, and a delete would be a destructive endpoint that nothing needs yet — easy to add when something does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
