### PR TITLE
code_execute can see a directory of the host, and a chat can run on its own prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **`code_execute` can be given a host directory to see.** The container used
+  to have nothing but its session scratch space, so sandboxed code could not
+  read the user's own files. A `mountDir` on the tool's agent binding — or the
+  runtime-wide `codeExecMountDir` — mounts one directory at `/mnt/host`,
+  read-only unless `mountWritable` says otherwise. The seeded `default-chat`
+  mounts the user's home (`~`). The path comes from the operator, never from a
+  tool argument: a directory chosen by model output is one that eventually
+  reads `/`. Mounting nothing stays the default for every other agent, and the
+  mount is part of the container's identity, so two bindings that disagree
+  about it do not share one.
+
+
 - **An agent can be given a roster of the agents it may delegate to.**
   `AgentDefinition.callableAgents` names them; the admin form offers the same
   multiselect the response reviewers use. `list_agents` then answers with that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **Chat settings no longer discard what you changed — or what you didn't.**
+  Applying the dialog dropped the model you had just picked, and quietly
+  stripped every tool the tool registry could not offer: on a machine without
+  Gmail credentials, opening the settings and pressing Apply cost the chat its
+  three Gmail tools. The dialog now writes back only the settings that actually
+  differ from the agent's, and leaves tools it never asked about alone.
+
 - **The chat settings dialog sees the agent the chat is running on.** A chat
   opened from an agent carries only its `agentDefinitionId`; the dialog read
   the session-agent list, found it empty, and reported "no agent" — so pressing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **A chat can run on a system prompt of its own.** The settings dialog gains
+  the field, pre-filled with what the chat runs on today — its agent's prompt
+  until you edit it. Editing it changes this one conversation; the agent, its
+  tools and the agents it may call stay as they are, and the header marks the
+  chat as running its own prompt so the agent's name on it is not misleading.
+  Leaving the field alone stores no override, so the chat keeps tracking edits
+  to the agent itself.
+
+
 - **`code_execute` can be given a host directory to see.** The container used
   to have nothing but its session scratch space, so sandboxed code could not
   read the user's own files. A `mountDir` on the tool's agent binding — or the
@@ -94,6 +103,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
   in the picker so opening the dialog cannot silently reassign it.
 
 ### Fixed
+
+- **The chat settings dialog sees the agent the chat is running on.** A chat
+  opened from an agent carries only its `agentDefinitionId`; the dialog read
+  the session-agent list, found it empty, and reported "no agent" — so pressing
+  Apply detached the chat from the agent it was plainly running on, losing its
+  tools and the agents it may call. It has always been wrong for chats started
+  from an agent page; with `default-chat` it became the ordinary case.
+
 
 - **The chat header names the conversation again.** Since the chat stopped
   rendering its own app-shell header, the header said which agent was

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/default-chat.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/default-chat.json
@@ -220,8 +220,10 @@
       "id": "00000003-0000-0000-0000-000000000070",
       "agentDefinitionId": "00000002-0000-0000-0000-000000000012",
       "name": "code_execute",
