### PR TITLE
code_execute can see a directory of the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **`code_execute` can be given a host directory to see.** The container used
+  to have nothing but its session scratch space, so sandboxed code could not
+  read the user's own files. A `mountDir` on the tool's agent binding — or the
+  runtime-wide `codeExecMountDir` — mounts one directory at `/mnt/host`,
+  read-only unless `mountWritable` says otherwise. The seeded `default-chat`
+  mounts the user's home (`~`). The path comes from the operator, never from a
+  tool argument: a directory chosen by model output is one that eventually
+  reads `/`. Mounting nothing stays the default for every other agent, and the
+  mount is part of the container's identity, so two bindings that disagree
+  about it do not share one.
+
+
 - **An agent can be given a roster of the agents it may delegate to.**
   `AgentDefinition.callableAgents` names them; the admin form offers the same
   multiselect the response reviewers use. `list_agents` then answers with that

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/default-chat.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/default-chat.json
@@ -220,8 +220,10 @@
       "id": "00000003-0000-0000-0000-000000000070",
       "agentDefinitionId": "00000002-0000-0000-0000-000000000012",
       "name": "code_execute",
-      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. Use it for calculations, data wrangling and quick scripts instead of doing the arithmetic yourself.",
-      "overrides": {},
+      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. The user's home directory is mounted read-only at /mnt/host, so this is also how you read their files. Use it for calculations, data wrangling and quick scripts.",
+      "overrides": {
+        "mountDir": "~"
+      },
       "enabled": true,
       "deferred": false,
       "needsApproval": true,

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteTool.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteTool.java
@@ -19,9 +19,17 @@ public final class CodeExecuteTool implements Tool {
     private final String sessionKey;
     /** Container network mode: {@code none} (default) or {@code bridge}. */
     private final String network;
+    /** Host directory visible inside the container, or {@code null} for none. */
+    private final HostMount mount;
 
     public CodeExecuteTool(CodeExecutionService service, Map<String, CodeLanguage> languages,
                            String sessionKey, String network) {
+        this(service, languages, sessionKey, network, null);
+    }
+
+    public CodeExecuteTool(CodeExecutionService service, Map<String, CodeLanguage> languages,
+                           String sessionKey, String network, HostMount mount) {
+        this.mount = mount;
         this.service = service;
         this.languages = languages;
         this.sessionKey = sessionKey;
@@ -43,9 +51,24 @@ public final class CodeExecuteTool implements Tool {
         return "Executes a program in an isolated container and returns exit code, stdout and stderr. "
                 + "Languages: " + String.join(", ", languages.keySet()) + ". "
                 + networkNote
+                + mountNote()
                 + "Each call runs a fresh interpreter process, so variables do NOT carry over between calls — "
                 + "but the working directory /workspace persists for this session. "
                 + "Write files to /workspace to pass data between calls.";
+    }
+
+    /**
+     * The model can only use the host directory if it is told it exists, and
+     * told where — the mount is invisible from inside otherwise.
+     */
+    private String mountNote() {
+        if (mount == null) {
+            return "";
+        }
+        return "The host directory " + mount.dir() + " is mounted at " + HostMount.MOUNT_POINT
+                + (mount.readOnly() ? " READ-ONLY" : " and is WRITABLE")
+                + " — read the user's own files from there. "
+                + "Paths outside it do not exist inside the container. ";
     }
 
     @Override
@@ -78,7 +101,7 @@ public final class CodeExecuteTool implements Tool {
         }
         CodeExecutionService.ExecResult result;
         try {
-            result = service.execute(sessionKey, language, network, source);
+            result = service.execute(sessionKey, language, network, mount, source);
         } catch (RuntimeException e) {
             return "Error: code execution failed: " + e.getMessage();
         }

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteToolFactory.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteToolFactory.java
@@ -41,6 +41,8 @@ public final class CodeExecuteToolFactory implements ToolFactory {
     private Map<String, CodeLanguage> languages = CodeLanguages.defaults();
     private CodeExecutionService service;
     private String defaultNetwork = "none";
+    /** Host directory offered to every binding that does not name its own; null = none. */
+    private String defaultMountDir;
 
     @Override
     public String name() {
@@ -62,6 +64,7 @@ public final class CodeExecuteToolFactory implements ToolFactory {
         }
         this.languages = CodeLanguages.parse(env.getString("codeExecLanguages").orElse(null));
         this.defaultNetwork = networkOrDefault(env.getString("codeExecNetwork").orElse(null), "none");
+        this.defaultMountDir = env.getString("codeExecMountDir").orElse(null);
         Path scratchRoot = Path.of(env.getString("dataBaseDir").orElse("data")).resolve("code-exec");
         CodeExecutionService.Settings settings = new CodeExecutionService.Settings(
                 env.getString("codeExecMemory").orElse("512m"),
@@ -93,7 +96,22 @@ public final class CodeExecuteToolFactory implements ToolFactory {
         network.put("default", defaultNetwork);
         network.put("description", "Container network mode. 'bridge' enables internet access "
                 + "(HTTP requests, pip/npm installs); 'none' fully isolates the container.");
-        return Map.of("type", "object", "properties", Map.of("network", network));
+        Map<String, Object> mountDir = new java.util.LinkedHashMap<>();
+        mountDir.put("type", "string");
+        mountDir.put("description", "Host directory to mount at " + HostMount.MOUNT_POINT
+                + " so the sandboxed code can read the user's own files. '~' is the user's "
+                + "home directory. Empty = nothing beyond the session scratch space.");
+        Map<String, Object> mountWritable = new java.util.LinkedHashMap<>();
+        mountWritable.put("type", "boolean");
+        mountWritable.put("default", false);
+        mountWritable.put("description", "Mount the directory writable instead of read-only. "
+                + "Model-written code can then change real files — leave this off unless that "
+                + "is the point.");
+        Map<String, Object> props = new java.util.LinkedHashMap<>();
+        props.put("network", network);
+        props.put("mountDir", mountDir);
+        props.put("mountWritable", mountWritable);
+        return Map.of("type", "object", "properties", props);
     }
 
     @Override
@@ -103,7 +121,42 @@ public final class CodeExecuteToolFactory implements ToolFactory {
         // for everything unlisted or invalid.
         String network = agentTool == null ? defaultNetwork
                 : networkOrDefault(String.valueOf(agentTool.overrides().getOrDefault("network", "")), defaultNetwork);
-        return new CodeExecuteTool(service, languages, sessionKey(scope), network);
+        return new CodeExecuteTool(service, languages, sessionKey(scope), network, mount(agentTool));
+    }
+
+    /**
+     * The host directory this binding may see, or {@code null}. Operator input
+     * only — the runtime setting, or a {@code mountDir} override on the agent's
+     * tool binding. Never a tool argument: a path the model chose is a path
+     * that eventually reads {@code /}.
+     */
+    private HostMount mount(AgentTool agentTool) {
+        Object raw = agentTool == null ? null : agentTool.overrides().get("mountDir");
+        String dir = raw == null || String.valueOf(raw).isBlank()
+                ? defaultMountDir : String.valueOf(raw);
+        if (dir == null || dir.isBlank()) {
+            return null;
+        }
+        java.nio.file.Path path = expandHome(dir.trim());
+        if (!java.nio.file.Files.isDirectory(path)) {
+            log.warn("code_execute mountDir '{}' is not a directory — mounting nothing", path);
+            return null;
+        }
+        boolean writable = agentTool != null
+                && Boolean.parseBoolean(String.valueOf(agentTool.overrides().getOrDefault("mountWritable", "false")));
+        return new HostMount(path, !writable);
+    }
+
+    /** {@code ~} and {@code ~/x} resolve against the user's home directory. */
+    private static java.nio.file.Path expandHome(String dir) {
+        java.nio.file.Path home = java.nio.file.Path.of(System.getProperty("user.home"));
+        if (dir.equals("~")) {
+            return home;
+        }
+        if (dir.startsWith("~/")) {
+            return home.resolve(dir.substring(2));
+        }
+        return java.nio.file.Path.of(dir);
     }
 
     /** Allowlist: only {@code none} and {@code bridge} are accepted network modes. */

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecutionService.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecutionService.java
@@ -25,7 +25,10 @@ import java.util.concurrent.TimeUnit;
  * packages survive between calls; a fresh interpreter process runs each time.
  *
  * <p>Isolation per container: no network, memory/cpu limits, and a bind mount
- * of one session-private scratch directory as the only host filesystem access.
+ * of one session-private scratch directory. That scratch directory is the only
+ * host filesystem the container sees unless an operator mounts a second one
+ * (see {@link HostMount}) — which is a deliberate hole in the isolation, opened
+ * per agent binding and read-only by default.
  * Idle containers are reaped after a timeout; everything carries a label so
  * containers from a crashed previous run are cleaned up at startup.
  */
@@ -83,16 +86,20 @@ public final class CodeExecutionService implements AutoCloseable {
      * the container (the runaway process would otherwise keep burning its CPU
      * budget); the next call starts fresh.
      */
-    public ExecResult execute(String sessionKey, CodeLanguage language, String network, String code) {
-        String key = sessionKey + ":" + language.name() + ":" + network;
-        Session session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network));
+    public ExecResult execute(String sessionKey, CodeLanguage language, String network,
+                              HostMount mount, String code) {
+        // The mount joins the key for the same reason the network does: it is
+        // fixed when the container starts, so two bindings that disagree about
+        // it must not end up sharing one container.
+        String key = sessionKey + ":" + language.name() + ":" + network + ":" + HostMount.key(mount);
+        Session session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network, mount));
         long begin = System.currentTimeMillis();
         ContainerCli.Result result = exec(session, language, code);
         if (containerGone(result)) {
             // Removed behind our back (manual prune, engine restart) — one retry
             // with a fresh container.
             sessions.remove(key, session);
-            session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network));
+            session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network, mount));
             begin = System.currentTimeMillis();
             result = exec(session, language, code);
         }
