### PR TITLE
The root reactor learns the module the release tripped over

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <module>agents/core/mc-agent-tools-gmail</module>
         <module>agents/server/mc-agent-api-rest</module>
         <module>agents/server/mc-agent-api-app</module>
+        <module>agents/server/mc-agent-chat-ui-rest</module>
         <module>agents/server/mc-agent-admin-ui-rest</module>
         <module>agents/server/mc-agent-admin-ui-app</module>
         <module>agents/client/mc-agent-cli</module>


### PR DESCRIPTION
## What happened

The 0.0.3 release run failed in `mvn -Prelease deploy`:

```
Could not find artifact ai.mindconnect:mc-agent-chat-ui-rest:jar:0.0.3 in central
```

`mc-agent-chat-ui-rest` was added to the agents area (and to `agents/pom.xml`)
when the chat became its own module, but never to the **root** aggregator the
release builds from. Locally the gap was invisible — area builds had long since
installed the snapshot into `~/.m2` — but the release reactor, building `0.0.3`
in a clean environment, had nowhere to get it.

## The fix

One line: the module joins the root reactor between `mc-agent-api-app` and its
dependent `mc-agent-admin-ui-rest`. A sweep over every `pom.xml` directory
confirmed no other module is missing from the root list.

Verified by deleting `~/.m2/repository/ai/mindconnect/mc-agent-chat-ui-rest`
and rebuilding from the root — green, with the reactor building the module
itself.

Build plumbing only, no changelog entry. The failed run pushed nothing (no
commit, no tag) and uploaded nothing to the Central portal, so re-running the
release workflow after this merge is all that's needed.