### PR TITLE
The JSON views follow the theme, and the name is written Mindconnect

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopter-or-consulting.md
+++ b/.github/ISSUE_TEMPLATE/adopter-or-consulting.md
@@ -1,6 +1,6 @@
 ---
 name: Adopter / Consulting enquiry
-about: Tell us you're using MindConnect, or ask about consulting & support
+about: Tell us you're using Mindconnect, or ask about consulting & support
 title: "[adopter] "
 labels: ["adopter"]
 ---
@@ -13,7 +13,7 @@ labels: ["adopter"]
 **Who are you / your project?**
 
 
-**How are you using MindConnect?**
+**How are you using Mindconnect?**
 <!-- agent runtime · workflow engine · semantic-ui · other -->
 
 

--- a/.github/assets/logo-dark.svg
+++ b/.github/assets/logo-dark.svg
@@ -1,5 +1,5 @@
 <svg width="370" height="240" viewBox="160 50 370 240" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect logo</title>
+<title>Mindconnect logo</title>
 <desc>A brain connected by a short cable to a plug, line drawing.</desc>
 <g fill="none" stroke="#e7eef5" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
 

--- a/.github/assets/logo-light.svg
+++ b/.github/assets/logo-light.svg
@@ -1,5 +1,5 @@
 <svg width="370" height="240" viewBox="160 50 370 240" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect logo</title>
+<title>Mindconnect logo</title>
 <desc>A brain connected by a short cable to a plug, line drawing.</desc>
 <g fill="none" stroke="#1a3a5c" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
 

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,6 +1,6 @@
 # Adopters
 