-      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. Use it for calculations, data wrangling and quick scripts instead of doing the arithmetic yourself.",
-      "overrides": {},
+      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. The user's home directory is mounted read-only at /mnt/host, so this is also how you read their files. Use it for calculations, data wrangling and quick scripts.",
+      "overrides": {
+        "mountDir": "~"
+      },
       "enabled": true,
       "deferred": false,
       "needsApproval": true,

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/session/SessionAgentRef.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/session/SessionAgentRef.java
@@ -13,10 +13,15 @@ import java.util.UUID;
  * <p>{@link #id()} is the agent's own id, so the workspace and the messages
  * stay with the agent and {@code ?agentId=} keeps finding these sessions.
  *
- * <p>The system prompt is deliberately not overridable: a ref whose prompt was
- * replaced would be an inline agent wearing someone else's name, and "sessions
- * of agent X" would stop meaning anything. Changing the prompt detaches the
- * chat into an {@link InlineSessionAgent} instead.
+ * <p>The system prompt used to be excluded here, on the grounds that a ref
+ * whose prompt was replaced is an inline agent wearing someone else's name,
+ * and that detaching into an {@link InlineSessionAgent} was the honest way to
+ * change it. That reasoning predates {@code callableAgents}: detaching now
+ * silently drops the roster the agent was given, so a chat that edits its
+ * prompt would quietly regain the run of every agent in the namespace. Keeping
+ * the binding and overriding the prompt is the lesser evil — and the name is
+ * kept honest by showing the override in the chat header rather than by
+ * forbidding it.
  */
 public record SessionAgentRef(
         UUID id,
@@ -27,8 +32,21 @@ public record SessionAgentRef(
         /** {@code null} = the agent's own. */
         List<AgentTool> tools,
         /** {@code null} = the agent's own. */
-        AgentDefinition.ToolSearchConfig toolSearch
+        AgentDefinition.ToolSearchConfig toolSearch,
+        /** {@code null} = the agent's own. Anything else is shown as an override. */
+        String systemPrompt
 ) implements SessionAgent {
+
+    /** Pre-override constructor: the agent's own prompt. */
+    public SessionAgentRef(UUID id, boolean main, String label, String llmConfigName,
+                           List<AgentTool> tools, AgentDefinition.ToolSearchConfig toolSearch) {
+        this(id, main, label, llmConfigName, tools, toolSearch, null);
+    }
+
+    /** Whether this chat runs on something other than the agent's own prompt. */
+    public boolean hasPromptOverride() {
+        return systemPrompt != null && !systemPrompt.isBlank();
+    }
 
     /** The agent this session runs — the id is the reference. */
     public UUID agentId() {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/SessionAgentResolver.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/SessionAgentResolver.java
@@ -72,16 +72,21 @@ public class SessionAgentResolver {
     }
 
     /**
-     * The agent as configured, with this chat's choices on top. Only the model
-     * and the tools: overriding the system prompt would make the agent's name
-     * on the session a lie, and detaching into an inline agent is the honest
-     * way to do that.
+     * The agent as configured, with this chat's choices on top: model, tools,
+     * and — since the roster made detaching costly — the system prompt. See
+     * {@link SessionAgentRef} for why that last one stopped being forbidden.
+     * Everything the chat does not name stays the agent's own, the roster
+     * included.
      */
     private static AgentDefinition withOverrides(AgentDefinition base, SessionAgentRef ref) {
         AgentDefinition out = base;
         if (ref.llmConfigName() != null && !ref.llmConfigName().isBlank()) {
             out = out.withBasicFields(out.name(), out.description(), out.systemPrompt(),
                     out.welcomeMessage(), ref.llmConfigName());
+        }
+        if (ref.hasPromptOverride()) {
+            out = out.withBasicFields(out.name(), out.description(), ref.systemPrompt(),
+                    out.welcomeMessage(), out.llmConfigName());
         }
         if (ref.tools() != null) {
             out = out.withTools(ref.tools());

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/session/SessionPromptOverrideTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/session/SessionPromptOverrideTest.java
@@ -1,0 +1,56 @@
+package ai.mindconnect.agent.domain.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A chat may run on a prompt of its own while staying bound to its agent.
+ *
+ * <p>The binding is what matters here: detaching into an
+ * {@link InlineSessionAgent} — the way this used to be done — drops the
+ * agent's roster, and a chat that edited its prompt would quietly regain the
+ * run of every agent in the namespace.
+ */
+class SessionPromptOverrideTest {
+
+    private static SessionAgentRef ref(String prompt) {
+        return new SessionAgentRef(UUID.randomUUID(), true, "default-chat", null, null, null, prompt);
+    }
+
+    @Test
+    void noOverrideMeansTheAgentsOwnPrompt() {
+        assertThat(ref(null).hasPromptOverride()).isFalse();
+        assertThat(ref("").hasPromptOverride()).isFalse();
+        assertThat(ref("   ").hasPromptOverride()).isFalse();
+    }
+
+    @Test
+    void anOverrideIsRecognisedAsOne() {
+        var r = ref("You only answer in haiku.");
+
+        assertThat(r.hasPromptOverride()).isTrue();
+        assertThat(r.systemPrompt()).isEqualTo("You only answer in haiku.");
+    }
+
+    /** The header names the agent, so the override has to be visible somewhere. */
+    @Test
+    void theBindingSurvivesTheOverride() {
+        UUID agentId = UUID.randomUUID();
+        var r = new SessionAgentRef(agentId, true, "default-chat", null, null, null, "mine");
+
+        assertThat(r.agentId()).isEqualTo(agentId);
+        assertThat(r.label()).isEqualTo("default-chat");
+    }
+
+    /** Sessions written before the field existed deserialise as "no override". */
+    @Test
+    void thePreOverrideConstructorStillWorks() {
+        var r = new SessionAgentRef(UUID.randomUUID(), true, "Poet", "claude", null, null);
+
+        assertThat(r.systemPrompt()).isNull();
+        assertThat(r.hasPromptOverride()).isFalse();
+    }
+}

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteTool.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteTool.java
@@ -19,9 +19,17 @@ public final class CodeExecuteTool implements Tool {
     private final String sessionKey;
     /** Container network mode: {@code none} (default) or {@code bridge}. */
     private final String network;
+    /** Host directory visible inside the container, or {@code null} for none. */
+    private final HostMount mount;
 
     public CodeExecuteTool(CodeExecutionService service, Map<String, CodeLanguage> languages,
                            String sessionKey, String network) {
+        this(service, languages, sessionKey, network, null);
+    }
+
+    public CodeExecuteTool(CodeExecutionService service, Map<String, CodeLanguage> languages,
+                           String sessionKey, String network, HostMount mount) {
+        this.mount = mount;
         this.service = service;
         this.languages = languages;
         this.sessionKey = sessionKey;
@@ -43,9 +51,24 @@ public final class CodeExecuteTool implements Tool {
         return "Executes a program in an isolated container and returns exit code, stdout and stderr. "
                 + "Languages: " + String.join(", ", languages.keySet()) + ". "
                 + networkNote
+                + mountNote()
                 + "Each call runs a fresh interpreter process, so variables do NOT carry over between calls — "
                 + "but the working directory /workspace persists for this session. "
                 + "Write files to /workspace to pass data between calls.";
+    }
+
+    /**
+     * The model can only use the host directory if it is told it exists, and
+     * told where — the mount is invisible from inside otherwise.
+     */
+    private String mountNote() {
+        if (mount == null) {
+            return "";
+        }
+        return "The host directory " + mount.dir() + " is mounted at " + HostMount.MOUNT_POINT
+                + (mount.readOnly() ? " READ-ONLY" : " and is WRITABLE")
+                + " — read the user's own files from there. "
+                + "Paths outside it do not exist inside the container. ";
     }
 
     @Override
@@ -78,7 +101,7 @@ public final class CodeExecuteTool implements Tool {
         }
         CodeExecutionService.ExecResult result;
         try {
-            result = service.execute(sessionKey, language, network, source);
+            result = service.execute(sessionKey, language, network, mount, source);
         } catch (RuntimeException e) {
             return "Error: code execution failed: " + e.getMessage();
         }

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteToolFactory.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecuteToolFactory.java
@@ -41,6 +41,8 @@ public final class CodeExecuteToolFactory implements ToolFactory {
     private Map<String, CodeLanguage> languages = CodeLanguages.defaults();
     private CodeExecutionService service;
     private String defaultNetwork = "none";
+    /** Host directory offered to every binding that does not name its own; null = none. */
+    private String defaultMountDir;
 
     @Override
     public String name() {
@@ -62,6 +64,7 @@ public final class CodeExecuteToolFactory implements ToolFactory {
         }
         this.languages = CodeLanguages.parse(env.getString("codeExecLanguages").orElse(null));
         this.defaultNetwork = networkOrDefault(env.getString("codeExecNetwork").orElse(null), "none");
+        this.defaultMountDir = env.getString("codeExecMountDir").orElse(null);
         Path scratchRoot = Path.of(env.getString("dataBaseDir").orElse("data")).resolve("code-exec");
         CodeExecutionService.Settings settings = new CodeExecutionService.Settings(
                 env.getString("codeExecMemory").orElse("512m"),
@@ -93,7 +96,22 @@ public final class CodeExecuteToolFactory implements ToolFactory {
         network.put("default", defaultNetwork);
         network.put("description", "Container network mode. 'bridge' enables internet access "
                 + "(HTTP requests, pip/npm installs); 'none' fully isolates the container.");
-        return Map.of("type", "object", "properties", Map.of("network", network));
+        Map<String, Object> mountDir = new java.util.LinkedHashMap<>();
+        mountDir.put("type", "string");
+        mountDir.put("description", "Host directory to mount at " + HostMount.MOUNT_POINT
+                + " so the sandboxed code can read the user's own files. '~' is the user's "
+                + "home directory. Empty = nothing beyond the session scratch space.");
+        Map<String, Object> mountWritable = new java.util.LinkedHashMap<>();
+        mountWritable.put("type", "boolean");
+        mountWritable.put("default", false);
+        mountWritable.put("description", "Mount the directory writable instead of read-only. "
+                + "Model-written code can then change real files — leave this off unless that "
+                + "is the point.");
+        Map<String, Object> props = new java.util.LinkedHashMap<>();
+        props.put("network", network);
+        props.put("mountDir", mountDir);
+        props.put("mountWritable", mountWritable);
+        return Map.of("type", "object", "properties", props);
     }
 
     @Override
@@ -103,7 +121,42 @@ public final class CodeExecuteToolFactory implements ToolFactory {
         // for everything unlisted or invalid.
         String network = agentTool == null ? defaultNetwork
                 : networkOrDefault(String.valueOf(agentTool.overrides().getOrDefault("network", "")), defaultNetwork);
-        return new CodeExecuteTool(service, languages, sessionKey(scope), network);
+        return new CodeExecuteTool(service, languages, sessionKey(scope), network, mount(agentTool));
+    }
+
+    /**
+     * The host directory this binding may see, or {@code null}. Operator input
+     * only — the runtime setting, or a {@code mountDir} override on the agent's
+     * tool binding. Never a tool argument: a path the model chose is a path
+     * that eventually reads {@code /}.
+     */
+    private HostMount mount(AgentTool agentTool) {
+        Object raw = agentTool == null ? null : agentTool.overrides().get("mountDir");
+        String dir = raw == null || String.valueOf(raw).isBlank()
+                ? defaultMountDir : String.valueOf(raw);
+        if (dir == null || dir.isBlank()) {
+            return null;
+        }
+        java.nio.file.Path path = expandHome(dir.trim());
+        if (!java.nio.file.Files.isDirectory(path)) {
+            log.warn("code_execute mountDir '{}' is not a directory — mounting nothing", path);
+            return null;
+        }
+        boolean writable = agentTool != null
+                && Boolean.parseBoolean(String.valueOf(agentTool.overrides().getOrDefault("mountWritable", "false")));
+        return new HostMount(path, !writable);
+    }
+
+    /** {@code ~} and {@code ~/x} resolve against the user's home directory. */
+    private static java.nio.file.Path expandHome(String dir) {
+        java.nio.file.Path home = java.nio.file.Path.of(System.getProperty("user.home"));
+        if (dir.equals("~")) {
+            return home;
+        }
+        if (dir.startsWith("~/")) {
+            return home.resolve(dir.substring(2));
+        }
+        return java.nio.file.Path.of(dir);
     }
 
     /** Allowlist: only {@code none} and {@code bridge} are accepted network modes. */

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecutionService.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/CodeExecutionService.java
@@ -25,7 +25,10 @@ import java.util.concurrent.TimeUnit;
  * packages survive between calls; a fresh interpreter process runs each time.
  *
  * <p>Isolation per container: no network, memory/cpu limits, and a bind mount
- * of one session-private scratch directory as the only host filesystem access.
+ * of one session-private scratch directory. That scratch directory is the only
+ * host filesystem the container sees unless an operator mounts a second one
+ * (see {@link HostMount}) — which is a deliberate hole in the isolation, opened
+ * per agent binding and read-only by default.
  * Idle containers are reaped after a timeout; everything carries a label so
  * containers from a crashed previous run are cleaned up at startup.
  */
@@ -83,16 +86,20 @@ public final class CodeExecutionService implements AutoCloseable {
      * the container (the runaway process would otherwise keep burning its CPU
      * budget); the next call starts fresh.
      */
-    public ExecResult execute(String sessionKey, CodeLanguage language, String network, String code) {
-        String key = sessionKey + ":" + language.name() + ":" + network;
-        Session session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network));
+    public ExecResult execute(String sessionKey, CodeLanguage language, String network,
+                              HostMount mount, String code) {
+        // The mount joins the key for the same reason the network does: it is
+        // fixed when the container starts, so two bindings that disagree about
+        // it must not end up sharing one container.
+        String key = sessionKey + ":" + language.name() + ":" + network + ":" + HostMount.key(mount);
+        Session session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network, mount));
         long begin = System.currentTimeMillis();
         ContainerCli.Result result = exec(session, language, code);
         if (containerGone(result)) {
             // Removed behind our back (manual prune, engine restart) — one retry
             // with a fresh container.
             sessions.remove(key, session);
-            session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network));
+            session = sessions.computeIfAbsent(key, k -> start(sessionKey, language, network, mount));
             begin = System.currentTimeMillis();
             result = exec(session, language, code);
         }
@@ -111,25 +118,33 @@ public final class CodeExecutionService implements AutoCloseable {
         return cli.run(settings.execTimeout(), code, args.toArray(String[]::new));
     }
 
-    private Session start(String sessionKey, CodeLanguage language, String network) {
+    private Session start(String sessionKey, CodeLanguage language, String network, HostMount mount) {
         Path scratch = scratchDir(sessionKey);
-        ContainerCli.Result result = cli.run(LIFECYCLE_TIMEOUT, null,
+        List<String> args = new ArrayList<>(List.of(
                 "run", "-d",
                 "--label", LABEL + "=1",
                 "--network", network,
                 "--memory", settings.memory(),
                 "--cpus", settings.cpus(),
                 "--workdir", "/workspace",
-                "-v", scratch.toAbsolutePath() + ":/workspace",
-                language.image(),
-                // Portable idle keep-alive: busybox sleep has no "infinity".
-                "sleep", "2147483647");
+                "-v", scratch.toAbsolutePath() + ":/workspace"));
+        if (mount != null) {
+            args.add("-v");
+            args.add(mount.dir().toAbsolutePath() + ":" + HostMount.MOUNT_POINT
+                    + (mount.readOnly() ? ":ro" : ""));
+        }
+        args.add(language.image());
+        // Portable idle keep-alive: busybox sleep has no "infinity".
+        args.add("sleep");
+        args.add("2147483647");
+        ContainerCli.Result result = cli.run(LIFECYCLE_TIMEOUT, null, args.toArray(String[]::new));
         if (!result.ok()) {
             throw new IllegalStateException("Could not start " + language.name() + " container ("
                     + cli.binary() + " run failed): " + result.stderr().trim());
         }
         String containerId = result.stdout().trim();
-        log.info("Started code-exec container {} ({} / {})", shortId(containerId), sessionKey, language.name());
+        log.info("Started code-exec container {} ({} / {}{})", shortId(containerId), sessionKey,
+                language.name(), mount == null ? "" : " / mount " + mount.describe());
         return new Session(containerId);
     }
 

--- a/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/HostMount.java
+++ b/agents/core/mc-agent-tools-code/src/main/java/ai/mindconnect/agent/tools/code/HostMount.java
@@ -1,0 +1,46 @@
+package ai.mindconnect.agent.tools.code;
+
+import java.nio.file.Path;
+
+/**
+ * A directory of the host machine made visible inside the code-execution
+ * container, at {@link #MOUNT_POINT}.
+ *
+ * <p>This is a deliberate hole in the container's isolation, so it is not
+ * something the model decides. The directory comes from the operator — the
+ * runtime's {@code codeExecMountDir} setting, or a {@code mountDir} override on
+ * one agent's tool binding — never from a tool argument. A path chosen by
+ * model output is a path that will eventually be {@code /} or {@code ~/.ssh}.
+ *
+ * <p>Read-only unless someone opts out. The container exists so that
+ * model-written code runs where it cannot do damage; handing it write access
+ * to real files gives that up, and should be a sentence someone typed on
+ * purpose.
+ */
+public record HostMount(Path dir, boolean readOnly) {
+
+    /** Where the host directory appears inside the container. */
+    public static final String MOUNT_POINT = "/mnt/host";
+
+    public HostMount {
+        if (dir == null) {
+            throw new IllegalArgumentException("HostMount.dir must not be null");
+        }
+    }
+
+    /**
+     * Part of the container's session key: the mount is fixed when the
+     * container starts, so two bindings that disagree about it must not share
+     * one. {@code null} — no mount — has its own value rather than an empty
+     * string, so "no mount" and "a mount whose path stringifies to nothing"
+     * can never collide.
+     */
+    public static String key(HostMount mount) {
+        return mount == null ? "-" : mount.dir().toAbsolutePath() + (mount.readOnly() ? ":ro" : ":rw");
+    }
+
+    /** For the log line and the tool description. */
+    public String describe() {
+        return dir + " → " + MOUNT_POINT + (readOnly ? " (read-only)" : " (writable)");
+    }
+}

--- a/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/CodeExecutionServiceTest.java
+++ b/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/CodeExecutionServiceTest.java
@@ -93,8 +93,8 @@ class CodeExecutionServiceTest {
     void firstCallStartsContainerFurtherCallsReuseIt() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        var first = svc.execute("session-a", python(), "none", "print(1)");
-        var second = svc.execute("session-a", python(), "none", "print(2)");
+        var first = svc.execute("session-a", python(), "none", null, "print(1)");
+        var second = svc.execute("session-a", python(), "none", null, "print(2)");
 
         assertThat(first.stdout()).contains("ran[print(1)]");
         assertThat(second.stdout()).contains("ran[print(2)]");
@@ -110,7 +110,7 @@ class CodeExecutionServiceTest {
     void containerIsHardenedAndSessionScratchDirMounted() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        svc.execute("session-b", python(), "none", "print(1)");
+        svc.execute("session-b", python(), "none", null, "print(1)");
 
         String run = calls().stream().filter(c -> c.startsWith("run ")).findFirst().orElseThrow();
         assertThat(run).contains("--network none")
@@ -126,8 +126,8 @@ class CodeExecutionServiceTest {
     void differentSessionsGetDifferentContainers() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        svc.execute("session-a", python(), "none", "print(1)");
-        svc.execute("session-c", python(), "none", "print(1)");
+        svc.execute("session-a", python(), "none", null, "print(1)");
+        svc.execute("session-c", python(), "none", null, "print(1)");
 
         assertThat(calls().stream().filter(c -> c.startsWith("run ")).toList()).hasSize(2);
     }
@@ -136,13 +136,13 @@ class CodeExecutionServiceTest {
     void timedOutExecutionKillsTheSessionContainer() throws IOException {
         var svc = newService(stub(3, ""), Duration.ofMillis(400));
 
-        var result = svc.execute("session-d", python(), "none", "while True: pass");
+        var result = svc.execute("session-d", python(), "none", null, "while True: pass");
 
         assertThat(result.timedOut()).isTrue();
         assertThat(calls()).anySatisfy(c -> assertThat(c).startsWith("rm -f container-1"));
 
         // The next call must start over with a fresh container.
-        svc.execute("session-d", python(), "none", "print(1)");
+        svc.execute("session-d", python(), "none", null, "print(1)");
         assertThat(calls().stream().filter(c -> c.startsWith("run ")).toList()).hasSize(2);
     }
 
@@ -182,8 +182,8 @@ class CodeExecutionServiceTest {
     void networkModeIsPartOfContainerCreationAndSessionKey() throws IOException {
         var svc = newService(stub(0, ""), Duration.ofSeconds(10));
 
-        svc.execute("session-n", python(), "none", "print(1)");
-        svc.execute("session-n", python(), "bridge", "print(1)");
+        svc.execute("session-n", python(), "none", null, "print(1)");
+        svc.execute("session-n", python(), "bridge", null, "print(1)");
 
         List<String> runs = calls().stream().filter(c -> c.startsWith("run ")).toList();
         assertThat(runs).hasSize(2);

--- a/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/HostMountTest.java
+++ b/agents/core/mc-agent-tools-code/src/test/java/ai/mindconnect/agent/tools/code/HostMountTest.java
@@ -1,0 +1,61 @@
+package ai.mindconnect.agent.tools.code;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The mount is a hole in the container's isolation, so the two rules that keep
+ * it honest are worth pinning down: it identifies the container it belongs to,
+ * and read-only is a different container from writable.
+ */
+class HostMountTest {
+
+    @Test
+    void noMountHasAKeyOfItsOwn() {
+        // Not the empty string: "no mount" must never collide with a mount
+        // whose path happens to stringify to nothing.
+        assertThat(HostMount.key(null)).isEqualTo("-");
+    }
+
+    @Test
+    void readOnlyAndWritableAreDifferentContainers() {
+        Path dir = Path.of("/tmp/mc-host");
+
+        String ro = HostMount.key(new HostMount(dir, true));
+        String rw = HostMount.key(new HostMount(dir, false));
+
+        assertThat(ro).isNotEqualTo(rw);
+        assertThat(ro).endsWith(":ro");
+        assertThat(rw).endsWith(":rw");
+    }
+
+    @Test
+    void differentDirectoriesAreDifferentContainers() {
+        assertThat(HostMount.key(new HostMount(Path.of("/tmp/a"), true)))
+                .isNotEqualTo(HostMount.key(new HostMount(Path.of("/tmp/b"), true)));
+    }
+
+    @Test
+    void theKeyIsAbsoluteSoTwoSpellingsOfOnePathAgree() {
+        Path relative = Path.of("target");
+        assertThat(HostMount.key(new HostMount(relative, true)))
+                .isEqualTo(HostMount.key(new HostMount(relative.toAbsolutePath(), true)));
+    }
+
+    @Test
+    void aMountWithoutADirectoryIsARefusal() {
+        assertThatThrownBy(() -> new HostMount(null, true))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void describeNamesBothEndsAndWhichWayItOpens() {
+        assertThat(new HostMount(Path.of("/home/u"), true).describe())
+                .contains("/home/u").contains(HostMount.MOUNT_POINT).contains("read-only");
+        assertThat(new HostMount(Path.of("/home/u"), false).describe()).contains("writable");
+    }
+}

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/default-chat.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/default-chat.json
@@ -220,8 +220,10 @@
       "id": "00000003-0000-0000-0000-000000000070",
       "agentDefinitionId": "00000002-0000-0000-0000-000000000012",
       "name": "code_execute",
-      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. Use it for calculations, data wrangling and quick scripts instead of doing the arithmetic yourself.",
-      "overrides": {},
+      "description": "Runs a program in an isolated container and returns exit code, stdout and stderr. The user's home directory is mounted read-only at /mnt/host, so this is also how you read their files. Use it for calculations, data wrangling and quick scripts.",
+      "overrides": {
+        "mountDir": "~"
+      },
       "enabled": true,
       "deferred": false,
       "needsApproval": true,

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
@@ -33,11 +33,23 @@ public final class ChatSettingsComponent implements UiComponent {
     private final List<String> currentTools;
     private final boolean toolSearchOn;
     private final UUID currentAgentId;
+    /** What this chat runs on today — the agent's prompt, or its own override. */
+    private final String currentSystemPrompt;
 
     public ChatSettingsComponent(UUID sessionId, List<LlmConfig> llmConfigs,
                                  List<AgentDefinition> agents, List<String> toolNames,
                                  String currentLlmConfigName, List<String> currentTools,
                                  boolean toolSearchOn, UUID currentAgentId) {
+        this(sessionId, llmConfigs, agents, toolNames, currentLlmConfigName, currentTools,
+                toolSearchOn, currentAgentId, null);
+    }
+
+    public ChatSettingsComponent(UUID sessionId, List<LlmConfig> llmConfigs,
+                                 List<AgentDefinition> agents, List<String> toolNames,
+                                 String currentLlmConfigName, List<String> currentTools,
+                                 boolean toolSearchOn, UUID currentAgentId,
+                                 String currentSystemPrompt) {
+        this.currentSystemPrompt = currentSystemPrompt;
         this.sessionId = sessionId;
         this.llmConfigs = llmConfigs;
         this.agents = agents;
@@ -83,6 +95,14 @@ public final class ChatSettingsComponent implements UiComponent {
                         currentAgentId == null ? "" : currentAgentId.toString(), agentOptions)
                         .asEditable()
                         .hint("Takes over prompt, model and tools — the fields above stop applying"))
+                // Last, because it is the longest field and the one you scroll
+                // past when you came for the model. Pre-filled with what the
+                // chat runs on today: the agent's prompt until it is edited.
+                .field(UiField.textarea("systemPrompt", "System prompt", currentSystemPrompt)
+                        .asEditable()
+                        .hint("Starts as the agent's own. Edit it and this chat alone uses "
+                                + "yours — the agent, its tools and the agents it may call "
+                                + "stay as they are"))
                 .action(UiAction.primary("apply", "Apply").icon("save")
                         .dispatch("POST", "/chat/api/sessions/" + sessionId + "/settings"))
                 .action(UiAction.secondary("cancel", "Cancel")

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatSettingsComponent.java
@@ -6,6 +6,8 @@ import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.ui.model.UiField;
 import ai.mindconnect.ui.model.UiForm;
+import ai.mindconnect.ui.model.UiFieldGroup;
+import ai.mindconnect.ui.model.UiSection;
 
 import java.util.List;
 import java.util.UUID;
@@ -80,7 +82,15 @@ public final class ChatSettingsComponent implements UiComponent {
                 .map(n -> UiField.Option.of(n, n))
                 .toList();
 
-        return UiForm.of(id(), "Model & tools")
+        // One tab per half. The fields live in field groups inside the tabs,
+        // and the tabs inside the FORM — not the form inside the tabs. The
+        // submitted payload is the id of the <form> the button sits in
+        // (EventBus.inferImplicitPayload), so a second form would submit only
+        // its own half: pressing Apply on the agent tab would send agentId and
+        // nothing else, and the model, the tools and the prompt would arrive
+        // as absent. A hidden tab is hidden, not removed, so its inputs are
+        // still part of the one form.
+        var modelTab = UiFieldGroup.of(id() + "-g-model", null)
                 .field(UiField.select("llmConfigName", "Model", currentLlmConfigName, modelOptions)
                         .asEditable()
                         .hint("Provider, key and context window come with the config"))
@@ -91,18 +101,25 @@ public final class ChatSettingsComponent implements UiComponent {
                         .asEditable()
                         .hint("Lets the chat find the remaining tools itself instead of carrying "
                                 + "every definition in its context"))
-                .field(UiField.select("agentId", "…or an agent",
-                        currentAgentId == null ? "" : currentAgentId.toString(), agentOptions)
-                        .asEditable()
-                        .hint("Takes over prompt, model and tools — the fields above stop applying"))
-                // Last, because it is the longest field and the one you scroll
-                // past when you came for the model. Pre-filled with what the
-                // chat runs on today: the agent's prompt until it is edited.
                 .field(UiField.textarea("systemPrompt", "System prompt", currentSystemPrompt)
                         .asEditable()
                         .hint("Starts as the agent's own. Edit it and this chat alone uses "
                                 + "yours — the agent, its tools and the agents it may call "
-                                + "stay as they are"))
+                                + "stay as they are"));
+
+        var agentTab = UiFieldGroup.of(id() + "-g-agent", null)
+                .field(UiField.select("agentId", "…or an agent",
+                                currentAgentId == null ? "" : currentAgentId.toString(), agentOptions)
+                        .asEditable()
+                        .hint("Takes over prompt, model and tools — the fields on the other tab "
+                                + "stop applying"));
+
+        var tabs = UiSection.of(id() + "-tabs", null)
+                .section(id() + "-tab-model", "Model & tools", modelTab)
+                .section(id() + "-tab-agent", "Agent", agentTab);
+
+        return UiForm.of(id(), "Chat settings")
+                .content(tabs)
                 .action(UiAction.primary("apply", "Apply").icon("save")
                         .dispatch("POST", "/chat/api/sessions/" + sessionId + "/settings"))
                 .action(UiAction.secondary("cancel", "Cancel")

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
@@ -84,6 +84,8 @@ public final class MessageListComponent implements UiComponent {
     private UUID parentSessionId;
     /** This conversation's title, when it has one — the header's subject. */
     private String sessionTitle;
+    /** Whether this chat replaced its agent's system prompt with its own. */
+    private boolean customPrompt;
     /** Bubbled sub-agent approval cards (from the ToolApprovalStore), rendered after the history. */
     private List<UiList.Item> bubbledApprovalCards = List.of();
     /** The host's overflow menu (parent session, back to agent, memory/trace
@@ -117,6 +119,18 @@ public final class MessageListComponent implements UiComponent {
      */
     public MessageListComponent withSessionTitle(String sessionTitle) {
         this.sessionTitle = sessionTitle;
+        return this;
+    }
+
+    /**
+     * Marks that this chat runs on its own system prompt rather than the
+     * agent's. The badge says so: the header still names the agent, because
+     * its tools and the agents it may call are still the agent's — but the
+     * name would be misleading on its own. Returns {@code this} for fluent
+     * chaining.
+     */
+    public MessageListComponent withCustomPrompt(boolean customPrompt) {
+        this.customPrompt = customPrompt;
         return this;
     }
 
@@ -194,8 +208,16 @@ public final class MessageListComponent implements UiComponent {
         var tools = ai.mindconnect.ui.model.UiStack.of(id() + "-tools")
                 .direction(ai.mindconnect.ui.model.UiStack.Direction.HORIZONTAL)
                 .<ai.mindconnect.ui.model.UiStack>withCssClass("chat-header-tools");
-        if (titled) {
-            tools.child(ai.mindconnect.ui.model.UiText.of(id() + "-agent", agentName)
+        // Titled: the badge names the agent, because the header names the
+        // conversation. Untitled: the header already names the agent, so the
+        // badge is only worth drawing when there is something else to say —
+        // and an overridden prompt is exactly that, on the chat where the
+        // header would otherwise claim the agent's own.
+        String badge = titled
+                ? (customPrompt ? agentName + " · own prompt" : agentName)
+                : (customPrompt ? "own prompt" : null);
+        if (badge != null) {
+            tools.child(ai.mindconnect.ui.model.UiText.of(id() + "-agent", badge)
                     .<ai.mindconnect.ui.model.UiText>withCssClass("chat-agent-badge"));
         }
         tools.child(new TokenUsageComponent(id(), memory).render());

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -151,16 +151,13 @@ public class ChatUiController {
         if (sessionOpt.isEmpty()) return ResponseEntity.notFound().build();
         var session = sessionOpt.get();
         var effective = agentResolver.resolve(session);
-        UUID agentId = session.mainAgent()
-                .filter(a -> a instanceof ai.mindconnect.agent.domain.session.SessionAgentRef)
-                .map(ai.mindconnect.agent.domain.session.SessionAgent::id)
-                .orElse(null);
+        UUID agentId = boundAgentId(session);
 
         var form = new ai.mindconnect.chatui.ui.component.ChatSettingsComponent(
                 sessionId, llmConfigRepository.findAll(), selectableAgents(agentId), allToolNames(),
                 effective.llmConfigName(),
                 effective.tools().stream().map(ai.mindconnect.agent.tool.AgentTool::name).toList(),
-                effective.toolSearchOrOff().enabled(), agentId).render();
+                effective.toolSearchOrOff().enabled(), agentId, effective.systemPrompt()).render();
 
         var dlg = ai.mindconnect.ui.model.UiDialog.of("Model & tools", null, form);
         dlg.setId("chat-dialog");
@@ -183,15 +180,23 @@ public class ChatUiController {
         if (agentId != null && !agentId.isBlank()) {
             var def = agentRepository.findById(UUID.fromString(agentId))
                     .orElseThrow(() -> new IllegalArgumentException("No such agent: " + agentId));
+            // Only a prompt that actually differs is stored: an untouched
+            // field must not turn into an override that then stops tracking
+            // edits to the agent itself.
+            String prompt = body.str("systemPrompt");
+            String override = prompt == null || prompt.isBlank()
+                    || prompt.strip().equals(String.valueOf(def.systemPrompt()).strip())
+                    ? null : prompt;
             agent = new ai.mindconnect.agent.domain.session.SessionAgentRef(
-                    def.id(), true, def.name(), null, null, null);
+                    def.id(), true, def.name(), null, null, null, override);
         } else {
             // Staying inline keeps the same agent — and therefore the same
             // workspace — while only the model and tools change. Coming from a
             // ref agent it is a new one, and the switch says so.
             var previous = sessionOpt.get().mainAgent().orElse(null);
+            String prompt = body.str("systemPrompt");
             var fresh = inlineAgent(body.str("llmConfigName"),
-                    body.strList("tools"), body.bool("toolSearch", true));
+                    body.strList("tools"), body.bool("toolSearch", true), prompt);
             agent = previous instanceof ai.mindconnect.agent.domain.session.InlineSessionAgent kept
                     ? kept.withLlmConfigName(fresh.llmConfigName())
                           .withTools(fresh.tools().stream()
@@ -336,12 +341,18 @@ public class ChatUiController {
     /** The session's own agent, built from a model name and tool names. */
     private ai.mindconnect.agent.domain.session.InlineSessionAgent inlineAgent(
             String llmConfigName, List<String> tools, boolean toolSearch) {
+        return inlineAgent(llmConfigName, tools, toolSearch, null);
+    }
+
+    /** @param systemPrompt {@code null} or blank falls back to the built-in one. */
+    private ai.mindconnect.agent.domain.session.InlineSessionAgent inlineAgent(
+            String llmConfigName, List<String> tools, boolean toolSearch, String systemPrompt) {
         List<String> names = tools == null || tools.isEmpty()
                 ? ai.mindconnect.chatui.ui.component.ChatSettingsComponent.DEFAULT_TOOLS
                 : tools;
         var known = allToolNames();
         return ai.mindconnect.agent.domain.session.InlineSessionAgent.of(
-                "Chat", CHAT_SYSTEM_PROMPT,
+                "Chat", systemPrompt == null || systemPrompt.isBlank() ? CHAT_SYSTEM_PROMPT : systemPrompt,
                 llmConfigName == null ? defaultLlmConfigName() : llmConfigName,
                 names.stream().filter(known::contains).toList(),
                 toolSearch);
@@ -371,6 +382,34 @@ public class ChatUiController {
      * assistant, so opening the dialog on such a chat and pressing Apply does
      * not silently reassign it.
      */
+    /**
+     * The registry agent this chat runs on, or {@code null} for a chat with an
+     * agent of its own.
+     *
+     * <p>Two shapes mean the same thing. Picking an agent in the settings
+     * dialog writes a {@link ai.mindconnect.agent.domain.session.SessionAgentRef};
+     * opening a chat from an agent — which is now every chat, via
+     * {@code default-chat} — sets only {@code agentDefinitionId} and leaves the
+     * session-agent list empty. Reading just the ref reported "no agent" for
+     * the second kind, and pressing Apply on one detached the chat from the
+     * agent it was plainly running on.
+     *
+     * <p>The id is checked against the registry: an inline agent's id is minted
+     * for the session and would otherwise look like a binding.
+     */
+    private UUID boundAgentId(ai.mindconnect.agent.domain.AgentSession session) {
+        UUID ref = session.mainAgent()
+                .filter(a -> a instanceof ai.mindconnect.agent.domain.session.SessionAgentRef)
+                .map(ai.mindconnect.agent.domain.session.SessionAgent::id)
+                .orElse(null);
+        if (ref != null) {
+            return ref;
+        }
+        UUID fromSession = session.agentDefinitionId();
+        return fromSession != null && agentRepository.findById(fromSession).isPresent()
+                ? fromSession : null;
+    }
+
     /**
      * Icon name per agent-definition id, for the history drawer. Read from the
      * registry in one go: a row only needs the icon, and resolving every

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -180,15 +180,41 @@ public class ChatUiController {
         if (agentId != null && !agentId.isBlank()) {
             var def = agentRepository.findById(UUID.fromString(agentId))
                     .orElseThrow(() -> new IllegalArgumentException("No such agent: " + agentId));
-            // Only a prompt that actually differs is stored: an untouched
-            // field must not turn into an override that then stops tracking
-            // edits to the agent itself.
-            String prompt = body.str("systemPrompt");
-            String override = prompt == null || prompt.isBlank()
-                    || prompt.strip().equals(String.valueOf(def.systemPrompt()).strip())
-                    ? null : prompt;
+            // Switching to another agent hands the chat over completely: that
+            // agent's model, tools and prompt win, which is what the picker
+            // promises. Staying on the same one keeps what this chat chose —
+            // the ref carries exactly these three overrides for that.
+            boolean sameAgent = def.id().equals(boundAgentId(sessionOpt.get()));
+
+            // Only a value that actually differs is stored: an untouched field
+            // must not turn into an override that then stops tracking edits to
+            // the agent itself.
+            String prompt = sameAgent ? differing(body.str("systemPrompt"), def.systemPrompt()) : null;
+            String llm = sameAgent ? differing(body.str("llmConfigName"), def.llmConfigName()) : null;
+
+            List<ai.mindconnect.agent.tool.AgentTool> toolOverride = null;
+            ai.mindconnect.agent.domain.AgentDefinition.ToolSearchConfig searchOverride = null;
+            if (sameAgent) {
+                // Compared against what the dialog could actually offer, not
+                // against everything the agent has: a tool the registry does
+                // not know — Gmail without credentials — never reaches the
+                // multiselect, so it can neither be kept nor removed there.
+                List<String> chosen = body.strList("tools");
+                var offerable = def.tools().stream()
+                        .map(ai.mindconnect.agent.tool.AgentTool::name)
+                        .filter(allToolNames()::contains)
+                        .collect(java.util.stream.Collectors.toSet());
+                if (chosen != null && !new java.util.HashSet<>(chosen).equals(offerable)) {
+                    toolOverride = pickTools(def, chosen);
+                }
+                boolean search = body.bool("toolSearch", def.toolSearchOrOff().enabled());
+                if (search != def.toolSearchOrOff().enabled()) {
+                    searchOverride = new ai.mindconnect.agent.domain.AgentDefinition.ToolSearchConfig(
+                            search, def.toolSearchOrOff().groups());
+                }
+            }
             agent = new ai.mindconnect.agent.domain.session.SessionAgentRef(
-                    def.id(), true, def.name(), null, null, null, override);
+                    def.id(), true, def.name(), llm, toolOverride, searchOverride, prompt);
         } else {
             // Staying inline keeps the same agent — and therefore the same
             // workspace — while only the model and tools change. Coming from a
@@ -382,6 +408,50 @@ public class ChatUiController {
      * assistant, so opening the dialog on such a chat and pressing Apply does
      * not silently reassign it.
      */
+
+    /** The submitted value when it says something other than the agent's own. */
+    private static String differing(String submitted, String agentsOwn) {
+        if (submitted == null || submitted.isBlank()) {
+            return null;
+        }
+        return submitted.strip().equals(String.valueOf(agentsOwn).strip()) ? null : submitted;
+    }
+
+    /**
+     * The chat's tool selection as {@link ai.mindconnect.agent.tool.AgentTool}s,
+     * reusing the agent's own binding for every name it already has.
+     *
+     * <p>Rebuilding them from bare names would quietly drop what the binding
+     * carries beyond the name — {@code needsApproval} on bash and
+     * {@code code_execute}, the {@code mountDir} that gives the sandbox its
+     * host directory, a deferred flag. Turning the model dropdown would have
+     * been enough to lose all of it.
+     */
+    private List<ai.mindconnect.agent.tool.AgentTool> pickTools(
+            ai.mindconnect.agent.domain.AgentDefinition def, List<String> names) {
+        var byName = def.tools().stream().collect(java.util.stream.Collectors.toMap(
+                ai.mindconnect.agent.tool.AgentTool::name, t -> t, (a, b) -> a));
+        var known = allToolNames();
+        var picked = new java.util.LinkedHashMap<String, ai.mindconnect.agent.tool.AgentTool>();
+        // Whatever the dialog could not show stays: the chat did not drop it,
+        // it was never asked about. Without this, opening the settings and
+        // pressing Apply would silently strip an agent's Gmail tools on a
+        // machine where Gmail is not configured.
+        for (var t : def.tools()) {
+            if (!known.contains(t.name())) {
+                picked.put(t.name(), t);
+            }
+        }
+        for (String n : names) {
+            if (!known.contains(n)) {
+                continue;
+            }
+            picked.put(n, byName.containsKey(n)
+                    ? byName.get(n)
+                    : ai.mindconnect.agent.tool.AgentTool.of(def.id(), n));
+        }
+        return List.copyOf(picked.values());
+    }
     /**
      * The registry agent this chat runs on, or {@code null} for a chat with an
      * agent of its own.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/page/ChatPage.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/page/ChatPage.java
@@ -85,6 +85,11 @@ public final class ChatPage {
         this.agent = agent;
         this.messages = new MessageListComponent(session.id(), agent, history, memory, subAgentTree)
                 .withSessionTitle(session.title())
+                .withCustomPrompt(session.mainAgent()
+                        .filter(a -> a instanceof ai.mindconnect.agent.domain.session.SessionAgentRef)
+                        .map(a -> ((ai.mindconnect.agent.domain.session.SessionAgentRef) a)
+                                .hasPromptOverride())
+                        .orElse(false))
                 .withParentSession(session.parentSessionId());
         this.chatForm = new ChatFormComponent(session.id(), agent.id(), streaming)
                 .withModelLabel(agent.llmConfigName());


### PR DESCRIPTION
Carries the tail of the #20 → #21 → #22 stack onto `main`. #21 and #22 were
merged into their stack base rather than retargeted after #20 landed, so their
commits never reached `main`. Nothing here is new work — it is the same code
that was already reviewed and approved on those two PRs.

## What lands

**`code_execute` can be given a host directory to see** (#21). A `mountDir` on
the tool's agent binding — or the runtime-wide `codeExecMountDir` — mounts one
directory at `/mnt/host`, read-only unless `mountWritable` says otherwise. The
path comes from the operator, never from a tool argument. The seeded
`default-chat` mounts the user's home. The mount is part of the container's
identity, so two bindings that disagree about it do not share one.

**A chat can run on a system prompt of its own** (#22). The settings dialog
gains the field, pre-filled with what the chat runs on today. Editing it changes
that one conversation; the agent and its tools stay as they are, and the header
marks the chat as running its own prompt.

**Two settings-dialog fixes** (#22). Applying the dialog dropped the model you
had just picked, and stripped every tool the registry could not offer — on a
machine without Gmail credentials, pressing Apply cost the chat its three Gmail
tools. The dialog now writes back only what actually differs from the agent's
settings, and leaves tools it never asked about alone. Separately, a chat opened
from an agent page carries only its `agentDefinitionId`; the dialog read the
session-agent list, found it empty, and reported "no agent", so Apply detached
the chat from the agent it was plainly running on.

## Review

`git diff main...feature/code-exec-host-mount` is the honest diff: 16 files,
~540 lines. The commits are `a5d0ca1`, `e4336e2`, `46132c6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)