### PR TITLE
Two local-only paths stop showing up in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,11 @@ dependency-reduced-pom.xml
 # Core TypeScript declarations staged into the editor build so tsc resolves the
 # real ../sui/* types (see mc-sui-editor/pom.xml). Generated, not source.
 semantic-ui/editor/mc-sui-editor/src/main/sui/
+
+# Local launcher scripts for the admin UI — kept out until they are documented
+# and linked from the README; an unreferenced entry point helps nobody.
+/scripts/
+
+# Marketing drafts: the LinkedIn post, its kit and its screenshots. Written
+# here because that is where the app is, published from somewhere else.
+/website/docs/agents/posts/


### PR DESCRIPTION
`.gitignore` only.

- **`/scripts/`** — three wrappers that download the admin UI from Maven Central
  and start it. They work, but nothing in the README or the docs points at them,
  and an entry point no one can find is not an entry point. Ignored until they
  are documented and linked; then this line comes out again.
- **`/website/docs/agents/posts/`** — the LinkedIn post, its kit and its
  screenshots. Drafts are written where the app is and published from somewhere
  else; a library repository is not the place to carry several megabytes of
  marketing screenshots.

Neither path has ever been tracked, so nothing is removed from the tree — this
only stops them turning up in `git status` and being swept in by `git add -A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)