-Are you using MindConnect — the agent runtime, the workflow engine, or
+Are you using Mindconnect — the agent runtime, the workflow engine, or
 semantic-ui — in a project, product, or experiment? **We'd love to know.**
 
 Listing yourself is **optional and free**. It helps the project (social

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The admin UI's JSON views follow the theme.** Working memory, LLM traces
+  and tool arguments were painted on a white slab whatever theme was on — a
+  glaring hole in the middle of Dark, Amethyst and Gipiti. They now take the
+  page's own code-slab colours, so a JSON view looks like every other code
+  block in the app, and a theme that retunes its tokens is followed without a
+  second edit.
+
 ## [0.1.0] - 2026-08-30
 
 ### Changed

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement (CLA)
 
-Thank you for contributing to MindConnect (the "Project"), maintained by
+Thank you for contributing to Mindconnect (the "Project"), maintained by
 David Beisert (the "Maintainer"). To keep the Project legally clean and
 sustainable, we ask every contributor to agree to the terms below before
 their contribution is merged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MindConnect (repo `mindconnect-ai/mindconnect`) is a multi-module Maven monorepo for building LLM-powered agents.
+Mindconnect (repo `mindconnect-ai/mindconnect`) is a multi-module Maven monorepo for building LLM-powered agents.
 It is built with Java 21; the deployable apps use Spring Boot 3.5.x, the core
 libraries are plain Java. The repo is organized into four areas plus one shared
 parent POM.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to MindConnect
+# Contributing to Mindconnect
 
 Thanks for your interest in contributing! 🎉 This project is maintained by
 David Beisert and welcomes contributions from everyone.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-MindConnect
+Mindconnect
 Copyright 2026 David Beisert
 
 This product includes software developed by David Beisert

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset=".github/assets/logo-dark.svg">
-    <img alt="MindConnect" src=".github/assets/logo-light.svg" width="200">
+    <img alt="Mindconnect" src=".github/assets/logo-light.svg" width="200">
   </picture>
 </p>
 
-<h1 align="center">MindConnect</h1>
+<h1 align="center">Mindconnect</h1>
 
 [![Build](https://github.com/mindconnect-ai/mindconnect/actions/workflows/build.yml/badge.svg)](https://github.com/mindconnect-ai/mindconnect/actions/workflows/build.yml)
 [![Docs](https://img.shields.io/badge/Docs-mindconnect--ai.github.io-blue.svg)](https://mindconnect-ai.github.io/mindconnect/)
@@ -74,7 +74,7 @@ appreciated.
 
 ## Adopters & consulting
 
-Using MindConnect? Add yourself to **[ADOPTERS.md](ADOPTERS.md)** via a pull
+Using Mindconnect? Add yourself to **[ADOPTERS.md](ADOPTERS.md)** via a pull
 request — optional, but it helps the project and gives you a public
 reference. For integration help, custom development or support, the
 maintainer offers consulting; reach out via
@@ -82,7 +82,7 @@ maintainer offers consulting; reach out via
 
 ## Support the project
 
-MindConnect is free and Apache-2.0 licensed, built and maintained in the
+Mindconnect is free and Apache-2.0 licensed, built and maintained in the
 open. If it's useful to you, you can support continued development:
 
 - ☕ **[Ko-fi](https://ko-fi.com/beisdog)** — buy me a coffee

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="../.github/assets/logo-dark.svg">
-    <img alt="MindConnect" src="../.github/assets/logo-light.svg" width="160">
+    <img alt="Mindconnect" src="../.github/assets/logo-light.svg" width="160">
   </picture>
 </p>
 

--- a/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/CliRunner.java
+++ b/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/CliRunner.java
@@ -879,7 +879,7 @@ public class CliRunner implements CommandLineRunner {
 
     private void printBanner() {
         System.out.println("╔══════════════════════════════════════╗");
-        System.out.println("║     MindConnect Agent CLI  v0.1      ║");
+        System.out.println("║     Mindconnect Agent CLI  v0.1      ║");
         System.out.println("╚══════════════════════════════════════╝");
         System.out.println("Type /help for commands, /quit to exit.");
     }

--- a/agents/client/mc-agent-cli/src/main/resources/logback-spring.xml
+++ b/agents/client/mc-agent-cli/src/main/resources/logback-spring.xml
@@ -56,7 +56,7 @@
         </encoder>
     </appender>
 
-    <!-- MindConnect: DEBUG to file -->
+    <!-- Mindconnect: DEBUG to file -->
     <logger name="ai.mindconnect" level="INFO" additivity="false">
         <appender-ref ref="FILE"/>
         <appender-ref ref="CONSOLE"/>

--- a/agents/core/mc-agent-protocol-mc-runtime/README.md
+++ b/agents/core/mc-agent-protocol-mc-runtime/README.md
@@ -1,7 +1,7 @@
 # mc-agent-protocol-mc-runtime
 
 Backend adapter: the `mc-agent-protocol` surface implemented against the
-**MindConnect agent runtime** (`mc-agent-runtime`). Here the runtime is the
+**Mindconnect agent runtime** (`mc-agent-runtime`). Here the runtime is the
 server side OpenAI cannot be: registered tools, sub-agents and memory run
 inside the turn.
 

--- a/agents/core/mc-agent-protocol-mc-runtime/pom.xml
+++ b/agents/core/mc-agent-protocol-mc-runtime/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
     <description>
         Backend adapter: the mc-agent-protocol surface (Sessions, AgentResponses,
-        Conversations) implemented against the MindConnect agent runtime
+        Conversations) implemented against the Mindconnect agent runtime
         (mc-agent-runtime). The runtime executes registered tools server-side;
         StreamEvents are assembled into protocol items and events.
     </description>

--- a/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 /**
- * Backend adapter: the protocol surface implemented against the MindConnect
+ * Backend adapter: the protocol surface implemented against the Mindconnect
  * agent runtime. The runtime is the server side OpenAI cannot be: registered
  * tools execute inside the turn (the inner loop), so {@code clientTools}
  * are rejected here until the runtime supports per-request tools.

--- a/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/FileAttacher.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/FileAttacher.java
@@ -3,7 +3,7 @@ package ai.mindconnect.agent.protocol.runtime;
 import java.util.UUID;
 
 /**
- * Ingests an already-stored file into a session's context — in the MindConnect
+ * Ingests an already-stored file into a session's context — in the Mindconnect
  * runtime typically: chunk + embed into the session's vector store and
  * activate the {@code vector_search} tool. Supplied by the composition root
  * (e.g. {@code AgentRuntime::attachStored} from the builder); the backend

--- a/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeFileQaExampleTest.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeFileQaExampleTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Live parity example: upload a file and ask against it — the SAME caller
- * code as the OpenAI backend's example 3, now against the MindConnect
+ * code as the OpenAI backend's example 3, now against the Mindconnect
  * runtime. The mechanics differ by design (OpenAI stuffs the document into
  * context; the runtime ingests it into the session's vector store and the
  * agent retrieves via {@code vector_search}) — the protocol hides that.

--- a/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeToolsExampleTest.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeToolsExampleTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Live parity examples — the SAME scenarios as the OpenAI backend's
- * {@code OpenAiHostedToolsExampleTest}, against the MindConnect runtime.
+ * {@code OpenAiHostedToolsExampleTest}, against the Mindconnect runtime.
  * What OpenAI hosts, the runtime runs as REGISTERED tools of the agent
  * definition; through the protocol both appear as identical
  * FunctionCall/Output item pairs:

--- a/agents/core/mc-agent-protocol-openai/README.md
+++ b/agents/core/mc-agent-protocol-openai/README.md
@@ -1,7 +1,7 @@
 # mc-agent-protocol-openai
 
 Backend adapter: the `mc-agent-protocol` surface implemented against the **real
-OpenAI Responses + Conversations API** — no MindConnect runtime involved.
+OpenAI Responses + Conversations API** — no Mindconnect runtime involved.
 Proves the protocol is backend-neutral; also usable standalone as a thin,
 typed OpenAI client.
 

--- a/agents/core/mc-agent-protocol-openai/pom.xml
+++ b/agents/core/mc-agent-protocol-openai/pom.xml
@@ -17,7 +17,7 @@
     <description>
         Backend adapter: implements the mc-agent-protocol surface (Sessions,
         AgentResponses, Conversations) against the real OpenAI Responses +
-        Conversations API instead of the MindConnect runtime. Agents are
+        Conversations API instead of the Mindconnect runtime. Agents are
         registered locally as PseudoAgents (name → model, instructions, tools).
     </description>
 

--- a/agents/core/mc-agent-protocol-openai/src/main/java/ai/mindconnect/agent/protocol/openai/OpenAiResponsesBackend.java
+++ b/agents/core/mc-agent-protocol-openai/src/main/java/ai/mindconnect/agent/protocol/openai/OpenAiResponsesBackend.java
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
 /**
  * Backend adapter: the whole protocol surface ({@link Sessions},
  * {@link AgentResponses}, {@link Conversations}) implemented against the
- * real OpenAI Responses + Conversations API. No MindConnect runtime involved
+ * real OpenAI Responses + Conversations API. No Mindconnect runtime involved
  * — agents are {@link PseudoAgent}s registered locally.
  *
  * <pre>

--- a/agents/core/mc-agent-protocol-openai/src/main/java/ai/mindconnect/agent/protocol/openai/PseudoAgent.java
+++ b/agents/core/mc-agent-protocol-openai/src/main/java/ai/mindconnect/agent/protocol/openai/PseudoAgent.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Local stand-in for an {@code AgentDefinition} when the MindConnect runtime
+ * Local stand-in for an {@code AgentDefinition} when the Mindconnect runtime
  * is not in play: everything the OpenAI Responses API needs per request,
  * registered under a name so the protocol's "agents are referenced by name"
  * contract keeps working.

--- a/agents/core/mc-agent-protocol/src/main/java/ai/mindconnect/agent/protocol/client/ToolLoop.java
+++ b/agents/core/mc-agent-protocol/src/main/java/ai/mindconnect/agent/protocol/client/ToolLoop.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * feeds the outputs back as the next request's input.
  *
  * <p>Backend-agnostic on purpose — the same loop runs against the
- * MindConnect runtime or the OpenAI backend, because the interruption
+ * Mindconnect runtime or the OpenAI backend, because the interruption
  * mechanic is part of the protocol, not of any implementation.
  */
 public final class ToolLoop {

--- a/agents/doc/architecture/system-overview.puml
+++ b/agents/doc/architecture/system-overview.puml
@@ -17,7 +17,7 @@ skinparam arrow {
   Color #555
 }
 
-title MindConnect — System Overview
+title Mindconnect — System Overview
 
 ' ─────────────────────────────────────────────
 ' ROW 1

--- a/agents/doc/images/system-overview.svg
+++ b/agents/doc/images/system-overview.svg
@@ -6,7 +6,7 @@
     <g>
         <g class="title" data-source-line="19">
             <text fill="#000000" font-family="Arial" font-size="14" font-weight="700" lengthAdjust="spacing"
-                  textLength="226.3926" x="485.9979" y="23.1318">MindConnect &#8212; System Overview
+                  textLength="226.3926" x="485.9979" y="23.1318">Mindconnect &#8212; System Overview
             </text>
         </g><!--entity DP-->
         <g class="entity" data-qualified-name="DP" data-source-line="25" id="ent0001">

--- a/agents/doc/presentation/agent-runtime.md
+++ b/agents/doc/presentation/agent-runtime.md
@@ -1,6 +1,6 @@
 ---
 marp: true
-title: MindConnect Agent Runtime
+title: Mindconnect Agent Runtime
 description: Architecture overview & how sub-agents work together
 theme: default
 paginate: true
@@ -20,14 +20,14 @@ style: |
 
 <!-- _class: lead -->
 
-# Meta-assistants — the MindConnect Agent Runtime
+# Meta-assistants — the Mindconnect Agent Runtime
 
 ### Architecture & sub-agents
 
 <span class="muted">David Beisert · Live demo</span>
 
 ---
-# MindConnect System Architecture
+# Mindconnect System Architecture
 
 ![w:1000](../images/system-overview.svg)
 
@@ -221,4 +221,4 @@ Transition: with that, I am at the end.
 
 ### Questions & discussion
 
-<span class="muted">David Beisert · MindConnect Agent Runtime</span>
+<span class="muted">David Beisert · Mindconnect Agent Runtime</span>

--- a/agents/mc-agents-parent/pom.xml
+++ b/agents/mc-agents-parent/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>mc-agents-parent</artifactId>
     <name>mc-agents-parent</name>
     <packaging>pom</packaging>
-    <description>Parent POM for all MindConnect agent platform modules</description>
+    <description>Parent POM for all Mindconnect agent platform modules</description>
 
     <properties>
         <jackson.version>2.16.1</jackson.version>

--- a/agents/server/mc-agent-admin-ui-app/keycloak/mindconnect-realm.json
+++ b/agents/server/mc-agent-admin-ui-app/keycloak/mindconnect-realm.json
@@ -1,7 +1,7 @@
 {
   "realm": "mindconnect",
   "enabled": true,
-  "displayName": "MindConnect",
+  "displayName": "Mindconnect",
   "sslRequired": "external",
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,

--- a/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/ChatFileUploadSmokeTest.java
+++ b/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/ChatFileUploadSmokeTest.java
@@ -110,7 +110,7 @@ class ChatFileUploadSmokeTest {
         AgentDefinition agent = agents.findByNamespace(namespace).stream().findFirst().orElseThrow();
         AgentSession session = sessionService.openChat(agent.id(), namespace, "upload-tester");
 
-        String text = "MindConnect upload smoke test.\n"
+        String text = "Mindconnect upload smoke test.\n"
                 + "The secret ingredient of the test soup is paprika.\n".repeat(40);
         MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
         form.add("chat-attach", new ByteArrayResource(text.getBytes(StandardCharsets.UTF_8)) {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/MemoryDetailSectionComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/MemoryDetailSectionComponent.java
@@ -95,13 +95,11 @@ public final class MemoryDetailSectionComponent implements UiComponent {
         }
 
         UiNode rawNode = UiJsonViewer.of(RAW_ID + "-json", rawJson)
-                .expandLevel(2)
-                .theme("default-light");
+                .expandLevel(2);
         UiNode llmNode;
         if (llmJsonContent != null) {
             llmNode = UiJsonViewer.of(LLM_ID + "-json", llmJsonContent)
-                    .expandLevel(2)
-                    .theme("default-light");
+                    .expandLevel(2);
         } else {
             llmNode = UiMarkdown.of(LLM_ID + "-md", "```\n" + nullSafe(llmText) + "\n```");
         }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/RoundtripCardComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/RoundtripCardComponent.java
@@ -69,8 +69,7 @@ public final class RoundtripCardComponent implements UiComponent {
                 + (trace.errorStatus() != null ? " · ✗ HTTP " + trace.errorStatus() : "");
 
         UiNode requestNode = UiJsonViewer.of(id() + "-req-json", trace.requestJson())
-                .expandLevel(1)
-                .theme("default-light");
+                .expandLevel(1);
         UiNode responseNode = buildResponseTab();
         UiNode rawNode;
         if (trace.responseEvents() == null || trace.responseEvents().isEmpty()) {
@@ -129,8 +128,7 @@ public final class RoundtripCardComponent implements UiComponent {
                 }
                 stack.section(tcId + "-args", null,
                         UiJsonViewer.of(tcId + "-args-json", argsJson)
-                                .expandLevel(2)
-                                .theme("default-light"));
+                                .expandLevel(2));
 
                 appendToolResult(stack, tcId, resultsByCallId.get(tc.id()));
             }
@@ -183,8 +181,7 @@ public final class RoundtripCardComponent implements UiComponent {
         UiNode body;
         if ("{".equals(firstChar) || "[".equals(firstChar)) {
             body = UiJsonViewer.of(tcId + "-result-json", resultText)
-                    .expandLevel(2)
-                    .theme("default-light");
+                    .expandLevel(2);
         } else {
             body = UiMarkdown.of(tcId + "-result-md", codeBlock(resultText, null));
         }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/img/logo.svg
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/img/logo.svg
@@ -1,5 +1,5 @@
 <svg width="370" height="240" viewBox="160 50 370 240" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect logo</title>
+<title>Mindconnect logo</title>
 <desc>A brain connected by a short cable to a plug, line drawing.</desc>
 <g fill="none" stroke="currentColor" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
 

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/index.html
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/index.html
@@ -71,5 +71,9 @@
     <!-- The theme picker in the header. Purely client-side: it swaps a class
          on <html> and remembers the choice per browser. -->
     <script src="/js/theme-switch.js" defer></script>
+    <!-- Hands the active theme's colours to the json-viewer web component,
+         which paints from a palette inside its own shadow root and so cannot
+         be reached from app.css. -->
+    <script src="/js/json-viewer-theme.js" defer></script>
 </body>
 </html>

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/json-viewer-theme.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/json-viewer-theme.js
@@ -1,0 +1,109 @@
+/*
+ * The JSON viewer takes its colours from the active theme.
+ *
+ * <andypf-json-viewer> paints itself from a base16 palette that it writes
+ * into a <style> inside its own shadow root, as `.container{--base00: …}`.
+ * That is a declaration on the very element the colours apply to, so nothing
+ * in app.css can reach it: a --base00 set on the host is only inherited, and
+ * an inherited value loses to the element's own rule. The palette has to be
+ * handed to the component; it cannot be styled around it.
+ *
+ * So this file translates the theme into base16 and hands it over as the
+ * component's `theme` attribute, which takes a JSON palette as readily as a
+ * theme name. The colours are read off <html> rather than kept in a table
+ * per theme: a new theme then needs no entry here, and one that retunes its
+ * tokens is followed without a second edit. The server no longer names a
+ * theme at all — it cannot, the choice lives in this browser's localStorage.
+ *
+ * An attribute rather than the .theme property on purpose: the component is
+ * loaded lazily from a CDN, so elements exist before their definition does,
+ * and a property set on a not-yet-upgraded element would shadow the setter
+ * that upgrade installs. An attribute is replayed into the component when
+ * the definition lands.
+ */
+(function () {
+    const TAG = "andypf-json-viewer";
+
+    function token(styles, name, fallback) {
+        return styles.getPropertyValue("--sui-color-" + name).trim() || fallback;
+    }
+
+    /*
+     * The comments are what the component does with each slot, not base16
+     * convention — that is what decides which ones have to stay legible.
+     * The fallbacks matter: the framework's own stylesheet uses
+     * --sui-color-warning and --sui-color-success without defining them, so
+     * on the default look those two arrive empty.
+     */
+    function palette() {
+        const s = getComputedStyle(document.documentElement);
+        const ink     = token(s, "code-fg", token(s, "text", "#383838"));
+        const ground  = token(s, "code-bg", token(s, "surface", "#ffffff"));
+        const border  = token(s, "border", "#d8d8d8");
+        const primary = token(s, "primary", "#7cafc2");
+        const success = token(s, "success", "#16a34a");
+        return {
+            base00: ground,                              // the slab behind everything
+            base01: token(s, "surface-alt", ground),     // toolbar and search fill
+            base02: border,                              // rules, indent guides, null pill
+            base03: token(s, "border-strong", border),   // hovered borders
+            base04: token(s, "text-muted", ink),         // item counts
+            base05: ink,                                 // plain text, undefined
+            base06: token(s, "text-body", ink),
+            base07: token(s, "text-strong", ink),        // keys, colons, brackets
+            base08: token(s, "danger", "#dc2626"),       // NaN
+            base09: token(s, "warning", "#d97706"),      // strings, ellipsis
+            base0A: token(s, "text-subtle", ink),        // null, regexp
+            base0B: success,                             // floats
+            base0C: primary,                             // numeric keys
+            base0D: primary,                             // icons, dates, open arrow
+            base0E: primary,                             // booleans, closed arrow
+            base0F: success,                             // integers
+        };
+    }
+
+    /** The palette as it is written to the attribute, or null before first run. */
+    let current = null;
+
+    function dress(el) {
+        if (current !== null && el.getAttribute("theme") !== current) {
+            el.setAttribute("theme", current);
+        }
+    }
+
+    /** Recomputes the palette and, if the theme moved, repaints every viewer. */
+    function refresh() {
+        const next = JSON.stringify(palette());
+        if (next === current) return;
+        current = next;
+        document.querySelectorAll(TAG).forEach(dress);
+    }
+
+    /*
+     * Two things to watch: the theme class on <html>, which the picker swaps,
+     * and viewers arriving in a re-render, which come back with whatever
+     * theme the server rendered. Dressing them straight from the observer
+     * callback — rather than on a timeout, as the picker does — keeps the
+     * default light slab from being painted for a frame first.
+     */
+    new MutationObserver(function (records) {
+        for (const record of records) {
+            if (record.type === "attributes") {
+                refresh();
+                continue;
+            }
+            for (const node of record.addedNodes) {
+                if (node.nodeType !== Node.ELEMENT_NODE) continue;
+                if (node.matches(TAG)) dress(node);
+                node.querySelectorAll(TAG).forEach(dress);
+            }
+        }
+    }).observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["class"],
+    });
+
+    refresh();
+})();

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/login.html
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sign in — MindConnect Admin</title>
+    <title>Sign in — Mindconnect Admin</title>
     <style>
         :root {
             color-scheme: light dark;
@@ -71,7 +71,7 @@
 </head>
 <body>
     <div class="card">
-        <h1>MindConnect Admin</h1>
+        <h1>Mindconnect Admin</h1>
         <p>Sign in with your Keycloak account to continue.</p>
         <!--
           Filled in by the inline script below from the ?error= query

--- a/common/README.md
+++ b/common/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="../.github/assets/logo-dark.svg">
-    <img alt="MindConnect" src="../.github/assets/logo-light.svg" width="160">
+    <img alt="Mindconnect" src="../.github/assets/logo-light.svg" width="160">
   </picture>
 </p>
 

--- a/mc-java-parent/pom.xml
+++ b/mc-java-parent/pom.xml
@@ -24,7 +24,7 @@
         <developer>
             <id>beisdog</id>
             <name>David Beisert</name>
-            <organization>MindConnect</organization>
+            <organization>Mindconnect</organization>
             <organizationUrl>https://github.com/mindconnect-ai</organizationUrl>
         </developer>
     </developers>

--- a/taskqueue/README.md
+++ b/taskqueue/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="../.github/assets/logo-dark.svg">
-    <img alt="MindConnect" src="../.github/assets/logo-light.svg" width="160">
+    <img alt="Mindconnect" src="../.github/assets/logo-light.svg" width="160">
   </picture>
 </p>
 

--- a/website/docs/agents/how-it-compares.md
+++ b/website/docs/agents/how-it-compares.md
@@ -7,11 +7,11 @@ sidebar_position: 3
 # Compared to LangChain4j & Spring AI
 
 LangChain4j and Spring AI are excellent **libraries** for calling LLMs from
-Java. The MindConnect agent runtime is a different kind of thing: a
+Java. The Mindconnect agent runtime is a different kind of thing: a
 **configuration-driven platform**. The core difference is where the work lives.
 
 > With LangChain4j or Spring AI you **write an application** that talks to an
-> LLM. With the MindConnect agent runtime you **configure an agent** — and a
+> LLM. With the Mindconnect agent runtime you **configure an agent** — and a
 > running server already knows how to chat, stream, call tools, orchestrate
 > sub-agents, and manage memory.
 
@@ -43,7 +43,7 @@ With a library, each of those is something you wire up and compile yourself.
 
 ## Side by side
 
-| | **LangChain4j** | **Spring AI** | **MindConnect agent runtime** |
+| | **LangChain4j** | **Spring AI** | **Mindconnect agent runtime** |
 |---|---|---|---|
 | What it is | Java LLM library | Spring LLM abstraction | Configuration-driven agent platform |
 | You ship | Your own app code | Your own app code | Configuration (JSON or UI) |
@@ -60,7 +60,7 @@ With a library, each of those is something you wire up and compile yourself.
 - **Reach for LangChain4j or Spring AI** when you're embedding LLM calls inside
   a larger Java application and want full programmatic control over every step —
   they are libraries, and that is their strength.
-- **Reach for the MindConnect agent runtime** when you want to **stand up and
+- **Reach for the Mindconnect agent runtime** when you want to **stand up and
   operate agents** — define them, give them tools, wire them into multi-agent
   systems, and change all of that without touching code or redeploying.
 

--- a/website/docs/agents/modules.md
+++ b/website/docs/agents/modules.md
@@ -27,7 +27,7 @@ carry the implementations.
 | Module | Purpose |
 |--------|---------|
 | `mc-agent-protocol` | The protocol vocabulary: `Response`, `Item`, `Conversation`, events and commands — pure types, zero runtime dependencies. |
-| `mc-agent-protocol-mc-runtime` | The protocol surface implemented against the MindConnect runtime. |
+| `mc-agent-protocol-mc-runtime` | The protocol surface implemented against the Mindconnect runtime. |
 | `mc-agent-protocol-openai` | The same surface implemented against the real OpenAI Responses + Conversations API. |
 
 ## `core/` — tools

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,10 +1,10 @@
 ---
 slug: /
-title: MindConnect
+title: Mindconnect
 sidebar_position: 1
 ---
 
-# MindConnect
+# Mindconnect
 
 **LLM-powered agents, a workflow engine, and a task queue — plain Java
 libraries at the core, Spring Boot apps on top.**

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? 'mindconnect-ai/mindconn
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'MindConnect',
+  title: 'Mindconnect',
   tagline: 'LLM-powered agents, a workflow engine, and a task queue',
   favicon: 'img/favicon.svg',
 
@@ -50,9 +50,9 @@ const config = {
       image: 'img/agents/research-lead-flow.svg',
       colorMode: {defaultMode: 'light', respectPrefersColorScheme: true},
       navbar: {
-        title: 'MindConnect',
+        title: 'Mindconnect',
         logo: {
-          alt: 'MindConnect logo',
+          alt: 'Mindconnect logo',
           src: 'img/logo.svg',
           srcDark: 'img/logo-dark.svg',
         },

--- a/website/src/images/logo.svg
+++ b/website/src/images/logo.svg
@@ -1,5 +1,5 @@
 <svg width="370" height="240" viewBox="160 50 370 240" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect logo</title>
+<title>Mindconnect logo</title>
 <desc>A brain connected by a short cable to a plug, line drawing.</desc>
 <g fill="none" stroke="#1a3a5c" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
 

--- a/website/static/img/favicon.svg
+++ b/website/static/img/favicon.svg
@@ -1,5 +1,5 @@
 <svg width="360" height="360" viewBox="150 30 360 360" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect favicon</title>
+<title>Mindconnect favicon</title>
 <desc>A brain connected by a cable to a plug.</desc>
 <g fill="none" stroke="#1a3a5c" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
 

--- a/website/static/img/logo-dark.svg
+++ b/website/static/img/logo-dark.svg
@@ -1,5 +1,5 @@
 <svg width="370" height="240" viewBox="160 50 370 240" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect logo</title>
+<title>Mindconnect logo</title>
 <desc>A brain connected by a short cable to a plug, line drawing.</desc>
 <g fill="none" stroke="#e7eef5" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
 

--- a/website/static/img/logo.svg
+++ b/website/static/img/logo.svg
@@ -1,5 +1,5 @@
 <svg width="370" height="240" viewBox="160 50 370 240" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect logo</title>
+<title>Mindconnect logo</title>
 <desc>A brain connected by a short cable to a plug, line drawing.</desc>
 <g fill="none" stroke="#1a3a5c" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
 

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="../.github/assets/logo-dark.svg">
-    <img alt="MindConnect" src="../.github/assets/logo-light.svg" width="160">
+    <img alt="Mindconnect" src="../.github/assets/logo-light.svg" width="160">
   </picture>
 </p>
 

--- a/workflow/mc-workflow-admin-app/src/main/java/ai/mindconnect/workflow/admin/app/WorkflowAdminLayout.java
+++ b/workflow/mc-workflow-admin-app/src/main/java/ai/mindconnect/workflow/admin/app/WorkflowAdminLayout.java
@@ -7,7 +7,7 @@ import ai.mindconnect.ui.model.UiStack;
 
 /**
  * App-level chrome for the standalone workflow admin: a header with the
- * MindConnect logo, the "Workflow Admin" brand, a Workflows nav link, and a
+ * Mindconnect logo, the "Workflow Admin" brand, a Workflows nav link, and a
  * fixed default user. Lives in the app (not the embeddable rest module) so the
  * rest module stays chrome-free and droppable into other hosts (e.g. the agent
  * UI, which brings its own header).

--- a/workflow/mc-workflow-admin-app/src/main/resources/static/img/logo.svg
+++ b/workflow/mc-workflow-admin-app/src/main/resources/static/img/logo.svg
@@ -1,5 +1,5 @@
 <svg width="370" height="240" viewBox="160 50 370 240" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>MindConnect logo</title>
+<title>Mindconnect logo</title>
 <desc>A brain connected by a short cable to a plug, line drawing.</desc>
 <g fill="none" stroke="#1a3a5c" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
 


### PR DESCRIPTION
Two independent changes, one commit each.

### The JSON views take the colours of the theme they sit in

Working memory, LLM traces and tool arguments were painted on a white slab
whatever theme was on — a hole in the middle of Dark, Amethyst and Gipiti.

It could not be fixed from `app.css`. The json-viewer web component writes its
palette into a `<style>` inside its own shadow root, as
`.container{--base00: …}` — a declaration on the very element the colours apply
to, so a value set on the host is only inherited, and inheritance loses. The
palette has to be handed over, not styled around.

`json-viewer-theme.js` translates the active theme into base16 and sets it as
the component's `theme` attribute, which takes a JSON palette as readily as a
theme name. The colours are read off `<html>` rather than kept in a table per
theme, so a new theme needs no entry here. `base00` is the theme's own code
slab — the same one every other code block in the app already uses. The server
stops naming a theme: it cannot know one, the choice lives in the browser's
localStorage.

Checked against Amethyst, Clody and Gipiti, in both the working-memory and the
traces dialog.

### The name is written Mindconnect, everywhere

The repository said `MindConnect` in 59 places and `Mindconnect` in one — the
admin UI header, which is the surface people actually look at. This settles it
the other way round from the count: the app is right and the prose follows.

Text only; no Java identifier carried the old spelling. The lower-case token is
untouched — packages (`ai.mindconnect`), artifact ids, the repository slug and
the property prefixes are a different name, and so are the `MINDCONNECT_`
environment variables.

Note that `NOTICE` and `<organization>` in `mc-java-parent/pom.xml` travel into
the artifact metadata on Maven Central from the next release on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)