### PR TITLE
A chat can run on a system prompt of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **Chat settings no longer discard what you changed — or what you didn't.**
+  Applying the dialog dropped the model you had just picked, and quietly
+  stripped every tool the tool registry could not offer: on a machine without
+  Gmail credentials, opening the settings and pressing Apply cost the chat its
+  three Gmail tools. The dialog now writes back only the settings that actually
+  differ from the agent's, and leaves tools it never asked about alone.
+
 - **The chat settings dialog sees the agent the chat is running on.** A chat
   opened from an agent carries only its `agentDefinitionId`; the dialog read
   the session-agent list, found it empty, and reported "no agent" — so pressing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **A chat can run on a system prompt of its own.** The settings dialog gains
+  the field, pre-filled with what the chat runs on today — its agent's prompt
+  until you edit it. Editing it changes this one conversation; the agent, its
+  tools and the agents it may call stay as they are, and the header marks the
+  chat as running its own prompt so the agent's name on it is not misleading.
+  Leaving the field alone stores no override, so the chat keeps tracking edits
+  to the agent itself.
+
+
 - **`code_execute` can be given a host directory to see.** The container used
   to have nothing but its session scratch space, so sandboxed code could not
   read the user's own files. A `mountDir` on the tool's agent binding — or the
@@ -94,6 +103,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
   in the picker so opening the dialog cannot silently reassign it.
 
 ### Fixed
