### PR TITLE
The chat header says which conversation you are in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **The chat header names the conversation again.** Since the chat stopped
+  rendering its own app-shell header, the header said which agent was
+  answering but not which conversation you were in — and the history is a
+  closed drawer, so there was nowhere else to look. The conversation's title
+  leads it now, with the agent beside it as a badge; an untitled chat still
+  shows the agent's name.
+
 - **The admin UI's JSON views follow the theme.** Working memory, LLM traces
   and tool arguments were painted on a white slab whatever theme was on — a
   glaring hole in the middle of Dark, Amethyst and Gipiti. They now take the

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
@@ -82,6 +82,8 @@ public final class MessageListComponent implements UiComponent {
     private final SubAgentTreeProvider subAgentTree;
     /** Set when this session was spawned by a parent (sub-agent session) — drives the header link. */
     private UUID parentSessionId;
+    /** This conversation's title, when it has one — the header's subject. */
+    private String sessionTitle;
     /** Bubbled sub-agent approval cards (from the ToolApprovalStore), rendered after the history. */
     private List<UiList.Item> bubbledApprovalCards = List.of();
     /** The host's overflow menu (parent session, back to agent, memory/trace
@@ -104,6 +106,18 @@ public final class MessageListComponent implements UiComponent {
         this.history = history;
         this.memory = memory;
         this.subAgentTree = subAgentTree != null ? subAgentTree : SubAgentTreeProvider.NONE;
+    }
+
+    /**
+     * Sets the conversation's title, which then leads the header with the
+     * agent beside it as a badge. Pass {@code null} or blank for a chat that
+     * has not been titled yet — the agent's name leads instead, which says
+     * more about an empty conversation than "New chat" does. Returns
+     * {@code this} for fluent chaining.
+     */
+    public MessageListComponent withSessionTitle(String sessionTitle) {
+        this.sessionTitle = sessionTitle;
+        return this;
     }
 
     /**
@@ -149,9 +163,16 @@ public final class MessageListComponent implements UiComponent {
         // to be empty because the chat rendered a second app-shell header
         // above it that named the agent — two title bars where every other
         // screen has one, which is what made the chat look like it came from
-        // somewhere else. That header is gone; this one names the agent, the
-        // way "Agents" names the agents list.
-        var list = UiList.of(id(), agent == null ? "Chat" : agent.name());
+        // somewhere else. That header is gone; this one names the conversation.
+        //
+        // The title leads and the agent follows as a badge: in a conversation
+        // the agent is the constant and the title is what tells this one apart
+        // from the others — and with the history a closed drawer, the header is
+        // the only place that can say which chat you are in. An untitled chat
+        // falls back to the agent's name; "New chat" would say nothing at all.
+        String agentName = agent == null ? "Chat" : agent.name();
+        boolean titled = sessionTitle != null && !sessionTitle.isBlank();
+        var list = UiList.of(id(), titled ? sessionTitle : agentName);
         // The icon leads the title, the way every other screen's does — the
         // agent's own where it has one, so the conversation is recognisable
         // as this agent's and not just as "a chat".
@@ -167,17 +188,19 @@ public final class MessageListComponent implements UiComponent {
         // arrows read as forward/back navigation, which this is not.
         list.action(ai.mindconnect.ui.model.UiAction.icon("chat-history", "Chats")
                 .icon("panel-left-open"));
-        var tokenBar = new TokenUsageComponent(id(), memory).render();
-        if (overflow == null) {
-            list.headerExtra(tokenBar);
-        } else {
-            // Token bar and overflow share the headerExtra slot, side by side.
-            list.headerExtra(ai.mindconnect.ui.model.UiStack.of(id() + "-tools")
-                    .direction(ai.mindconnect.ui.model.UiStack.Direction.HORIZONTAL)
-                    .child(tokenBar)
-                    .child(overflow)
-                    .withCssClass("chat-header-tools"));
+        // Agent badge, token bar and overflow share the headerExtra slot,
+        // side by side. The badge only appears when the title has taken over
+        // the header — otherwise it would repeat the name standing next to it.
+        var tools = ai.mindconnect.ui.model.UiStack.of(id() + "-tools")
+                .direction(ai.mindconnect.ui.model.UiStack.Direction.HORIZONTAL)
+                .<ai.mindconnect.ui.model.UiStack>withCssClass("chat-header-tools");
+        if (titled) {
+            tools.child(ai.mindconnect.ui.model.UiText.of(id() + "-agent", agentName)
+                    .<ai.mindconnect.ui.model.UiText>withCssClass("chat-agent-badge"));
         }
+        tools.child(new TokenUsageComponent(id(), memory).render());
+        if (overflow != null) tools.child(overflow);
+        list.headerExtra(tools);
 
         // Sort by sequenceNum to be safe — persisted ordering should already
         // be correct but the component does not trust upstream.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/page/ChatPage.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/page/ChatPage.java
@@ -84,6 +84,7 @@ public final class ChatPage {
         this.session = session;
         this.agent = agent;
         this.messages = new MessageListComponent(session.id(), agent, history, memory, subAgentTree)
+                .withSessionTitle(session.title())
                 .withParentSession(session.parentSessionId());
         this.chatForm = new ChatFormComponent(session.id(), agent.id(), streaming)
                 .withModelLabel(agent.llmConfigName());

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
@@ -839,3 +839,18 @@
     width: 30px;
     height: 30px;
 }
+
+/* The agent beside the conversation's title: the header names the chat, and
+   this says who is answering in it. Same pill the agents list uses for an
+   agent's LLM config — a quiet fact next to a name, not a status. */
+.chat-agent-badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 999px;
+    background: var(--sui-color-surface-alt);
+    color: var(--sui-color-text-muted);
+    border: 1px solid var(--sui-color-border);
+    font-size: var(--sui-text-xs, 12px);
+    font-weight: 500;
+    white-space: nowrap;
+}


### PR DESCRIPTION
When the chat stopped rendering its own app-shell header (`96e6ce9`, 29 Aug),
the session title went with it. That header had the agent as its title and the
session title as an extra beside it; the conversation's own header — the one
that took the job over — only ever named the agent. With the history a closed
drawer, nothing on screen said which chat was open.

The title leads the header now, with the agent beside it as a badge:

- In a conversation the agent is the constant; the title is what tells this
  one apart from the others.
- The icon in front already says who is answering.

An **untitled** chat keeps the agent's name as its header rather than falling
back to "New chat", which would say nothing at all — and the badge stays away
in that case, so the same name is not printed twice side by side.

The badge shares the header-extra slot with the token gauge and the "…" menu,
which is where it can go: a `UiList` header's title is a plain escaped string
with no room for a second node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)