### PR TITLE
The header and the sidebar stay put while a page scrolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
   which is what lets the content area do the scrolling — the behaviour the
   framework's own shell was already built for.
 
+- **The navigation drawer is opaque on a narrow screen.** Below 768px the
+  sidebar slides over the content instead of pushing it, and it had no
+  background of its own — what reads as its colour on a wide screen is the
+  shell showing through. The page was legible straight through the nav labels.
+  The drawer now carries the sidebar's own colour and an edge shadow, in every
+  theme; the pushed sidebar is unchanged.
+
 ## [0.1.0] - 2026-08-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
   block in the app, and a theme that retunes its tokens is followed without a
   second edit.
 
+- **The admin UI's header and sidebar stay put while a page scrolls.** Only the
+  chat page and the API explorer capped themselves to the window; on every
+  other screen a long list scrolled the whole document and carried the header
+  and the navigation off the top. The shell is now capped once for all of them,
+  which is what lets the content area do the scrolling — the behaviour the
+  framework's own shell was already built for.
+
 ## [0.1.0] - 2026-08-30
 
 ### Changed

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -48,6 +48,39 @@ body {
     height: 100dvh;
 }
 
+/* A drawer needs a ground of its own.
+
+   The sidebar has no background: what reads as its colour is the shell body
+   showing through it. That holds while the menu pushes the content aside, and
+   falls apart the moment it floats above it — below 768px the RESPONSIVE menu
+   becomes a drawer, and the page shows straight through the nav labels.
+
+   The framework does give its drawer an elevation, but `.sui-shell-body >
+   .sui-menu` (two classes) outweighs the `.sui-menu--responsive` rule inside
+   the media query (one class — a media query adds no specificity), so the
+   shadow is reset before it ever lands. Ground and elevation are therefore
+   both set here, in the very token the shell body paints itself with, so the
+   drawer is the sidebar's own colour in every theme.
+
+   The selector weight is deliberate. Every theme states `.sui-menu {
+   background: transparent }` on purpose — a pushed sidebar should read as one
+   plane with the shell — and does so as `:root.sui-theme-x .sui-menu`: three
+   classes, from a sheet that loads after this one. Matching that count would
+   lose the tie on order, so `:root` plus the repeated modifier takes these to
+   four and settles it by weight rather than by `!important`, which nothing
+   downstream could then override. Only the floating case is exempted; a pushed
+   sidebar keeps the transparency its theme asked for. */
+:root .sui-shell-body > .sui-menu--overlay.sui-menu--overlay {
+    background: var(--sui-color-bg);
+    box-shadow: 4px 0 16px rgb(0 0 0 / .28);
+}
+@media (max-width: 768px) {
+    :root .sui-shell-body > .sui-menu--responsive.sui-menu--responsive {
+        background: var(--sui-color-bg);
+        box-shadow: 4px 0 16px rgb(0 0 0 / .28);
+    }
+}
+
 /* Content is anchored to the sidebar, not centred in the leftover space —
    a centred card reads as a floating island on a wide monitor, while the
    right-hand whitespace reads as intentional breathing room. Two caps:

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -31,7 +31,22 @@ body {
     flex-direction: column;
     width: 100%;
 }
-#main > .sui-shell { flex: 1 1 auto; }
+/* The shell ends at the bottom of the window, on every page.
+
+   The framework says `min-height: 100dvh`, which fills the window but lets
+   the shell grow past it once the content is taller — and then the window
+   scrolls, carrying the header and the sidebar off the top. Its own
+   `.sui-shell-body { overflow: hidden }` and `.sui-shell-content { overflow:
+   auto }` are already waiting to scroll the content pane instead; they only
+   ever engage when something caps the height. The chat page and the API
+   explorer each capped it for themselves, so those two behaved and every
+   other screen did not.
+
+   `height` instead of `min-height` caps it here, once, for all of them. */
+#main > .sui-shell {
+    flex: 1 1 auto;
+    height: 100dvh;
+}
 
 /* Content is anchored to the sidebar, not centred in the leftover space —
    a centred card reads as a floating island on a wide monitor, while the
@@ -202,9 +217,8 @@ body {
 
 /* ── Embedded API explorer (Swagger UI in a UiIFrame) ──────────────────── */
 
-/* Same viewport-capping trick as the chat page: the shell stops growing and
-   the frame takes everything between header and pane edges. */
-.sui-shell:has(.app-fill-frame) { height: 100dvh; }
+/* The shell is capped for every page now (see #main > .sui-shell); the frame
+   only has to claim what is left between the header and the pane edges. */
 .sui-shell-content:has(.app-fill-frame) { display: flex; flex-direction: column; }
 .sui-shell-content > .app-fill-frame { max-width: none; }
 
@@ -216,10 +230,9 @@ body {
    the .chat-container must each become growing flex columns — :has() walks
    exactly that chain and nothing else (the Info tab and every other page
    keep the default flow). */
-/* Cap the shell to the viewport on the chat page — its min-height would
-   otherwise let the whole shell grow with the history and push the composer
-   below the fold; with the cap, the conversation list is the scrollpane. */
-.sui-shell:has(.chat-container) { height: 100dvh; }
+/* The shell is capped for every page now (see #main > .sui-shell), which is
+   what keeps the composer above the fold however long the history grows and
+   leaves the conversation list as the scrollpane. */
 .sui-shell-content:has(.chat-container) {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
One CSS rule in the admin UI.

The framework's shell is built to scroll its content area rather than the
window — `.sui-shell-body` is `overflow: hidden`, `.sui-shell-content` is
`overflow: auto`. Neither engages until something caps the shell's height, and
the framework only sets `min-height: 100dvh`. So a page taller than the window
grew the shell instead, the document scrolled, and the header and the sidebar
went with it.

The chat page and the API explorer had each capped the shell for themselves.
That is why those two behaved and no other screen did. One cap on
`#main > .sui-shell` replaces both special cases.

### Checked

| | before | after |
|---|---|---|
| workflow editor (19 steps) | window scrolls, chrome leaves | pane scrolls, chrome stays |
| LLM config list | window scrolls | pane scrolls |
| chat | already correct | unchanged, composer above the fold |
| API explorer | already correct | unchanged, frame ends at the window |

Also at 390px: the responsive drawer still starts closed and the burger still
opens it.

### Not in scope

The standalone workflow admin app (`mc-workflow-admin-app`) has no shell rules
of its own and so still scrolls the window. Same one-line fix if you want it —
it is a separate app, so it is not in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)