### PR TITLE
An agent can be given the roster it delegates to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **An agent can be given a roster of the agents it may delegate to.**
+  `AgentDefinition.callableAgents` names them; the admin form offers the same
+  multiselect the response reviewers use. `list_agents` then answers with that
+  roster instead of the whole namespace, and a `run_agent` for anything else is
+  refused with "agent 'x' is not available to you". Naming nobody is no
+  restriction, not a ban — an agent without a roster reaches everyone, which is
+  how every agent behaved before the field existed, so nothing on disk changes
+  behaviour.
 - **An agent carries a group and an icon.** `AgentDefinition` grows two
   fields. The group is the rubric the admin list files it under — the same
   idea as a tool's group, except an agent is configuration, so it carries it

--- a/agents/builder/mc-agent-runtime-builder/src/test/java/ai/mindconnect/agent/builder/lmstudio/LmStudioSupport.java
+++ b/agents/builder/mc-agent-runtime-builder/src/test/java/ai/mindconnect/agent/builder/lmstudio/LmStudioSupport.java
@@ -92,7 +92,8 @@ final class LmStudioSupport {
                 tools.stream().map(t -> new AgentTool(t.id(), base.id(), t.name(), t.description(),
                         t.overrides(), t.enabled(), t.deferred(), t.needsApproval(), t.maxResultChars()))
                         .toList(),
-                base.responseReviewers(), base.toolSearch(), base.createdAt(), base.updatedAt());
+                base.responseReviewers(), base.callableAgents(), base.toolSearch(),
+                base.createdAt(), base.updatedAt());
         return AgentRuntimeBuilder.useInMemoryPersistence()
                 .llmConfig(LlmConfig.lmStudio("it-llm", model, BASE_URL))
                 .agentDefinition(def)

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AgentDefinition.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AgentDefinition.java
@@ -52,6 +52,19 @@ public record AgentDefinition(
          */
         List<String> responseReviewers,
         /**
+         * The other agents this one may see and call, by name — the roster it
+         * delegates to. {@code null} or empty means no restriction: it sees
+         * every agent in its namespace, which is what an agent that was never
+         * given a roster has always done.
+         *
+         * <p>Governs both halves of delegating, because half of it would be
+         * theatre: {@code list_agents} returns only these, and a
+         * {@code run_agent} for anything else is refused. Filtering the list
+         * alone would leave a model free to call a name it read in its own
+         * prompt.
+         */
+        List<String> callableAgents,
+        /**
          * Agent-level tool-search setting. {@code null} (older persisted
          * agents) means disabled. When enabled, the runtime injects the
          * {@code tool_search} tool automatically; its search space is the
@@ -99,7 +112,7 @@ public record AgentDefinition(
                            List<AgentTool> tools, List<String> responseReviewers,
                            Instant createdAt, Instant updatedAt) {
         this(id, namespace, name, description, null, null, systemPrompt, welcomeMessage, llmConfigName,
-                maxIterations, memoryConfig, status, tools, responseReviewers, null,
+                maxIterations, memoryConfig, status, tools, responseReviewers, null, null,
                 createdAt, updatedAt);
     }
 
@@ -148,44 +161,71 @@ public record AgentDefinition(
         return icon == null || icon.isBlank() ? DEFAULT_ICON : icon;
     }
 
+    /** The roster as a list, empty when the agent may reach everything. */
+    public List<String> effectiveCallableAgents() {
+        return callableAgents != null ? callableAgents : List.of();
+    }
+
+    /**
+     * Whether this agent may see and call the named one. An empty roster is
+     * no restriction, not a ban — an agent that names nobody reaches everyone,
+     * which is how every agent behaved before the field existed.
+     *
+     * <p>The comparison ignores case, like the name lookup a sub-agent call
+     * does: a roster entry that differs only in case would otherwise pass the
+     * lookup and fail this check.
+     */
+    public boolean mayCall(String agentName) {
+        List<String> roster = effectiveCallableAgents();
+        if (roster.isEmpty()) return true;
+        return agentName != null && roster.stream().anyMatch(agentName::equalsIgnoreCase);
+    }
+
+    /** Replaces the roster of agents this one may see and call. */
+    public AgentDefinition withCallableAgents(List<String> callableAgents) {
+        return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
+                llmConfigName, maxIterations, memoryConfig,
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+    }
+
     /** Replaces the Lucide icon name (see {@link #icon()}). */
     public AgentDefinition withIcon(String icon) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     /** Refiles the agent under another rubric. */
     public AgentDefinition withGroup(String group) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     /** Replaces the tool-search setting (see {@link ToolSearchConfig}). */
     public AgentDefinition withToolSearch(ToolSearchConfig toolSearch) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     public AgentDefinition withMemoryConfig(MemoryConfig memoryConfig) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig, status, tools, responseReviewers,
-                toolSearch, createdAt, Instant.now());
+                callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     public AgentDefinition withTools(List<AgentTool> tools) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     public AgentDefinition withBasicFields(String name, String description, String systemPrompt,
                                            String welcomeMessage, String llmConfigName) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     public AgentDefinition withBasicFields(Namespace namespace, String name, String description,
@@ -193,7 +233,7 @@ public record AgentDefinition(
                                            String llmConfigName, List<String> responseReviewers) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     /**
@@ -209,13 +249,13 @@ public record AgentDefinition(
                                            List<String> responseReviewers) {
         return new AgentDefinition(id, namespace, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
     }
 
     public AgentDefinition asCopy() {
         Instant now = Instant.now();
         return new AgentDefinition(UUID.randomUUID(), namespace, name + "-copy", description, group, icon,
                 systemPrompt, welcomeMessage, llmConfigName, maxIterations, memoryConfig,
-                AgentDefinitionStatus.ACTIVE, List.of(), responseReviewers, toolSearch, now, now);
+                AgentDefinitionStatus.ACTIVE, List.of(), responseReviewers, callableAgents, toolSearch, now, now);
     }
 }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AgentPatch.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AgentPatch.java
@@ -33,6 +33,7 @@ public record AgentPatch(
         Optional<String> llmConfigName,
         Optional<Integer> maxIterations,
         Optional<List<String>> responseReviewers,
+        Optional<List<String>> callableAgents,
         Optional<AgentDefinition.ToolSearchConfig> toolSearch,
         Optional<List<AgentTool>> tools,
         Optional<ai.mindconnect.agent.memory.domain.MemoryConfig> memoryConfig
@@ -43,73 +44,80 @@ public record AgentPatch(
         return new AgentPatch(Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty());
+                Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public AgentPatch withNamespace(Namespace namespace) {
         return new AgentPatch(Optional.ofNullable(namespace), name, description, group, icon, systemPrompt,
-                welcomeMessage, llmConfigName, maxIterations, responseReviewers, toolSearch, tools, memoryConfig);
+                welcomeMessage, llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withName(String name) {
         return new AgentPatch(namespace, Optional.ofNullable(name), description, group, icon, systemPrompt,
-                welcomeMessage, llmConfigName, maxIterations, responseReviewers, toolSearch, tools, memoryConfig);
+                welcomeMessage, llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withDescription(String description) {
         return new AgentPatch(namespace, name, Optional.ofNullable(description), group, icon, systemPrompt,
-                welcomeMessage, llmConfigName, maxIterations, responseReviewers, toolSearch, tools, memoryConfig);
+                welcomeMessage, llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withGroup(String group) {
         return new AgentPatch(namespace, name, description, Optional.ofNullable(group), icon, systemPrompt,
-                welcomeMessage, llmConfigName, maxIterations, responseReviewers, toolSearch, tools, memoryConfig);
+                welcomeMessage, llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withIcon(String icon) {
         return new AgentPatch(namespace, name, description, group, Optional.ofNullable(icon), systemPrompt,
-                welcomeMessage, llmConfigName, maxIterations, responseReviewers, toolSearch, tools, memoryConfig);
+                welcomeMessage, llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withSystemPrompt(String systemPrompt) {
         return new AgentPatch(namespace, name, description, group, icon, Optional.ofNullable(systemPrompt),
-                welcomeMessage, llmConfigName, maxIterations, responseReviewers, toolSearch, tools, memoryConfig);
+                welcomeMessage, llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withWelcomeMessage(String welcomeMessage) {
         return new AgentPatch(namespace, name, description, group, icon, systemPrompt,
                 Optional.ofNullable(welcomeMessage), llmConfigName, maxIterations,
-                responseReviewers, toolSearch, tools, memoryConfig);
+                responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withLlmConfigName(String llmConfigName) {
         return new AgentPatch(namespace, name, description, group, icon, systemPrompt, welcomeMessage,
-                Optional.ofNullable(llmConfigName), maxIterations, responseReviewers, toolSearch, tools, memoryConfig);
+                Optional.ofNullable(llmConfigName), maxIterations, responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withMaxIterations(Integer maxIterations) {
         return new AgentPatch(namespace, name, description, group, icon, systemPrompt, welcomeMessage,
-                llmConfigName, Optional.ofNullable(maxIterations), responseReviewers, toolSearch, tools, memoryConfig);
+                llmConfigName, Optional.ofNullable(maxIterations), responseReviewers, callableAgents, toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withResponseReviewers(List<String> responseReviewers) {
         return new AgentPatch(namespace, name, description, group, icon, systemPrompt, welcomeMessage,
-                llmConfigName, maxIterations, Optional.ofNullable(responseReviewers), toolSearch, tools, memoryConfig);
+                llmConfigName, maxIterations, Optional.ofNullable(responseReviewers), callableAgents, toolSearch, tools, memoryConfig);
+    }
+
+    public AgentPatch withCallableAgents(List<String> callableAgents) {
+        return new AgentPatch(namespace, name, description, group, icon, systemPrompt, welcomeMessage,
+                llmConfigName, maxIterations, responseReviewers, Optional.ofNullable(callableAgents),
+                toolSearch, tools, memoryConfig);
     }
 
     public AgentPatch withToolSearch(AgentDefinition.ToolSearchConfig toolSearch) {
         return new AgentPatch(namespace, name, description, group, icon, systemPrompt, welcomeMessage,
-                llmConfigName, maxIterations, responseReviewers, Optional.ofNullable(toolSearch), tools, memoryConfig);
+                llmConfigName, maxIterations, responseReviewers, callableAgents,
+                Optional.ofNullable(toolSearch), tools, memoryConfig);
     }
 
     public AgentPatch withTools(List<AgentTool> tools) {
         return new AgentPatch(namespace, name, description, group, icon, systemPrompt, welcomeMessage,
-                llmConfigName, maxIterations, responseReviewers, toolSearch, Optional.ofNullable(tools), memoryConfig);
+                llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, Optional.ofNullable(tools), memoryConfig);
     }
 
     public AgentPatch withMemoryConfig(ai.mindconnect.agent.memory.domain.MemoryConfig memoryConfig) {
         return new AgentPatch(namespace, name, description, group, icon, systemPrompt, welcomeMessage,
-                llmConfigName, maxIterations, responseReviewers, toolSearch, tools,
+                llmConfigName, maxIterations, responseReviewers, callableAgents, toolSearch, tools,
                 Optional.ofNullable(memoryConfig));
     }
 }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentRegistryService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentRegistryService.java
@@ -79,6 +79,9 @@ public class AgentRegistryService {
         if (patch.icon().isPresent()) {
             updated = updated.withIcon(patch.icon().get());
         }
+        if (patch.callableAgents().isPresent()) {
+            updated = updated.withCallableAgents(patch.callableAgents().get());
+        }
         if (patch.toolSearch().isPresent()) {
             updated = updated.withToolSearch(patch.toolSearch().get());
         }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/SessionAgentResolver.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/SessionAgentResolver.java
@@ -67,7 +67,7 @@ public class SessionAgentResolver {
                 inline.id(), session.namespace(), inline.label(), "", null, null,
                 inline.systemPrompt(), null, inline.llmConfigName(),
                 DEFAULT_MAX_ITERATIONS, SummarizingWindowConfig.DEFAULT,
-                AgentDefinitionStatus.ACTIVE, inline.tools(), java.util.List.of(),
+                AgentDefinitionStatus.ACTIVE, inline.tools(), java.util.List.of(), null,
                 inline.toolSearch(), now, now);
     }
 

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/SubAgentCalls.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/SubAgentCalls.java
@@ -72,13 +72,13 @@ final class SubAgentCalls {
         this.queue = queue;
     }
 
-    String run(TaskContext ctx, AgentSession parentSession, UUID parentTurnId,
+    String run(TaskContext ctx, AgentSession parentSession, AgentDefinition caller, UUID parentTurnId,
                                 int parentDepth, Consumer<StreamEvent> parentStream,
                                 String toolName, String toolCallId, Map<String, Object> arguments) {
         return InlineAgentTools.RUN_AGENTS.equals(toolName)
-                ? dispatchBatch(ctx, parentSession, parentTurnId, parentDepth, parentStream,
+                ? dispatchBatch(ctx, parentSession, caller, parentTurnId, parentDepth, parentStream,
                         toolCallId, arguments)
-                : dispatchOne(ctx, parentSession, parentTurnId, parentDepth, parentStream,
+                : dispatchOne(ctx, parentSession, caller, parentTurnId, parentDepth, parentStream,
                         toolCallId, 0, arguments);
     }
 
@@ -94,7 +94,8 @@ final class SubAgentCalls {
      *
      * <p>Never throws for tool failures — errors become text.
      */
-    private String dispatchOne(TaskContext ctx, AgentSession parentSession, UUID parentTurnId,
+    private String dispatchOne(TaskContext ctx, AgentSession parentSession, AgentDefinition caller,
+                               UUID parentTurnId,
                                int parentDepth, Consumer<StreamEvent> parentStream,
                                String toolCallId, int slot, Map<String, Object> arguments) {
         if (parentDepth + 1 > AgentTurnWorker.MAX_DEPTH) {
@@ -108,6 +109,14 @@ final class SubAgentCalls {
         }
         if (message == null || message.isBlank()) {
             return "Error: message is required";
+        }
+        // The roster is a permission, not a display filter: an agent that
+        // cannot see a name in list_agents cannot reach it by knowing the name
+        // from somewhere else either. Refused by its own word rather than as
+        // "not found", so a trace says which of the two it was.
+        if (caller != null && !caller.mayCall(agentName)) {
+            return "Error: agent '" + agentName + "' is not available to you. "
+                    + "Available: " + String.join(", ", caller.effectiveCallableAgents());
         }
 
         // Deterministic per call AND slot: all run_agents batch tasks share the
@@ -190,7 +199,8 @@ final class SubAgentCalls {
 
     /** {@code run_agents}: submit all, await all — they run concurrently on the queue. */
     @SuppressWarnings("unchecked")
-    private String dispatchBatch(TaskContext ctx, AgentSession parentSession, UUID parentTurnId,
+    private String dispatchBatch(TaskContext ctx, AgentSession parentSession, AgentDefinition caller,
+                                 UUID parentTurnId,
                                  int parentDepth, Consumer<StreamEvent> parentStream,
                                  String toolCallId, Map<String, Object> arguments) {
         if (parentDepth + 1 > AgentTurnWorker.MAX_DEPTH) {
@@ -210,7 +220,7 @@ final class SubAgentCalls {
             final Object rawTask = taskList.get(i);
             threads.add(Thread.ofVirtual().start(() -> {
                 String result = rawTask instanceof Map<?, ?> taskMap
-                        ? dispatchOne(ctx, parentSession, parentTurnId, parentDepth, parentStream,
+                        ? dispatchOne(ctx, parentSession, caller, parentTurnId, parentDepth, parentStream,
                                 toolCallId, index, (Map<String, Object>) taskMap)
                         : "Error: task " + (index + 1) + " is not an object with 'name' and 'message'";
                 synchronized (results) {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/ToolCallWorker.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/ToolCallWorker.java
@@ -196,7 +196,7 @@ public final class ToolCallWorker implements TaskWorker {
                 try {
                     output = InlineAgentTools.RUN_AGENT.equals(toolName)
                             || InlineAgentTools.RUN_AGENTS.equals(toolName)
-                            ? subAgents.run(ctx, session, turnId, depth, stream, toolName, callId, arguments)
+                            ? subAgents.run(ctx, session, def, turnId, depth, stream, toolName, callId, arguments)
                             : runRegistryTool(session, def, tokenCounter, stream, callId, toolName, arguments);
                     failed = output != null && output.startsWith("Error:");
                 } catch (RuntimeException e) {

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AgentDefinitionGroupAndIconTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AgentDefinitionGroupAndIconTest.java
@@ -23,7 +23,7 @@ class AgentDefinitionGroupAndIconTest {
     private static AgentDefinition withGroupAndIcon(String group, String icon) {
         return new AgentDefinition(UUID.randomUUID(), new Namespace("local"), "n", "d", group, icon,
                 "prompt", null, "cfg", 5, null, AgentDefinitionStatus.ACTIVE,
-                List.of(), List.of(), null, null, null);
+                List.of(), List.of(), null, null, null, null);
     }
 
     @Test

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AgentDefinitionRosterTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AgentDefinitionRosterTest.java
@@ -1,0 +1,65 @@
+package ai.mindconnect.agent.domain;
+
+import ai.mindconnect.common.Namespace;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The roster rule, which both halves of delegating go through: {@code
+ * list_agents} filters with it and a {@code run_agent} is refused by it. It
+ * lives here, on the definition, so the two can never drift into disagreeing
+ * about what an agent is allowed to reach.
+ */
+class AgentDefinitionRosterTest {
+
+    private static AgentDefinition withRoster(List<String> roster) {
+        return new AgentDefinition(UUID.randomUUID(), new Namespace("local"), "planner", "d",
+                null, null, "prompt", null, "cfg", 5, null, AgentDefinitionStatus.ACTIVE,
+                List.of(), List.of(), roster, null, null, null);
+    }
+
+    @Test
+    void namingNobodyReachesEveryone() {
+        // The default for every agent that predates the field, and for one
+        // whose roster was cleared: no entries is no restriction, not a ban.
+        assertThat(withRoster(null).mayCall("verifier")).isTrue();
+        assertThat(withRoster(List.of()).mayCall("verifier")).isTrue();
+        assertThat(withRoster(null).effectiveCallableAgents()).isEmpty();
+    }
+
+    @Test
+    void aRosterAdmitsWhatItNamesAndNothingElse() {
+        var planner = withRoster(List.of("web-researcher", "verifier"));
+
+        assertThat(planner.mayCall("web-researcher")).isTrue();
+        assertThat(planner.mayCall("verifier")).isTrue();
+        assertThat(planner.mayCall("title-generator")).isFalse();
+        assertThat(planner.mayCall(null)).isFalse();
+    }
+
+    /**
+     * A sub-agent call resolves its target with {@code equalsIgnoreCase}, so
+     * the check has to as well — otherwise "Web-Researcher" would find the
+     * agent and then be turned away by its own roster.
+     */
+    @Test
+    void caseIsIgnoredHereBecauseTheNameLookupIgnoresIt() {
+        var planner = withRoster(List.of("Web-Researcher"));
+
+        assertThat(planner.mayCall("web-researcher")).isTrue();
+        assertThat(planner.mayCall("WEB-RESEARCHER")).isTrue();
+    }
+
+    @Test
+    void theRosterIsReplacedWholeAndClearingItRestoresTheDefault() {
+        var planner = withRoster(List.of("verifier"));
+
+        assertThat(planner.withCallableAgents(List.of("explorer")).mayCall("verifier")).isFalse();
+        assertThat(planner.withCallableAgents(List.of("explorer")).mayCall("explorer")).isTrue();
+        assertThat(planner.withCallableAgents(List.of()).mayCall("anything")).isTrue();
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/tools/toolsearch/ToolSearchToolTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/tools/toolsearch/ToolSearchToolTest.java
@@ -194,7 +194,7 @@ class ToolSearchToolTest {
     private static AgentDefinition definition(UUID agentId, List<AgentTool> tools,
                                               AgentDefinition.ToolSearchConfig toolSearch) {
         return new AgentDefinition(agentId, new Namespace("test"), "a", null, null, null, null, null,
-                "cfg", 5, null, null, tools, List.of(), toolSearch, null, null);
+                "cfg", 5, null, null, tools, List.of(), null, toolSearch, null, null);
     }
 
     @Test

--- a/agents/core/mc-agent-tools/src/main/java/ai/mindconnect/agent/tools/builtin/ListAgentsTool.java
+++ b/agents/core/mc-agent-tools/src/main/java/ai/mindconnect/agent/tools/builtin/ListAgentsTool.java
@@ -7,14 +7,29 @@ import ai.mindconnect.common.Namespace;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class ListAgentsTool implements Tool {
 
     private final AgentDefinitionRepository definitionRepository;
     private final Namespace namespace;
+    /** The agent doing the asking — its roster decides what comes back. */
+    private final UUID callerId;
 
     public ListAgentsTool(AgentDefinitionRepository definitionRepository, Namespace namespace) {
+        this(definitionRepository, namespace, null);
+    }
+
+    /**
+     * @param callerId the calling agent, whose {@code callableAgents} roster
+     *                 narrows the answer. {@code null} — or an id with no
+     *                 definition behind it, as a session's inline agent has —
+     *                 lists the whole namespace.
+     */
+    public ListAgentsTool(AgentDefinitionRepository definitionRepository, Namespace namespace,
+                          UUID callerId) {
+        this.callerId = callerId;
         this.definitionRepository = definitionRepository;
         this.namespace = namespace;
     }
@@ -40,7 +55,14 @@ public class ListAgentsTool implements Tool {
 
     @Override
     public String execute(Map<String, Object> arguments) {
-        List<AgentDefinition> agents = definitionRepository.findByNamespace(namespace);
+        // The roster lives on the calling agent and the rule for reading it
+        // lives on AgentDefinition — the same mayCall a run_agent is checked
+        // against, so the list can never offer what the call would refuse.
+        AgentDefinition caller = callerId == null
+                ? null : definitionRepository.findById(callerId).orElse(null);
+        List<AgentDefinition> agents = definitionRepository.findByNamespace(namespace).stream()
+                .filter(a -> caller == null || caller.mayCall(a.name()))
+                .toList();
         if (agents.isEmpty()) return "No agents found in namespace " + namespace.value();
         return agents.stream()
                 .map(a -> "- " + a.name() + ": " + a.description())

--- a/agents/core/mc-agent-tools/src/main/java/ai/mindconnect/agent/tools/builtin/ListAgentsToolFactory.java
+++ b/agents/core/mc-agent-tools/src/main/java/ai/mindconnect/agent/tools/builtin/ListAgentsToolFactory.java
@@ -19,6 +19,6 @@ public final class ListAgentsToolFactory implements ToolFactory {
     }
 
     @Override public Tool create(AgentTool agentTool, ToolCallScope scope) {
-        return new ListAgentsTool(definitionRepository, scope.namespace());
+        return new ListAgentsTool(definitionRepository, scope.namespace(), scope.agentDefinitionId());
     }
 }

--- a/agents/core/mc-agent-tools/src/test/java/ai/mindconnect/agent/tools/builtin/ListAgentsToolTest.java
+++ b/agents/core/mc-agent-tools/src/test/java/ai/mindconnect/agent/tools/builtin/ListAgentsToolTest.java
@@ -1,0 +1,91 @@
+package ai.mindconnect.agent.tools.builtin;
+
+import ai.mindconnect.agent.domain.AgentDefinition;
+import ai.mindconnect.agent.domain.AgentDefinitionStatus;
+import ai.mindconnect.agent.port.out.AgentDefinitionRepository;
+import ai.mindconnect.common.Namespace;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code list_agents} answers with the caller's roster, not with the whole
+ * namespace — otherwise it would advertise agents that {@code run_agent} then
+ * refuses, which is worse than not listing them at all.
+ */
+class ListAgentsToolTest {
+
+    private static final Namespace NS = new Namespace("local");
+
+    private static AgentDefinition agent(String name, List<String> roster) {
+        return new AgentDefinition(UUID.randomUUID(), NS, name, name + " does things",
+                null, null, "prompt", null, "cfg", 5, null, AgentDefinitionStatus.ACTIVE,
+                List.of(), List.of(), roster, null, null, null);
+    }
+
+    /** In-memory repository over a fixed roster of definitions. */
+    private static AgentDefinitionRepository repo(List<AgentDefinition> all) {
+        return new AgentDefinitionRepository() {
+            @Override public AgentDefinition save(AgentDefinition d) { return d; }
+            @Override public Optional<AgentDefinition> findById(UUID id) {
+                return all.stream().filter(a -> a.id().equals(id)).findFirst();
+            }
+            @Override public Optional<AgentDefinition> findByName(Namespace ns, String name) {
+                return all.stream().filter(a -> a.name().equals(name)).findFirst();
+            }
+            @Override public List<AgentDefinition> findByNamespace(Namespace ns) { return all; }
+            @Override public void deleteById(UUID id) { }
+        };
+    }
+
+    @Test
+    void aCallerWithARosterSeesOnlyIt() {
+        var planner = agent("planner", List.of("web-researcher", "verifier"));
+        var all = List.of(planner, agent("web-researcher", null),
+                agent("verifier", null), agent("title-generator", null));
+
+        String out = new ListAgentsTool(repo(all), NS, planner.id()).execute(Map.of());
+
+        assertThat(out).contains("web-researcher").contains("verifier");
+        assertThat(out).doesNotContain("title-generator");
+        // Not even itself: the roster names who it delegates to, and an agent
+        // does not delegate to itself.
+        assertThat(out).doesNotContain("planner does things");
+    }
+
+    @Test
+    void anEmptyRosterListsTheWholeNamespace() {
+        var assistant = agent("general", List.of());
+        var all = List.of(assistant, agent("web-researcher", null), agent("title-generator", null));
+
+        String out = new ListAgentsTool(repo(all), NS, assistant.id()).execute(Map.of());
+
+        assertThat(out).contains("general").contains("web-researcher").contains("title-generator");
+    }
+
+    /**
+     * A session's inline agent has an id with no definition behind it, and the
+     * old two-argument constructor passes none at all. Both mean "no roster",
+     * which is the whole namespace — not an empty answer.
+     */
+    @Test
+    void anUnknownOrAbsentCallerIsNotARestriction() {
+        var all = List.of(agent("web-researcher", null), agent("title-generator", null));
+
+        assertThat(new ListAgentsTool(repo(all), NS, UUID.randomUUID()).execute(Map.of()))
+                .contains("web-researcher").contains("title-generator");
+        assertThat(new ListAgentsTool(repo(all), NS).execute(Map.of()))
+                .contains("web-researcher").contains("title-generator");
+    }
+
+    @Test
+    void anEmptyNamespaceSaysSoRatherThanReturningNothing() {
+        assertThat(new ListAgentsTool(repo(List.of()), NS).execute(Map.of()))
+                .startsWith("No agents found");
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentDetailComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentDetailComponent.java
@@ -91,6 +91,7 @@ public final class AgentDetailComponent implements UiComponent {
                 // The name only. UiDetail does not draw a field's icon, and
                 // the header above the tabs already shows the symbol itself.
                 .field(UiField.text("icon", "Icon", agent.iconOrDefault()))
+                .field(UiField.text("callableAgents", "Callable Agents", callableAgentsSummary()))
                 .field(UiField.text("llmConfigName", "LLM Config", agent.llmConfigName()))
                 .field(UiField.text("status", "Status",
                         agent.status() != null ? agent.status().name() : null))
@@ -104,6 +105,12 @@ public final class AgentDetailComponent implements UiComponent {
                 .action(UiAction.danger("delete", "Delete").icon("delete")
                         .confirm("Delete agent '" + agent.name() + "'?")
                         .dispatch("DELETE", "/admin/api/agents/" + agent.id()));
+    }
+
+    /** The roster, or the word for having none — which means all of them. */
+    private String callableAgentsSummary() {
+        var roster = agent.effectiveCallableAgents();
+        return roster.isEmpty() ? "all agents" : String.join(", ", roster);
     }
 
     /** The effective strategy kind, plus the compression switch where it exists. */

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentFormComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentFormComponent.java
@@ -150,6 +150,14 @@ public final class AgentFormComponent implements UiComponent {
                         .hint("Comma-separated registry groups searchable beyond the agent's own "
                                 + "deferred tools, e.g. web, documents — or * for every group. "
                                 + "Empty = only deferred assigned tools are searchable"))
+                // The roster this agent delegates to. Empty is not "none" but
+                // "no restriction" — the hint has to say so, or an empty
+                // multiselect reads as a locked door.
+                .field(UiField.multiselect("callableAgents", "Callable Agents",
+                        isNew ? List.of() : agent.effectiveCallableAgents(), reviewerOptions)
+                        .asEditable()
+                        .hint("The agents this one may see in list_agents and reach with "
+                                + "run_agent. Select none to leave it unrestricted"))
                 .field(UiField.multiselect("responseReviewers", "Response Reviewers",
                         isNew ? List.of() : agent.effectiveResponseReviewers(), reviewerOptions)
                         .asEditable()

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AgentUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AgentUiController.java
@@ -144,6 +144,7 @@ public class AgentUiController {
                 .withIcon(body.str("icon"))
                 .withMaxIterations(body.num("maxIterations", agent.maxIterations()))
                 .withResponseReviewers(body.strList("responseReviewers"))
+                .withCallableAgents(body.strList("callableAgents"))
                 .withToolSearch(toolSearchFromForm(body));
         try {
             patch = withMemoryConfig(patch, body);
@@ -172,6 +173,7 @@ public class AgentUiController {
                             .withLlmConfigName(body.str("llmConfigName"))
                             .withMaxIterations(body.num("maxIterations", existing.maxIterations()))
                             .withResponseReviewers(body.strList("responseReviewers"))
+                            .withCallableAgents(body.strList("callableAgents"))
                             .withToolSearch(toolSearchFromForm(body));
                     try {
                         patch = withMemoryConfig(patch, body);


### PR DESCRIPTION
`list_agents` answered with the whole namespace, so a planner was offered the
title generator and the conversation summarizer alongside the four specialists
it actually delegates to — and every one of those is a disappointment when
picked, because a utility answers in the one shape the runtime calls it for.

`AgentDefinition.callableAgents` names the agents this one may reach. The admin
form offers the same multiselect the response reviewers use, over the same
options.

### Naming nobody is no restriction

An agent without a roster reaches everyone — which is how every agent behaved
before the field existed, so **nothing already on disk changes behaviour**. The
form's hint says so, because an empty multiselect otherwise reads as a locked
door.

### It governs both halves, because half of it would be theatre

Filtering `list_agents` alone leaves a model free to call a name it read in its
own prompt — the planner's prompt names five specialists outright. So a
`run_agent` outside the roster is refused too, and refused in its own words
("agent 'x' is not available to you") rather than as "not found", so a trace
says which of the two it was.

### Keeping the core clean

- **The rule is one method**, `AgentDefinition.mayCall`, and both call sites go
  through it. Writing "empty means all" twice — once in the tool module, once
  in the turn loop — is how the two would come to disagree about what an agent
  may reach.
- **The caller's definition travels into `SubAgentCalls` from `ToolCallWorker`**,
  which has already resolved it, rather than being looked up a second way. A
  session can carry an inline agent; there should be one answer to "who is
  calling", not two.
- `ListAgentsTool` takes the caller's id from `ToolCallScope`, the same handle
  the workspace tools already use. An id with no definition behind it — an
  inline session agent — is no roster, hence no restriction.

### Checked

- `AgentDefinitionRosterTest` — the rule: empty roster, named roster, case
  folding (the name lookup ignores case, so this must too), replacement.
- `ListAgentsToolTest` — filtered answer, empty roster, unknown caller, absent
  caller, empty namespace.
- End to end: the seeded planner, given `web-researcher`, `verifier` and
  `explorer`, called `list_agents` and got back those three out of sixteen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)