### PR TITLE
Sending mail is the one thing the assistant asks about first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Changed
 
+- **The seeded assistant asks before sending e-mail.** `gmail_send_email` in
+  the "Assistant with tools" binding now carries `needsApproval` — reading and
+  searching mail stay unattended, but every send waits for a human yes (with
+  "allow for this session" available on the approval card). Existing data
+  directories keep their seeded binding; this affects fresh installs.
+
+### Changed
+
 - **The seeded `web-researcher` agent runs on `agent-default`.** It was the
   one agent pinned to `openai-default`, so a fresh install without an OpenAI
   key shipped an agent that could not start.

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/assistant-with-tools.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/assistant-with-tools.json
@@ -174,7 +174,8 @@
       "agentDefinitionId": "00000002-0000-0000-0000-000000000012",
       "name": "gmail_send_email",
       "description": "Sends an email from the user's Gmail account. Confirm recipients with the user before calling.",
-      "enabled": true
+      "enabled": true,
+      "needsApproval": true
     }
   ],
   "createdAt": "2025-01-01T00:00:00Z",

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/assistant-with-tools.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/assistant-with-tools.json
@@ -174,7 +174,8 @@
       "agentDefinitionId": "00000002-0000-0000-0000-000000000012",
       "name": "gmail_send_email",
       "description": "Sends an email from the user's Gmail account. Confirm recipients with the user before calling.",
-      "enabled": true
+      "enabled": true,
+      "needsApproval": true
     }
   ],
   "createdAt": "2025-01-01T00:00:00Z",


### PR DESCRIPTION
Follow-up to the seed review: the "Assistant with tools" seed keeps its Gmail
tools (no credentials ship — the bindings are inert until a user connects
Gmail), but `gmail_send_email` now carries `needsApproval: true` in both apps
(admin-ui-app and CLI). Reading and searching stay unattended; every send ends
the turn WAITING_FOR_APPROVAL and shows the concrete arguments on the approval
card, with "allow for this session" as the coarse memory.

Fresh installs get the new binding; existing data directories keep what they
were seeded with.