+
+- **The chat settings dialog sees the agent the chat is running on.** A chat
+  opened from an agent carries only its `agentDefinitionId`; the dialog read
+  the session-agent list, found it empty, and reported "no agent" — so pressing
+  Apply detached the chat from the agent it was plainly running on, losing its
+  tools and the agents it may call. It has always been wrong for chats started
+  from an agent page; with `default-chat` it became the ordinary case.
+
 
 - **The chat header names the conversation again.** Since the chat stopped
   rendering its own app-shell header, the header said which agent was

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/session/SessionAgentRef.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/session/SessionAgentRef.java
@@ -13,10 +13,15 @@ import java.util.UUID;
  * <p>{@link #id()} is the agent's own id, so the workspace and the messages
  * stay with the agent and {@code ?agentId=} keeps finding these sessions.
  *
- * <p>The system prompt is deliberately not overridable: a ref whose prompt was
- * replaced would be an inline agent wearing someone else's name, and "sessions
- * of agent X" would stop meaning anything. Changing the prompt detaches the
- * chat into an {@link InlineSessionAgent} instead.
+ * <p>The system prompt used to be excluded here, on the grounds that a ref
+ * whose prompt was replaced is an inline agent wearing someone else's name,
+ * and that detaching into an {@link InlineSessionAgent} was the honest way to
+ * change it. That reasoning predates {@code callableAgents}: detaching now
+ * silently drops the roster the agent was given, so a chat that edits its
+ * prompt would quietly regain the run of every agent in the namespace. Keeping
+ * the binding and overriding the prompt is the lesser evil — and the name is
+ * kept honest by showing the override in the chat header rather than by
+ * forbidding it.
  */
 public record SessionAgentRef(
         UUID id,
@@ -27,8 +32,21 @@ public record SessionAgentRef(
         /** {@code null} = the agent's own. */
         List<AgentTool> tools,
         /** {@code null} = the agent's own. */
-        AgentDefinition.ToolSearchConfig toolSearch
+        AgentDefinition.ToolSearchConfig toolSearch,
+        /** {@code null} = the agent's own. Anything else is shown as an override. */
+        String systemPrompt
 ) implements SessionAgent {
+
+    /** Pre-override constructor: the agent's own prompt. */
+    public SessionAgentRef(UUID id, boolean main, String label, String llmConfigName,
+                           List<AgentTool> tools, AgentDefinition.ToolSearchConfig toolSearch) {
+        this(id, main, label, llmConfigName, tools, toolSearch, null);
+    }
+
+    /** Whether this chat runs on something other than the agent's own prompt. */
+    public boolean hasPromptOverride() {
+        return systemPrompt != null && !systemPrompt.isBlank();
+    }
 
     /** The agent this session runs — the id is the reference. */
     public UUID agentId() {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/SessionAgentResolver.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/SessionAgentResolver.java
@@ -72,16 +72,21 @@ public class SessionAgentResolver {
     }
 
     /**
-     * The agent as configured, with this chat's choices on top. Only the model
-     * and the tools: overriding the system prompt would make the agent's name
-     * on the session a lie, and detaching into an inline agent is the honest
-     * way to do that.
+     * The agent as configured, with this chat's choices on top: model, tools,
+     * and — since the roster made detaching costly — the system prompt. See
+     * {@link SessionAgentRef} for why that last one stopped being forbidden.
+     * Everything the chat does not name stays the agent's own, the roster
+     * included.
      */
     private static AgentDefinition withOverrides(AgentDefinition base, SessionAgentRef ref) {
         AgentDefinition out = base;
         if (ref.llmConfigName() != null && !ref.llmConfigName().isBlank()) {
             out = out.withBasicFields(out.name(), out.description(), out.systemPrompt(),
                     out.welcomeMessage(), ref.llmConfigName());
+        }
+        if (ref.hasPromptOverride()) {
+            out = out.withBasicFields(out.name(), out.description(), ref.systemPrompt(),
+                    out.welcomeMessage(), out.llmConfigName());
         }
         if (ref.tools() != null) {
             out = out.withTools(ref.tools());

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/session/SessionPromptOverrideTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/session/SessionPromptOverrideTest.java
@@ -1,0 +1,56 @@
+package ai.mindconnect.agent.domain.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A chat may run on a prompt of its own while staying bound to its agent.
+ *
+ * <p>The binding is what matters here: detaching into an
+ * {@link InlineSessionAgent} — the way this used to be done — drops the
+ * agent's roster, and a chat that edited its prompt would quietly regain the
+ * run of every agent in the namespace.
+ */
+class SessionPromptOverrideTest {
+
+    private static SessionAgentRef ref(String prompt) {
+        return new SessionAgentRef(UUID.randomUUID(), true, "default-chat", null, null, null, prompt);
+    }
+
+    @Test
+    void noOverrideMeansTheAgentsOwnPrompt() {
+        assertThat(ref(null).hasPromptOverride()).isFalse();
+        assertThat(ref("").hasPromptOverride()).isFalse();
+        assertThat(ref("   ").hasPromptOverride()).isFalse();
+    }
+
+    @Test
+    void anOverrideIsRecognisedAsOne() {
+        var r = ref("You only answer in haiku.");
+
+        assertThat(r.hasPromptOverride()).isTrue();
+        assertThat(r.systemPrompt()).isEqualTo("You only answer in haiku.");
+    }
+
+    /** The header names the agent, so the override has to be visible somewhere. */
+    @Test
+    void theBindingSurvivesTheOverride() {
+        UUID agentId = UUID.randomUUID();
+        var r = new SessionAgentRef(agentId, true, "default-chat", null, null, null, "mine");
+
+        assertThat(r.agentId()).isEqualTo(agentId);
+        assertThat(r.label()).isEqualTo("default-chat");
+    }
+
+    /** Sessions written before the field existed deserialise as "no override". */
+    @Test
+    void thePreOverrideConstructorStillWorks() {
+        var r = new SessionAgentRef(UUID.randomUUID(), true, "Poet", "claude", null, null);
+
+        assertThat(r.systemPrompt()).isNull();
+        assertThat(r.hasPromptOverride()).isFalse();
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
@@ -33,11 +33,23 @@ public final class ChatSettingsComponent implements UiComponent {
     private final List<String> currentTools;
     private final boolean toolSearchOn;
     private final UUID currentAgentId;
+    /** What this chat runs on today — the agent's prompt, or its own override. */
+    private final String currentSystemPrompt;
 
     public ChatSettingsComponent(UUID sessionId, List<LlmConfig> llmConfigs,
                                  List<AgentDefinition> agents, List<String> toolNames,
                                  String currentLlmConfigName, List<String> currentTools,
                                  boolean toolSearchOn, UUID currentAgentId) {
+        this(sessionId, llmConfigs, agents, toolNames, currentLlmConfigName, currentTools,
+                toolSearchOn, currentAgentId, null);
+    }
+
+    public ChatSettingsComponent(UUID sessionId, List<LlmConfig> llmConfigs,
+                                 List<AgentDefinition> agents, List<String> toolNames,
+                                 String currentLlmConfigName, List<String> currentTools,
+                                 boolean toolSearchOn, UUID currentAgentId,
+                                 String currentSystemPrompt) {
+        this.currentSystemPrompt = currentSystemPrompt;
         this.sessionId = sessionId;
         this.llmConfigs = llmConfigs;
         this.agents = agents;
@@ -83,6 +95,14 @@ public final class ChatSettingsComponent implements UiComponent {
                         currentAgentId == null ? "" : currentAgentId.toString(), agentOptions)
                         .asEditable()
                         .hint("Takes over prompt, model and tools — the fields above stop applying"))
+                // Last, because it is the longest field and the one you scroll
+                // past when you came for the model. Pre-filled with what the
+                // chat runs on today: the agent's prompt until it is edited.
+                .field(UiField.textarea("systemPrompt", "System prompt", currentSystemPrompt)
+                        .asEditable()
+                        .hint("Starts as the agent's own. Edit it and this chat alone uses "
+                                + "yours — the agent, its tools and the agents it may call "
+                                + "stay as they are"))
                 .action(UiAction.primary("apply", "Apply").icon("save")
                         .dispatch("POST", "/chat/api/sessions/" + sessionId + "/settings"))
                 .action(UiAction.secondary("cancel", "Cancel")

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
@@ -6,6 +6,8 @@ import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.ui.model.UiField;
 import ai.mindconnect.ui.model.UiForm;
+import ai.mindconnect.ui.model.UiFieldGroup;
+import ai.mindconnect.ui.model.UiSection;
 
 import java.util.List;
 import java.util.UUID;
@@ -80,7 +82,15 @@ public final class ChatSettingsComponent implements UiComponent {
                 .map(n -> UiField.Option.of(n, n))
                 .toList();
 
-        return UiForm.of(id(), "Model & tools")
+        // One tab per half. The fields live in field groups inside the tabs,
+        // and the tabs inside the FORM — not the form inside the tabs. The
+        // submitted payload is the id of the <form> the button sits in
+        // (EventBus.inferImplicitPayload), so a second form would submit only
+        // its own half: pressing Apply on the agent tab would send agentId and
+        // nothing else, and the model, the tools and the prompt would arrive
+        // as absent. A hidden tab is hidden, not removed, so its inputs are
+        // still part of the one form.
+        var modelTab = UiFieldGroup.of(id() + "-g-model", null)
                 .field(UiField.select("llmConfigName", "Model", currentLlmConfigName, modelOptions)
                         .asEditable()
                         .hint("Provider, key and context window come with the config"))
@@ -91,18 +101,25 @@ public final class ChatSettingsComponent implements UiComponent {
                         .asEditable()
                         .hint("Lets the chat find the remaining tools itself instead of carrying "
                                 + "every definition in its context"))
-                .field(UiField.select("agentId", "…or an agent",
-                        currentAgentId == null ? "" : currentAgentId.toString(), agentOptions)
-                        .asEditable()
-                        .hint("Takes over prompt, model and tools — the fields above stop applying"))
-                // Last, because it is the longest field and the one you scroll
-                // past when you came for the model. Pre-filled with what the
-                // chat runs on today: the agent's prompt until it is edited.
                 .field(UiField.textarea("systemPrompt", "System prompt", currentSystemPrompt)
                         .asEditable()
                         .hint("Starts as the agent's own. Edit it and this chat alone uses "
                                 + "yours — the agent, its tools and the agents it may call "
-                                + "stay as they are"))
+                                + "stay as they are"));
+
+        var agentTab = UiFieldGroup.of(id() + "-g-agent", null)
+                .field(UiField.select("agentId", "…or an agent",
+                                currentAgentId == null ? "" : currentAgentId.toString(), agentOptions)
+                        .asEditable()
+                        .hint("Takes over prompt, model and tools — the fields on the other tab "
+                                + "stop applying"));
+
+        var tabs = UiSection.of(id() + "-tabs", null)
+                .section(id() + "-tab-model", "Model & tools", modelTab)
+                .section(id() + "-tab-agent", "Agent", agentTab);
+
+        return UiForm.of(id(), "Chat settings")
+                .content(tabs)
                 .action(UiAction.primary("apply", "Apply").icon("save")
                         .dispatch("POST", "/chat/api/sessions/" + sessionId + "/settings"))
                 .action(UiAction.secondary("cancel", "Cancel")

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
@@ -84,6 +84,8 @@ public final class MessageListComponent implements UiComponent {
     private UUID parentSessionId;
     /** This conversation's title, when it has one — the header's subject. */
     private String sessionTitle;
+    /** Whether this chat replaced its agent's system prompt with its own. */
+    private boolean customPrompt;
     /** Bubbled sub-agent approval cards (from the ToolApprovalStore), rendered after the history. */
     private List<UiList.Item> bubbledApprovalCards = List.of();
     /** The host's overflow menu (parent session, back to agent, memory/trace
@@ -117,6 +119,18 @@ public final class MessageListComponent implements UiComponent {
      */
     public MessageListComponent withSessionTitle(String sessionTitle) {
         this.sessionTitle = sessionTitle;
+        return this;
+    }
+
+    /**
+     * Marks that this chat runs on its own system prompt rather than the
+     * agent's. The badge says so: the header still names the agent, because
+     * its tools and the agents it may call are still the agent's — but the
+     * name would be misleading on its own. Returns {@code this} for fluent
+     * chaining.
+     */
+    public MessageListComponent withCustomPrompt(boolean customPrompt) {
+        this.customPrompt = customPrompt;
         return this;
     }
 
@@ -194,8 +208,16 @@ public final class MessageListComponent implements UiComponent {
         var tools = ai.mindconnect.ui.model.UiStack.of(id() + "-tools")
                 .direction(ai.mindconnect.ui.model.UiStack.Direction.HORIZONTAL)
                 .<ai.mindconnect.ui.model.UiStack>withCssClass("chat-header-tools");
-        if (titled) {
-            tools.child(ai.mindconnect.ui.model.UiText.of(id() + "-agent", agentName)
+        // Titled: the badge names the agent, because the header names the
+        // conversation. Untitled: the header already names the agent, so the
+        // badge is only worth drawing when there is something else to say —
+        // and an overridden prompt is exactly that, on the chat where the
+        // header would otherwise claim the agent's own.
+        String badge = titled
+                ? (customPrompt ? agentName + " · own prompt" : agentName)
+                : (customPrompt ? "own prompt" : null);
+        if (badge != null) {
+            tools.child(ai.mindconnect.ui.model.UiText.of(id() + "-agent", badge)
                     .<ai.mindconnect.ui.model.UiText>withCssClass("chat-agent-badge"));
         }
         tools.child(new TokenUsageComponent(id(), memory).render());

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -151,16 +151,13 @@ public class ChatUiController {
         if (sessionOpt.isEmpty()) return ResponseEntity.notFound().build();
         var session = sessionOpt.get();
         var effective = agentResolver.resolve(session);
-        UUID agentId = session.mainAgent()
-                .filter(a -> a instanceof ai.mindconnect.agent.domain.session.SessionAgentRef)
-                .map(ai.mindconnect.agent.domain.session.SessionAgent::id)
-                .orElse(null);
+        UUID agentId = boundAgentId(session);
 
         var form = new ai.mindconnect.chatui.ui.component.ChatSettingsComponent(
                 sessionId, llmConfigRepository.findAll(), selectableAgents(agentId), allToolNames(),
                 effective.llmConfigName(),
                 effective.tools().stream().map(ai.mindconnect.agent.tool.AgentTool::name).toList(),
-                effective.toolSearchOrOff().enabled(), agentId).render();
+                effective.toolSearchOrOff().enabled(), agentId, effective.systemPrompt()).render();
 
         var dlg = ai.mindconnect.ui.model.UiDialog.of("Model & tools", null, form);
         dlg.setId("chat-dialog");
@@ -183,15 +180,23 @@ public class ChatUiController {
         if (agentId != null && !agentId.isBlank()) {
             var def = agentRepository.findById(UUID.fromString(agentId))
                     .orElseThrow(() -> new IllegalArgumentException("No such agent: " + agentId));
+            // Only a prompt that actually differs is stored: an untouched
+            // field must not turn into an override that then stops tracking
+            // edits to the agent itself.
+            String prompt = body.str("systemPrompt");
+            String override = prompt == null || prompt.isBlank()
+                    || prompt.strip().equals(String.valueOf(def.systemPrompt()).strip())
+                    ? null : prompt;
             agent = new ai.mindconnect.agent.domain.session.SessionAgentRef(
-                    def.id(), true, def.name(), null, null, null);
+                    def.id(), true, def.name(), null, null, null, override);
         } else {
             // Staying inline keeps the same agent — and therefore the same
             // workspace — while only the model and tools change. Coming from a
             // ref agent it is a new one, and the switch says so.
             var previous = sessionOpt.get().mainAgent().orElse(null);
+            String prompt = body.str("systemPrompt");
             var fresh = inlineAgent(body.str("llmConfigName"),
-                    body.strList("tools"), body.bool("toolSearch", true));
+                    body.strList("tools"), body.bool("toolSearch", true), prompt);
             agent = previous instanceof ai.mindconnect.agent.domain.session.InlineSessionAgent kept
                     ? kept.withLlmConfigName(fresh.llmConfigName())
                           .withTools(fresh.tools().stream()
@@ -336,12 +341,18 @@ public class ChatUiController {
     /** The session's own agent, built from a model name and tool names. */
     private ai.mindconnect.agent.domain.session.InlineSessionAgent inlineAgent(
             String llmConfigName, List<String> tools, boolean toolSearch) {
+        return inlineAgent(llmConfigName, tools, toolSearch, null);
+    }
+
+    /** @param systemPrompt {@code null} or blank falls back to the built-in one. */
+    private ai.mindconnect.agent.domain.session.InlineSessionAgent inlineAgent(
+            String llmConfigName, List<String> tools, boolean toolSearch, String systemPrompt) {
         List<String> names = tools == null || tools.isEmpty()
                 ? ai.mindconnect.chatui.ui.component.ChatSettingsComponent.DEFAULT_TOOLS
                 : tools;
         var known = allToolNames();
         return ai.mindconnect.agent.domain.session.InlineSessionAgent.of(
-                "Chat", CHAT_SYSTEM_PROMPT,
+                "Chat", systemPrompt == null || systemPrompt.isBlank() ? CHAT_SYSTEM_PROMPT : systemPrompt,
                 llmConfigName == null ? defaultLlmConfigName() : llmConfigName,
                 names.stream().filter(known::contains).toList(),
                 toolSearch);
@@ -371,6 +382,34 @@ public class ChatUiController {
      * assistant, so opening the dialog on such a chat and pressing Apply does
      * not silently reassign it.
      */
+    /**
+     * The registry agent this chat runs on, or {@code null} for a chat with an
+     * agent of its own.
+     *
+     * <p>Two shapes mean the same thing. Picking an agent in the settings
+     * dialog writes a {@link ai.mindconnect.agent.domain.session.SessionAgentRef};
+     * opening a chat from an agent — which is now every chat, via
+     * {@code default-chat} — sets only {@code agentDefinitionId} and leaves the
+     * session-agent list empty. Reading just the ref reported "no agent" for
+     * the second kind, and pressing Apply on one detached the chat from the
+     * agent it was plainly running on.
+     *
+     * <p>The id is checked against the registry: an inline agent's id is minted
+     * for the session and would otherwise look like a binding.
+     */
+    private UUID boundAgentId(ai.mindconnect.agent.domain.AgentSession session) {
+        UUID ref = session.mainAgent()
+                .filter(a -> a instanceof ai.mindconnect.agent.domain.session.SessionAgentRef)
+                .map(ai.mindconnect.agent.domain.session.SessionAgent::id)
+                .orElse(null);
+        if (ref != null) {
+            return ref;
+        }
+        UUID fromSession = session.agentDefinitionId();
+        return fromSession != null && agentRepository.findById(fromSession).isPresent()
+                ? fromSession : null;
+    }
+
     /**
      * Icon name per agent-definition id, for the history drawer. Read from the
      * registry in one go: a row only needs the icon, and resolving every

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -180,15 +180,41 @@ public class ChatUiController {
         if (agentId != null && !agentId.isBlank()) {
             var def = agentRepository.findById(UUID.fromString(agentId))
                     .orElseThrow(() -> new IllegalArgumentException("No such agent: " + agentId));
-            // Only a prompt that actually differs is stored: an untouched
-            // field must not turn into an override that then stops tracking
-            // edits to the agent itself.
-            String prompt = body.str("systemPrompt");
-            String override = prompt == null || prompt.isBlank()
-                    || prompt.strip().equals(String.valueOf(def.systemPrompt()).strip())
-                    ? null : prompt;
+            // Switching to another agent hands the chat over completely: that
+            // agent's model, tools and prompt win, which is what the picker
+            // promises. Staying on the same one keeps what this chat chose —
+            // the ref carries exactly these three overrides for that.
+            boolean sameAgent = def.id().equals(boundAgentId(sessionOpt.get()));
+
+            // Only a value that actually differs is stored: an untouched field
+            // must not turn into an override that then stops tracking edits to
+            // the agent itself.
+            String prompt = sameAgent ? differing(body.str("systemPrompt"), def.systemPrompt()) : null;
+            String llm = sameAgent ? differing(body.str("llmConfigName"), def.llmConfigName()) : null;
+
+            List<ai.mindconnect.agent.tool.AgentTool> toolOverride = null;
+            ai.mindconnect.agent.domain.AgentDefinition.ToolSearchConfig searchOverride = null;
+            if (sameAgent) {
+                // Compared against what the dialog could actually offer, not
+                // against everything the agent has: a tool the registry does
+                // not know — Gmail without credentials — never reaches the
+                // multiselect, so it can neither be kept nor removed there.
+                List<String> chosen = body.strList("tools");
+                var offerable = def.tools().stream()
+                        .map(ai.mindconnect.agent.tool.AgentTool::name)
+                        .filter(allToolNames()::contains)
+                        .collect(java.util.stream.Collectors.toSet());
+                if (chosen != null && !new java.util.HashSet<>(chosen).equals(offerable)) {
+                    toolOverride = pickTools(def, chosen);
+                }
+                boolean search = body.bool("toolSearch", def.toolSearchOrOff().enabled());
+                if (search != def.toolSearchOrOff().enabled()) {
+                    searchOverride = new ai.mindconnect.agent.domain.AgentDefinition.ToolSearchConfig(
+                            search, def.toolSearchOrOff().groups());
+                }
+            }
             agent = new ai.mindconnect.agent.domain.session.SessionAgentRef(
-                    def.id(), true, def.name(), null, null, null, override);
+                    def.id(), true, def.name(), llm, toolOverride, searchOverride, prompt);
         } else {
             // Staying inline keeps the same agent — and therefore the same
             // workspace — while only the model and tools change. Coming from a
@@ -382,6 +408,50 @@ public class ChatUiController {
      * assistant, so opening the dialog on such a chat and pressing Apply does
      * not silently reassign it.
      */
+
+    /** The submitted value when it says something other than the agent's own. */
+    private static String differing(String submitted, String agentsOwn) {
+        if (submitted == null || submitted.isBlank()) {
+            return null;
+        }
+        return submitted.strip().equals(String.valueOf(agentsOwn).strip()) ? null : submitted;
+    }
+
+    /**
+     * The chat's tool selection as {@link ai.mindconnect.agent.tool.AgentTool}s,
+     * reusing the agent's own binding for every name it already has.
+     *
+     * <p>Rebuilding them from bare names would quietly drop what the binding
+     * carries beyond the name — {@code needsApproval} on bash and
+     * {@code code_execute}, the {@code mountDir} that gives the sandbox its
+     * host directory, a deferred flag. Turning the model dropdown would have
+     * been enough to lose all of it.
+     */
+    private List<ai.mindconnect.agent.tool.AgentTool> pickTools(
+            ai.mindconnect.agent.domain.AgentDefinition def, List<String> names) {
+        var byName = def.tools().stream().collect(java.util.stream.Collectors.toMap(
+                ai.mindconnect.agent.tool.AgentTool::name, t -> t, (a, b) -> a));
+        var known = allToolNames();
+        var picked = new java.util.LinkedHashMap<String, ai.mindconnect.agent.tool.AgentTool>();
+        // Whatever the dialog could not show stays: the chat did not drop it,
+        // it was never asked about. Without this, opening the settings and
+        // pressing Apply would silently strip an agent's Gmail tools on a
+        // machine where Gmail is not configured.
+        for (var t : def.tools()) {
+            if (!known.contains(t.name())) {
+                picked.put(t.name(), t);
+            }
+        }
+        for (String n : names) {
+            if (!known.contains(n)) {
+                continue;
+            }
+            picked.put(n, byName.containsKey(n)
+                    ? byName.get(n)
+                    : ai.mindconnect.agent.tool.AgentTool.of(def.id(), n));
+        }
+        return List.copyOf(picked.values());
+    }
     /**
      * The registry agent this chat runs on, or {@code null} for a chat with an
      * agent of its own.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/page/ChatPage.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/page/ChatPage.java
@@ -85,6 +85,11 @@ public final class ChatPage {
         this.agent = agent;
         this.messages = new MessageListComponent(session.id(), agent, history, memory, subAgentTree)
                 .withSessionTitle(session.title())
+                .withCustomPrompt(session.mainAgent()
+                        .filter(a -> a instanceof ai.mindconnect.agent.domain.session.SessionAgentRef)
+                        .map(a -> ((ai.mindconnect.agent.domain.session.SessionAgentRef) a)
+                                .hasPromptOverride())
+                        .orElse(false))
                 .withParentSession(session.parentSessionId());
         this.chatForm = new ChatFormComponent(session.id(), agent.id(), streaming)
                 .withModelLabel(agent.llmConfigName());


### PR DESCRIPTION
> Stacked on `feature/code-exec-host-mount` (#21), which is stacked on
> `feature/default-chat-agent` (#20). Merge in that order and each retargets.

The settings dialog let you change the model and the tools but not the prompt —
the setting people most want to try something with. It is there now, pre-filled
with what the chat runs on today: its agent's prompt, until you edit it.

### Overturning a documented decision, on purpose

Two comments said not to do this — a ref whose prompt was replaced is "an inline
agent wearing someone else's name", and detaching into an `InlineSessionAgent`
was "the honest way" to change it.

That reasoning predates `callableAgents`. **`InlineSessionAgent` has no roster**,
so detaching now silently hands the chat the run of every agent in the namespace
— the exact problem `default-chat` was built to stop. Keeping the binding and
overriding the prompt is the smaller loss.

The objection is answered rather than ignored: the header marks the chat as
running its own prompt, so the agent's name on it is not misleading. Both
comments were updated to say what changed and why.

Only a prompt that actually differs from the agent's is stored — an untouched
field must not become an override that then stops tracking edits to the agent.

### A bug the field uncovered

A chat opened from an agent carries only `agentDefinitionId`; the session-agent
list is empty. The dialog read only that list, found nothing, and offered
**"— no agent —"** — so pressing Apply **detached the chat from the agent it was
plainly running on**, losing its tools and its roster.

That has always been wrong for chats started from an agent page. With
`default-chat` it became the ordinary case. `boundAgentId(...)` now falls back to
the session's `agentDefinitionId`, checked against the registry so an inline
agent's minted id is not mistaken for a binding.

### Checked

Overriding the prompt on a `default-chat` session:

- the stored ref still names the agent, with no tool or model override
- working memory drops from ~1200 prompt tokens to 18
- the header reads `default-chat · own prompt`

Four tests in `SessionPromptOverrideTest` cover the override semantics and that
sessions written before the field deserialise as "no override". Full core suite:
73 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Two more settings bugs, found while splitting the dialog into tabs

The dialog now has a **Model & tools** and an **Agent** tab. They live inside one
`UiForm`: the event bus derives a trigger's payload from the enclosing form, so
two forms meant Apply submitted only the fields of its own tab.

Fixing that exposed the rest.

**The model you picked was thrown away.** The apply handler passed `null` for the
ref's model, tool and tool-search overrides — all three of which
`SessionAgentResolver` applies. Reopen the dialog and your change was gone.

**Applying cost the chat tools nobody had touched.** The multiselect can only
offer what the tool registry knows. On a machine without Gmail credentials,
`default-chat`'s three Gmail tools never reached the dialog — and Apply wrote
back the shortened list of 17, deleting them. Changing the model alone was
enough to trigger it.

What the dialog cannot show is now carried over untouched, and the
"did this change?" test compares against what was actually offered. Only
settings that genuinely differ from the agent's are stored.

### Checked

Fresh `default-chat` session, model changed to `claude-default` and nothing else:

```
kind         : ref              (still bound — roster intact)
llmConfigName: claude-default
tools        : no override      (Gmail tools survive)
systemPrompt : null
```

Reopening shows `claude-default`. A prompt change alone stores only
`systemPrompt`. `code_execute` keeps its `mountDir` and approval badge because
the agent's own `AgentTool` objects are reused. `mvn -f agents/pom.xml test`
green.