@@ -111,25 +118,33 @@ public final class CodeExecutionService implements AutoCloseable {
         return cli.run(settings.execTimeout(), code, args.toArray(String[]::new));
     }
 
-    private Session start(String sessionKey, CodeLanguage language, String network) {
+    private Session start(String sessionKey, CodeLanguage language, String network, HostMount mount) {
         Path scratch = scratchDir(sessionKey);
-        ContainerCli.Result result = cli.run(LIFECYCLE_TIMEOUT, null,
+        List<String> args = new ArrayList<>(List.of(
                 "run", "-d",
                 "--label", LABEL + "=1",
                 "--network", network,
                 "--memory", settings.memory(),
                 "--cpus", settings.cpus(),
                 "--workdir", "/workspace",
-                "-v", scratch.toAbsolutePath() + ":/workspace",
-                language.image(),
-                // Portable idle keep-alive: busybox sleep has no "infinity".
-                "sleep", "2147483647");
+                "-v", scratch.toAbsolutePath() + ":/workspace"));
+        if (mount != null) {
+            args.add("-v");
+            args.add(mount.dir().toAbsolutePath() + ":" + HostMount.MOUNT_POINT
+                    + (mount.readOnly() ? ":ro" : ""));
+        }
+        args.add(language.image());
+        // Portable idle keep-alive: busybox sleep has no "infinity".
+        args.add("sleep");
+        args.add("2147483647");
+        ContainerCli.Result result = cli.run(LIFECYCLE_TIMEOUT, null, args.toArray(String[]::new));
         if (!result.ok()) {
             throw new IllegalStateException("Could not start " + language.name() + " container ("
                     + cli.binary() + " run failed): " + result.stderr().trim());
         }
         String containerId = result.stdout().trim();
-        log.info("Started code-exec container {} ({} / {})", shortId(containerId), sessionKey, language.name());
+        log.info("Started code-exec container {} ({} / {}{})", shortId(containerId), sessionKey,
+                language.name(), mount == null ? "" : " / mount " + mount.describe());
         return new Session(containerId);
     }
 

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/HostMount.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/HostMount.java
@@ -1,0 +1,46 @@
+package ai.mindconnect.agent.tools.code;
+
+import java.nio.file.Path;
+
+/**
+ * A directory of the host machine made visible inside the code-execution
+ * container, at {@link #MOUNT_POINT}.
+ *
+ * <p>This is a deliberate hole in the container's isolation, so it is not
+ * something the model decides. The directory comes from the operator — the
+ * runtime's {@code codeExecMountDir} setting, or a {@code mountDir} override on
+ * one agent's tool binding — never from a tool argument. A path chosen by
+ * model output is a path that will eventually be {@code /} or {@code ~/.ssh}.
+ *
+ * <p>Read-only unless someone opts out. The container exists so that
+ * model-written code runs where it cannot do damage; handing it write access
+ * to real files gives that up, and should be a sentence someone typed on
+ * purpose.
+ */
+public record HostMount(Path dir, boolean readOnly) {
+
+    /** Where the host directory appears inside the container. */
+    public static final String MOUNT_POINT = "/mnt/host";
+
+    public HostMount {
+        if (dir == null) {
+            throw new IllegalArgumentException("HostMount.dir must not be null");
+        }
+    }
+
+    /**
+     * Part of the container's session key: the mount is fixed when the
+     * container starts, so two bindings that disagree about it must not share
+     * one. {@code null} — no mount — has its own value rather than an empty
+     * string, so "no mount" and "a mount whose path stringifies to nothing"
+     * can never collide.
+     */
+    public static String key(HostMount mount) {
+        return mount == null ? "-" : mount.dir().toAbsolutePath() + (mount.readOnly() ? ":ro" : ":rw");
+    }
+
+    /** For the log line and the tool description. */
+    public String describe() {
+        return dir + " → " + MOUNT_POINT + (readOnly ? " (read-only)" : " (writable)");
+    }
+}

--- a/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/CodeExecutionServiceTest.java
+++ b/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/CodeExecutionServiceTest.java
@@ -93,8 +93,8 @@ class CodeExecutionServiceTest {
     void firstCallStartsContainerFurtherCallsReuseIt() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        var first = svc.execute("session-a", python(), "none", "print(1)");
-        var second = svc.execute("session-a", python(), "none", "print(2)");
+        var first = svc.execute("session-a", python(), "none", null, "print(1)");
+        var second = svc.execute("session-a", python(), "none", null, "print(2)");
 
         assertThat(first.stdout()).contains("ran[print(1)]");
         assertThat(second.stdout()).contains("ran[print(2)]");
@@ -110,7 +110,7 @@ class CodeExecutionServiceTest {
     void containerIsHardenedAndSessionScratchDirMounted() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        svc.execute("session-b", python(), "none", "print(1)");
+        svc.execute("session-b", python(), "none", null, "print(1)");
 
         String run = calls().stream().filter(c -> c.startsWith("run ")).findFirst().orElseThrow();
         assertThat(run).contains("--network none")
@@ -126,8 +126,8 @@ class CodeExecutionServiceTest {
     void differentSessionsGetDifferentContainers() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        svc.execute("session-a", python(), "none", "print(1)");
-        svc.execute("session-c", python(), "none", "print(1)");
+        svc.execute("session-a", python(), "none", null, "print(1)");
+        svc.execute("session-c", python(), "none", null, "print(1)");
 
         assertThat(calls().stream().filter(c -> c.startsWith("run ")).toList()).hasSize(2);
     }
@@ -136,13 +136,13 @@ class CodeExecutionServiceTest {
     void timedOutExecutionKillsTheSessionContainer() throws IOException {
         var svc = newService(stub(3, ""), Duration.ofMillis(400));
 
-        var result = svc.execute("session-d", python(), "none", "while True: pass");
+        var result = svc.execute("session-d", python(), "none", null, "while True: pass");
 
         assertThat(result.timedOut()).isTrue();
         assertThat(calls()).anySatisfy(c -> assertThat(c).startsWith("rm -f container-1"));
 
         // The next call must start over with a fresh container.
-        svc.execute("session-d", python(), "none", "print(1)");
+        svc.execute("session-d", python(), "none", null, "print(1)");
         assertThat(calls().stream().filter(c -> c.startsWith("run ")).toList()).hasSize(2);
     }
 
@@ -182,8 +182,8 @@ class CodeExecutionServiceTest {
     void networkModeIsPartOfContainerCreationAndSessionKey() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        svc.execute("session-n", python(), "none", "print(1)");
-        svc.execute("session-n", python(), "bridge", "print(1)");
+        svc.execute("session-n", python(), "none", null, "print(1)");
+        svc.execute("session-n", python(), "bridge", null, "print(1)");
 
         List<String> runs = calls().stream().filter(c -> c.startsWith("run ")).toList();
         assertThat(runs).hasSize(2);

--- a/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/HostMountTest.java
+++ b/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/HostMountTest.java
@@ -1,0 +1,61 @@
+package ai.mindconnect.agent.tools.code;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The mount is a hole in the container's isolation, so the two rules that keep
+ * it honest are worth pinning down: it identifies the container it belongs to,
+ * and read-only is a different container from writable.
+ */
+class HostMountTest {
+
+    @Test
+    void noMountHasAKeyOfItsOwn() {
+        // Not the empty string: "no mount" must never collide with a mount
+        // whose path happens to stringify to nothing.
+        assertThat(HostMount.key(null)).isEqualTo("-");
+    }
+
+    @Test
+    void readOnlyAndWritableAreDifferentContainers() {
+        Path dir = Path.of("/tmp/mc-host");
+
+        String ro = HostMount.key(new HostMount(dir, true));
+        String rw = HostMount.key(new HostMount(dir, false));
+
+        assertThat(ro).isNotEqualTo(rw);
+        assertThat(ro).endsWith(":ro");
+        assertThat(rw).endsWith(":rw");
+    }
+
+    @Test
+    void differentDirectoriesAreDifferentContainers() {
+        assertThat(HostMount.key(new HostMount(Path.of("/tmp/a"), true)))
+                .isNotEqualTo(HostMount.key(new HostMount(Path.of("/tmp/b"), true)));
+    }
+
+    @Test
+    void theKeyIsAbsoluteSoTwoSpellingsOfOnePathAgree() {
+        Path relative = Path.of("target");
+        assertThat(HostMount.key(new HostMount(relative, true)))
+                .isEqualTo(HostMount.key(new HostMount(relative.toAbsolutePath(), true)));
+    }
+
+    @Test
+    void aMountWithoutADirectoryIsARefusal() {
+        assertThatThrownBy(() -> new HostMount(null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void describeNamesBothEndsAndWhichWayItOpens() {
+        assertThat(new HostMount(Path.of("/home/u"), true).describe())
+                .contains("/home/u").contains(HostMount.MOUNT_POINT).contains("read-only");
+        assertThat(new HostMount(Path.of("/home/u"), false).describe()).contains("writable");
+    }
+}

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/default-chat.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/default-chat.json
@@ -220,8 +220,10 @@
       "id": "00000003-0000-0000-0000-000000000070",
       "agentDefinitionId": "00000002-0000-0000-0000-000000000012",
       "name": "code_execute",
-      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. Use it for calculations, data wrangling and quick scripts instead of doing the arithmetic yourself.",
-      "overrides": {},
+      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. The user's home directory is mounted read-only at /mnt/host, so this is also how you read their files. Use it for calculations, data wrangling and quick scripts.",
+      "overrides": {
+        "mountDir": "~"
+      },
       "enabled": true,
       "deferred": false,
       "needsApproval": true,


### PR DESCRIPTION
> Based on `feature/default-chat-agent` (#20), not on `main` — the mount is
> configured on the seeded `default-chat` agent, which only exists there. Merge
> #20 first and this retargets cleanly.

The container had its session scratch space and nothing else, so sandboxed code
could not read the user's own files — "your isolated environment has no access
to my filesystem" was the honest answer it kept giving.

`/workspace` was already a bind mount, so this adds a second one rather than a
mechanism.

| where | what |
|---|---|
| `codeExecMountDir` (runtime) | default for every binding that names none |
| `mountDir` on the agent's tool binding | per-agent override, like `network` |
| `mountWritable` (default `false`) | opt out of read-only |
| `/mnt/host` | where it appears inside |

The seeded `default-chat` mounts the user's home (`~`, expanded against
`user.home` so the seed stays portable).

### Two decisions worth keeping

- **The path is the operator's, never a tool argument.** A directory chosen by
  model output is one that eventually reads `/` or `~/.ssh` — and the model
  gains nothing from choosing it, it only needs to know where to look, which
  the tool description now tells it.
- **Read-only unless asked otherwise.** The container exists so that
  model-written code runs where it cannot do damage.

### Correctness

The mount joins the container's session key, for the reason the network mode
already does: it is fixed when the container starts, so two bindings that
disagree about it must not share one container. `HostMountTest` pins that down,
including that "no mount" has a key of its own rather than the empty string.

The class javadoc no longer claims the scratch directory is the only host
access. That was a documented invariant; this weakens it on purpose, so it says
so.

### Checked

- 22 tests in the module, 11 of them real podman runs.
- End to end: `default-chat` listed the real home directory through `/mnt/host`
  (exit 0, 108 ms), after the approval card — `code_execute` is gated in #20.
- Read-only proven against podman directly: `touch` returns
  `Read-only file system`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)