### PR TITLE
The detail page stops asking for an icon it cannot draw

### DIFF
--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentDetailComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentDetailComponent.java
@@ -88,8 +88,9 @@ public final class AgentDetailComponent implements UiComponent {
                 // view only reads. The edit form shows the stored machine name.
                 .field(UiField.text("group", "Group",
                         ToolCatalogComponent.displayGroup(agent.groupOrDefault())))
-                .field(UiField.text("icon", "Icon", agent.iconOrDefault())
-                        .icon(agent.iconOrDefault()))
+                // The name only. UiDetail does not draw a field's icon, and
+                // the header above the tabs already shows the symbol itself.
+                .field(UiField.text("icon", "Icon", agent.iconOrDefault()))
                 .field(UiField.text("llmConfigName", "LLM Config", agent.llmConfigName()))
                 .field(UiField.text("status", "Status",
                         agent.status() != null ? agent.status().name() : null))


### PR DESCRIPTION
One dead call.

`UiDetail` renders a field's label and its value, not the field's icon, so
`.icon(...)` on the agent detail page's Icon row never drew anything. A call
that looks like it draws something is worse than no call at all for the next
reader.

The row keeps the icon's **name** — that is what a detail view is for — and
the symbol itself is in the header above the tabs, added in #16.

No changelog entry: nothing a user of this repo has to know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)