### PR TITLE
The agent server starts, and its Swagger shows only the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
   working through `subscribeTurn(...)`; the turn is a coordinate in the
   envelope now, not a channel of its own.
 
+### Fixed
+
+- **The agent server starts again.** `mc-agent-api-app` failed at startup with
+  `required a bean of type 'ai.mindconnect.common.Namespace'`: the workflow
+  tools resolve agents by name and need the namespace, which only the admin UI
+  app defined. The agent server now declares it too.
+- **Swagger on the agent server lists the REST API only.** The workflow
+  admin's page controller arrives on the classpath with the workflow tools and
+  mapped 40 `/workflow-admin` routes into the OpenAPI document. Those are
+  server-rendered UI, not API, and their recursive `UiNode` schemas made
+  Swagger UI crawl. The document is now scoped to `/api/**`.
+
 ### Documentation
 
 - The REST API has a page of its own, including the stream and the approvals:

--- a/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/AgentApplication.java
+++ b/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/AgentApplication.java
@@ -2,6 +2,7 @@ package ai.mindconnect.agentapp;
 
 import ai.mindconnect.agent.adapter.config.DefaultAgentRuntimeConfig;
 import ai.mindconnect.agent.adapter.config.TodoToolsConfig;
+import ai.mindconnect.common.Namespace;
 import ai.mindconnect.common.util.encryption.EncryptionHelper;
 import ai.mindconnect.llm.adapter.anthropic.ClaudeGateway;
 import ai.mindconnect.llm.adapter.file.EncryptingLlmConfigRepository;
@@ -44,6 +45,15 @@ public class AgentApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(AgentApplication.class, args);
+    }
+
+    /**
+     * The namespace every request runs in. The server serves one installation,
+     * so it is fixed; the workflow tools need it to resolve agents by name.
+     */
+    @Bean
+    Namespace namespace() {
+        return new Namespace("local");
     }
 
     @Bean

--- a/agents/server/mc-agent-api-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-api-app/src/main/resources/application.yaml
@@ -23,6 +23,13 @@ mindconnect:
   memory:
     storage-dir: data/memory
 
+springdoc:
+  # Scope the OpenAPI document to the REST API. The workflow admin's page
+  # controller comes in with mc-workflow-admin-rest and maps 40 /workflow-admin
+  # routes that return recursive UiNode trees — server-rendered UI, not API,
+  # and schemas that freeze Swagger UI's example renderer.
+  paths-to-match: /api/**
+
 logging:
   level:
     ai.mindconnect: INFO


### PR DESCRIPTION
Running `mc-agent-api-app` from a clean checkout turns up two problems. Neither has anything to do with a feature; together they stand between anyone and a running agent server.

## It did not start

```
Parameter 3 of method workflowAgentInvoker in
ai.mindconnect.agent.tools.workflow.McAgentWorkflowStepsAutoConfiguration
required a bean of type 'ai.mindconnect.common.Namespace' that could not be found.
```

`mc-agent-tools-workflow` is a dependency of the api app, and its auto-configuration wires the agent-call workflow step. That step resolves agents by name, so it needs a `Namespace`. Only `AdminUiApplication` ever declared that bean — the api app never did, and died in the context.

`AgentApplication` now declares the same `"local"` namespace. The server serves one installation, so the value is fixed, exactly as in the admin UI.

## Swagger listed the workflow admin UI

Once it was up, `/v3/api-docs` carried a `workflow-admin-ui-controller` tag with 40 `/workflow-admin` routes next to the seven real API tags.

`WorkflowAdminAutoConfiguration` imports `WorkflowAdminUiController`, and `mc-workflow-admin-rest` reaches the classpath through the workflow tools. That controller returns `UiNode` trees: server-rendered UI, not API, and recursive schemas of exactly the kind that made `mc-agent-admin-ui-app` scope its own document. The same one-liner applies here — `springdoc.paths-to-match: /api/**` — leaving 42 paths under Agents, Sessions, Workspaces, Files, LLM Configs, Vector Stores and Workflows.

The controller stays mapped: `/workflow-admin` still serves its UI on the agent server. Only the OpenAPI document is scoped. Whether that UI belongs on this server at all is a separate question — the honest fix would be a `@ConditionalOnProperty` on the UI controller inside `WorkflowAdminAutoConfiguration`, so every embedding host decides for itself while keeping `/api/workflows`. Not in this PR.

## Verified

Server started with `mvn -f agents/server/mc-agent-api-app/pom.xml spring-boot:run`, up in 1.3s. `/v3/api-docs` returns 42 paths, none under `/workflow-admin`; Swagger UI shows the seven API tags. Smoke test on the workspace endpoints: listing returns `200` with `[]`, an unknown name returns `404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
