### PR TITLE
Everyone watching a chat sees it live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,16 @@ fresh empty one, so nothing has to be moved by hand at release time.
   carrying page content the old output only pointed at. Set
   `include_content: false` for the old URL-list behaviour.
 
+- **The "still running" indicator names the chat you left.** It used to say
+  "Open chat", because semantic-ui drew it and had one guess for every
+  application — a layer that moves bytes cannot know it is carrying a chat
+  rather than a report or an import. 0.3.0 stopped drawing it and publishes
+  stream state instead; the admin UI now renders it, so it says what the
+  session is actually called (its title, or the agent's name while the chat is
+  untitled) and offers "Watch" while the agent works, "Read it" once the answer
+  is there. It also no longer appears for a chat where nothing is running,
+  which the old one did as soon as a stream was merely connected.
+
 - **A chat can run on a system prompt of its own.** The settings dialog gains
   the field, pre-filled with what the chat runs on today — its agent's prompt
   until you edit it. Editing it changes this one conversation; the agent, its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **Everyone watching a chat sees it live.** A chat's stream now belongs to the
+  session rather than to one turn, so a second browser tab — or a colleague on
+  the same session — receives the same tokens, tool cards and approval prompts
+  as the person who typed, at the same moment. Clients attach when they open
+  the session and stay attached across turns, which is what lets them see a
+  turn somebody else starts; previously a client could only ever join a turn it
+  had started itself. Only the running turn is streamed: joining a quiet
+  session replays nothing and reads the persisted history, as before.
 - **An agent can make an optional tool parameter mandatory for itself.** A
   `requiredParams` list in a tool binding's `overrides` adds those names to the
   schema the model is offered, and refuses a call that omits one before the

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -659,3 +659,35 @@ body {
     cursor: pointer;
 }
 .group-picker-toggle:hover { border-color: var(--sui-color-border-strong); }
+
+/* ── Floating "still running" indicator ──────────────────────────────────────
+   Ours, not the framework's: what a live stream should look like — and what to
+   call it — is an application decision. Mounted on body rather than in the
+   toast container so it survives navigation independently of the regular
+   toast queue. Rendered by renderStreamStatus() in app.js. */
+.stream-status {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    z-index: 1500;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: var(--sui-color-surface, #fff);
+    border: 1px solid var(--sui-color-border, #d4d4d8);
+    border-left-width: 4px;
+    border-left-color: var(--sui-color-primary, #3b82f6);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    font-size: 14px;
+}
+.stream-status .sui-toast-link {
+    background: none;
+    border: none;
+    color: var(--sui-color-primary, #3b82f6);
+    cursor: pointer;
+    font-weight: 600;
+    padding: 0;
+}
+.stream-status .sui-toast-link:hover { text-decoration: underline; }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -53,7 +53,59 @@ const bus = new SuiEventBus(renderer, main);
 bus.setFetcher(bffFetch)
    .setOnUnauthenticated(handle401)
    // App-defined SSE event: chat errors come over the same stream as patches.
-   .onStreamEvent("error", (msg) => showStreamError(msg));
+   .onStreamEvent("error", (msg) => showStreamError(msg))
+   // The framework publishes stream state; what it looks like is ours.
+   .onStreamStateChange(renderStreamStatus);
+
+// ── Floating "still running" indicator ──────────────────────────────────────
+
+/**
+ * Shows what is running somewhere the user cannot see. Only streams whose
+ * page is NOT mounted qualify: while you are looking at the chat, the chat
+ * itself is the status display.
+ *
+ * The wording lives here rather than in the framework, which moves bytes and
+ * has no idea whether a stream carries a chat, a report or an import. The
+ * destination names itself through `returnLabel` (the chat page sends its
+ * session title); `returnHref` is where the button goes.
+ */
+function renderStreamStatus(streams) {
+    const away = streams.filter(s => !s.pageAttached);
+    const running = away.filter(s => s.state === "running");
+    const finished = away.filter(s => s.state === "completed" || s.state === "errored");
+
+    const existing = document.getElementById("stream-status-toast");
+    if (running.length === 0 && finished.length === 0) {
+        if (existing) existing.remove();
+        return;
+    }
+
+    // Prefer what still needs waiting for; an answer already sitting there
+    // can wait a moment longer.
+    const isRunning = running.length > 0;
+    const focus = isRunning ? running[0] : finished[0];
+    const what = focus.returnLabel || focus.label || "Agent";
+
+    const toast = existing || document.createElement("div");
+    if (!existing) {
+        toast.id = "stream-status-toast";
+        toast.className = "sui-toast sui-toast--info stream-status";
+        toast.setAttribute("role", "status");
+        document.body.appendChild(toast);
+    }
+    toast.replaceChildren();
+
+    const text = document.createElement("span");
+    text.textContent = isRunning ? `${what} is working…` : `${what}: answer ready`;
+    toast.appendChild(text);
+
+    const link = document.createElement("button");
+    link.type = "button";
+    link.className = "sui-toast-link";
+    link.textContent = isRunning ? "Watch" : "Read it";
+    link.addEventListener("click", () => { void bus.navigate(focus.returnHref); });
+    toast.appendChild(link);
+}
 
 // ── Transient error banner used by the streaming chat ───────────────────────
 

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/SessionStreams.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/SessionStreams.java
@@ -1,0 +1,158 @@
+package ai.mindconnect.chatui.service;
+
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * One live {@link StreamBus} per chat session, outliving the turns that
+ * publish into it. This is what lets a second client see tokens at all: a
+ * bus that is created when a turn starts can only ever reach clients that
+ * were already listening, and a client with nothing to listen to has no way
+ * to find out that a turn began.
+ *
+ * <p>Clients therefore attach when they open the session — before anything
+ * runs — and stay attached. A turn resolves the session's bus, publishes its
+ * patches, and ends; the subscribers remain.
+ *
+ * <p><b>Only the current turn is replayed.</b> {@link #turnStarted} clears
+ * the bus's ring buffer, so a client joining a quiet session replays nothing
+ * and simply reads the persisted history — which is the truth. Carrying a
+ * finished turn's patches across the boundary would be actively wrong:
+ * they are APPEND operations against a page that already contains what they
+ * would append, so the messages would show up twice.
+ *
+ * <p>The heartbeat is also the liveness check. An idle SSE connection is cut
+ * by proxies after 30-60s, so every {@link #HEARTBEAT} each bus sends an SSE
+ * comment; a write that fails drops that subscriber. A bus with no
+ * subscribers left and no turn running is discarded — the next attach
+ * creates a fresh one.
+ */
+@Component
+public class SessionStreams {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionStreams.class);
+
+    /** Comfortably inside the 30-60s idle timeout of a typical proxy. */
+    static final Duration HEARTBEAT = Duration.ofSeconds(25);
+
+    private final Map<String, StreamBus> buses = new ConcurrentHashMap<>();
+
+    /**
+     * Channels with a turn currently publishing. A bus must not be evicted
+     * while a turn holds a reference to it — the producer captured the
+     * object, so dropping it from the map would send later joiners to a
+     * different bus and they would see nothing.
+     */
+    private final Set<String> busy = ConcurrentHashMap.newKeySet();
+
+    private final ScheduledExecutorService pulse = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "chat-stream-heartbeat");
+        t.setDaemon(true);
+        return t;
+    });
+
+    public SessionStreams() {
+        pulse.scheduleWithFixedDelay(this::beat,
+                HEARTBEAT.toSeconds(), HEARTBEAT.toSeconds(), TimeUnit.SECONDS);
+    }
+
+    /** The session's bus, created on first use. */
+    public StreamBus bus(String channelId) {
+        return buses.computeIfAbsent(channelId, key -> {
+            log.debug("Opening session stream {}", key);
+            return new StreamBus();
+        });
+    }
+
+    /** The session's bus if one exists — no side effect. */
+    public Optional<StreamBus> find(String channelId) {
+        return Optional.ofNullable(buses.get(channelId));
+    }
+
+    /**
+     * A turn begins publishing: pin the bus against eviction and drop the
+     * previous turn's patches, so anyone joining from here on replays this
+     * turn and nothing older.
+     */
+    public StreamBus turnStarted(String channelId) {
+        busy.add(channelId);
+        catchUps.remove(channelId);
+        StreamBus bus = bus(channelId);
+        bus.resetBuffer();
+        return bus;
+    }
+
+    /** The turn is over. The bus stays; its subscribers keep listening. */
+    public void turnEnded(String channelId) {
+        busy.remove(channelId);
+        catchUps.remove(channelId);
+    }
+
+    /**
+     * The two patches that put a late joiner's DOM into the running turn's
+     * current state: the one that CREATES the streaming reply bubble, and
+     * the last one that filled it. Token patches carry the cumulative text
+     * and REPLACE the bubble, so those two are the whole state — but the
+     * replace lands nowhere if the joiner never saw the append that made
+     * the bubble.
+     *
+     * <p>Rendered JSON rather than raw text on purpose: the producer has
+     * the renderer, this layer must not grow one.
+     */
+    public record CatchUp(String bubblePatch, String textPatch) { }
+
+    private final Map<String, CatchUp> catchUps = new ConcurrentHashMap<>();
+
+    /** The first token's patch — the one that appends the reply bubble. */
+    public void rememberBubble(String channelId, String patchJson) {
+        catchUps.put(channelId, new CatchUp(patchJson, null));
+    }
+
+    /** The newest token patch; replaces the previous one. */
+    public void rememberText(String channelId, String patchJson) {
+        catchUps.computeIfPresent(channelId, (k, c) -> new CatchUp(c.bubblePatch(), patchJson));
+    }
+
+    /** What a client joining right now needs before the live feed. */
+    public Optional<CatchUp> catchUp(String channelId) {
+        return Optional.ofNullable(catchUps.get(channelId));
+    }
+
+    /**
+     * Heartbeat every attached client, then discard whatever is left with no
+     * listeners and no turn. Never lets one broken bus stop the sweep.
+     */
+    private void beat() {
+        for (var entry : buses.entrySet()) {
+            String channelId = entry.getKey();
+            StreamBus bus = entry.getValue();
+            try {
+                bus.ping();
+            } catch (RuntimeException e) {
+                log.warn("Heartbeat failed for {}: {}", channelId, e.toString());
+            }
+            if (bus.subscriberCount() == 0 && !busy.contains(channelId)) {
+                buses.remove(channelId, bus);
+                log.debug("Closed idle session stream {}", channelId);
+            }
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        pulse.shutdownNow();
+        buses.values().forEach(StreamBus::closeAll);
+        buses.clear();
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/StreamBus.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/StreamBus.java
@@ -86,6 +86,19 @@ public final class StreamBus {
      * stream's own producer thread doesn't need replay).
      */
     public synchronized void attach(SseEmitter emitter, long lastSeq) {
+        attach(emitter, lastSeq, List.of());
+    }
+
+    /**
+     * Attach with a PRELUDE sent ahead of the replay — the frames that bring
+     * a client joining mid-turn up to the current state. Sent inside the
+     * lock, so a token published concurrently cannot slip in front of the
+     * prelude and land on a DOM node the prelude has yet to create.
+     */
+    public synchronized void attach(SseEmitter emitter, long lastSeq, List<Event> prelude) {
+        for (Event e : prelude) {
+            if (!sendTo(emitter, e)) return;
+        }
         for (Event e : buffer) {
             if (e.seq() > lastSeq) {
                 if (!sendTo(emitter, e)) return; // emitter already broken
@@ -97,6 +110,44 @@ public final class StreamBus {
     /** Drops an emitter from the subscriber list. No-op if not present. */
     public void detach(SseEmitter emitter) {
         subscribers.remove(emitter);
+    }
+
+    /** How many clients are currently attached. */
+    public int subscriberCount() {
+        return subscribers.size();
+    }
+
+    /**
+     * Forgets the buffered past without touching the sequence or the
+     * subscribers. Called when a turn starts: a client that attaches later
+     * replays THIS turn and nothing before it. The patches are APPEND
+     * operations, so replaying a finished turn into a page that already
+     * renders it from persisted history would duplicate every message.
+     */
+    public synchronized void resetBuffer() {
+        buffer.clear();
+    }
+
+    /**
+     * Sends an SSE comment to every subscriber and drops those that fail.
+     * Two jobs in one: it keeps a connection alive that would otherwise be
+     * cut as idle by a proxy, and a failed write is how a client that went
+     * away is noticed — there is no other signal.
+     *
+     * <p>A comment carries no event name and no data, so it costs the client
+     * nothing; its SSE reader parses the block and finds nothing to
+     * dispatch.
+     */
+    public synchronized void ping() {
+        Iterator<SseEmitter> it = subscribers.iterator();
+        while (it.hasNext()) {
+            SseEmitter sub = it.next();
+            try {
+                sub.send(SseEmitter.event().comment("hb"));
+            } catch (Exception e) {
+                subscribers.remove(sub);
+            }
+        }
     }
 
     /** Last published seq, for clients that need to track "where am I". */

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatFormComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatFormComponent.java
@@ -150,7 +150,11 @@ public final class ChatFormComponent implements UiComponent {
                         .<UiAction>withCssClass("chat-model-btn"))
                 .action(UiAction.icon("send", "Send").icon("send")
                         .style(UiAction.Style.PRIMARY)
-                        .onClick(streaming(on(ChatUiController.class).chatStream(sessionId, null), id())));
+                        // A plain dispatch, not a stream: the turn's output
+                        // comes back on the session stream this client already
+                        // reads, the same one every other client of the session
+                        // reads.
+                        .onClick(trigger(on(ChatUiController.class).chatStream(sessionId, null), id())));
         return form.<UiForm>withCssClass("chat-form");
     }
 

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
@@ -64,7 +64,9 @@ public final class MessageComponent {
         if (isUser) {
             item.action(UiAction.icon("regen-" + m.id(), "🔄")
                     .confirm("Delete the response(s) after this message and generate a new one?")
-                    .onClick(streaming(on(ChatUiController.class).regenerate(sessionId, seq), null)));
+                    // Plain dispatch — the regenerated turn streams on the
+                    // session's stream like any other.
+                    .onClick(trigger(on(ChatUiController.class).regenerate(sessionId, seq))));
         }
 
         // Delete-from-here: remove this message and every message after it.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -55,6 +55,7 @@ public class ChatUiController {
     /** Optional — null in setups where trace persistence is disabled. */
     private final ai.mindconnect.agent.port.out.LlmCallTraceRepository traceRepository;
     private final ai.mindconnect.chatui.service.ActiveStreams activeStreams;
+    private final ai.mindconnect.chatui.service.SessionStreams sessionStreams;
 
     private final ai.mindconnect.agentrest.service.SessionFileService sessionFiles;
     private final ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore;
@@ -75,6 +76,7 @@ public class ChatUiController {
                              ObjectMapper objectMapper,
                              ai.mindconnect.agent.port.out.LlmCallTraceRepository traceRepository,
                              ai.mindconnect.chatui.service.ActiveStreams activeStreams,
+                             ai.mindconnect.chatui.service.SessionStreams sessionStreams,
                              ai.mindconnect.agentrest.service.SessionFileService sessionFiles,
                              ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore,
                              org.springframework.beans.factory.ObjectProvider<ai.mindconnect.chatui.ui.ChatHostLinks> hostLinks,
@@ -90,6 +92,7 @@ public class ChatUiController {
         this.objectMapper = objectMapper;
         this.traceRepository = traceRepository;
         this.activeStreams = activeStreams;
+        this.sessionStreams = sessionStreams;
         this.approvalStore = approvalStore;
         this.hostLinks = hostLinks.getIfAvailable(() -> ai.mindconnect.chatui.ui.ChatHostLinks.NONE);
         this.defaultNamespace = defaultNamespace;
@@ -598,15 +601,34 @@ public class ChatUiController {
                         buildSubAgentCards(session.id(), toolCallId, running, in, out))
                 .withBubbledApprovals(bubbledApprovalCards(session.id()))
                 .withHostLinks(hostLinks);
-        // Hand the SPA the resume URL for this session's stream (when
-        // any). The bus re-attaches via GET on every applyPage so F5,
-        // tab close/reopen, and second-tab observers all converge.
-        handleOpt.ifPresent(h -> page.withActiveStreams(java.util.List.of(
+        // Every render hands the SPA this session's stream — whether or not
+        // a turn is running. That is the whole point: a client with nothing
+        // to listen to cannot find out that someone else started a turn, so
+        // it attaches while the session is quiet and stays attached.
+        //
+        // The cursor matters. This page already renders everything the
+        // stream has published so far, and the patches are APPENDs, so a
+        // replay from 0 would add the user message and the task cards a
+        // second time. Asking for what comes AFTER the current position is
+        // the only correct request; a client joining mid-turn is brought up
+        // to date by the catch-up frames instead (see StreamController).
+        long from = sessionStreams.find(channelId)
+                .map(ai.mindconnect.chatui.service.StreamBus::lastSeq).orElse(0L);
+        String agentLabel = agent.name() != null ? agent.name() : "Agent";
+        // What to call this page on a surface that links back to it. The
+        // framework must not guess: it has no idea it is streaming a chat.
+        // The session's own title first, the agent's name while the chat is
+        // still untitled.
+        String returnLabel = session.title() != null && !session.title().isBlank()
+                ? session.title() : agentLabel;
+        page.withActiveStreams(java.util.List.of(
                 ai.mindconnect.ui.model.UiPage.ActiveStream.of(
-                        h.channelId(),
-                        "/chat/api/streams/" + h.channelId() + "/sse",
-                        h.label(),
-                        h.returnHref()))));
+                        channelId,
+                        "/chat/api/streams/" + channelId + "/sse?from=" + from,
+                        handleOpt.map(ai.mindconnect.chatui.service.ActiveStreams.Handle::label)
+                                .orElse(agentLabel),
+                        "/chat/sessions/" + session.id(),
+                        returnLabel)));
         return page;
     }
 
@@ -789,28 +811,22 @@ public class ChatUiController {
                 buildChatPage(sessionOpt.get(), agentOpt.get()).headerOnly());
     }
 
-    @PostMapping(value = "/sessions/{sessionId}/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> chatStream(@PathVariable UUID sessionId,
+    @PostMapping("/sessions/{sessionId}/chat/stream")
+    public ResponseEntity<ai.mindconnect.ui.model.UiPatch> chatStream(@PathVariable UUID sessionId,
                                                  @RequestBody Map<String, Object> raw) {
         var body = new FormBody(raw);
         String text = body.str("message");
         if (text == null || text.isBlank()) {
-            var emitter = new SseEmitter();
-            emitter.completeWithError(new IllegalArgumentException("message required"));
-            return ResponseEntity.ok(emitter);
+            return ResponseEntity.badRequest().build();
         }
 
         var sessionOpt = sessionRepository.findById(sessionId);
         if (sessionOpt.isEmpty()) {
-            var emitter = new SseEmitter();
-            emitter.completeWithError(new IllegalStateException("session not found"));
-            return ResponseEntity.ok(emitter);
+            return ResponseEntity.badRequest().build();
         }
         var agentOpt = java.util.Optional.of(agentResolver.resolve(sessionOpt.get()));
         if (agentOpt.isEmpty()) {
-            var emitter = new SseEmitter();
-            emitter.completeWithError(new IllegalStateException("agent not found"));
-            return ResponseEntity.ok(emitter);
+            return ResponseEntity.badRequest().build();
         }
         return runChatStream(sessionOpt.get(), agentOpt.get(), text, false);
     }
@@ -849,21 +865,16 @@ public class ChatUiController {
      * Sub-agent sessions spawned by the discarded turns are intentionally
      * left in place (not cleaned up).
      */
-    @PostMapping(value = "/sessions/{sessionId}/messages/{seq}/regenerate",
-            produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> regenerate(@PathVariable UUID sessionId,
+    @PostMapping(value = "/sessions/{sessionId}/messages/{seq}/regenerate")
+    public ResponseEntity<ai.mindconnect.ui.model.UiPatch> regenerate(@PathVariable UUID sessionId,
                                                  @PathVariable int seq) {
         var sessionOpt = sessionRepository.findById(sessionId);
         if (sessionOpt.isEmpty()) {
-            var emitter = new SseEmitter();
-            emitter.completeWithError(new IllegalStateException("session not found"));
-            return ResponseEntity.ok(emitter);
+            return ResponseEntity.badRequest().build();
         }
         var agentOpt = java.util.Optional.of(agentResolver.resolve(sessionOpt.get()));
         if (agentOpt.isEmpty()) {
-            var emitter = new SseEmitter();
-            emitter.completeWithError(new IllegalStateException("agent not found"));
-            return ResponseEntity.ok(emitter);
+            return ResponseEntity.badRequest().build();
         }
 
         // Capture the user text at `seq` before we delete it.
@@ -875,10 +886,7 @@ public class ChatUiController {
                 .findFirst()
                 .orElse(null);
         if (text == null || text.isBlank()) {
-            var emitter = new SseEmitter();
-            emitter.completeWithError(new IllegalArgumentException(
-                    "no user message at seq " + seq));
-            return ResponseEntity.ok(emitter);
+            return ResponseEntity.badRequest().build();
         }
 
         // Drop this message and everything after it; the turn below re-adds
@@ -903,7 +911,7 @@ public class ChatUiController {
      *                       before the turn starts — used by regenerate so the
      *                       just-deleted messages leave the DOM immediately.
      */
-    private ResponseEntity<SseEmitter> runChatStream(ai.mindconnect.agent.domain.AgentSession session,
+    private ResponseEntity<ai.mindconnect.ui.model.UiPatch> runChatStream(ai.mindconnect.agent.domain.AgentSession session,
                                                      ai.mindconnect.agent.domain.AgentDefinition agent,
                                                      String text, boolean initialRefresh) {
         return runTurnStream(session, agent, text, initialRefresh,
@@ -915,27 +923,18 @@ public class ChatUiController {
      * message ({@code text} echoed as a user bubble) or an approval answer
      * ({@code text == null} — the card click is the input, nothing to echo).
      */
-    private ResponseEntity<SseEmitter> runTurnStream(ai.mindconnect.agent.domain.AgentSession session,
+    private ResponseEntity<ai.mindconnect.ui.model.UiPatch> runTurnStream(ai.mindconnect.agent.domain.AgentSession session,
                                                      ai.mindconnect.agent.domain.AgentDefinition agent,
                                                      String text, boolean initialRefresh,
                                                      java.util.function.Function<java.util.function.Consumer<StreamEvent>, ChatTurnHandle> turnStarter) {
         UUID sessionId = session.id();
-        var emitter = new SseEmitter(0L); // no timeout — agent can take a while
-        // Custom headers consumed by the client-side StreamRegistry:
-        // {@code Sui-Stream-Channel} keys the live stream so a re-mount of
-        // the chat page can replay buffered patches; {@code Return-Href}
-        // is what the floating running-agent toast navigates to; the label
-        // is what the toast displays.
         // Channel id == the id of the message-list container the patches
-        // target. This way the bus's getElementById fallback in
-        // {@code findStreamTarget} naturally detects "chat page mounted".
+        // target. This way the client's {@code findStreamTarget} lookup
+        // naturally detects "chat page mounted", and both the submitter and
+        // any observer resolve the same stream.
         String channelId = "msg-list-" + sessionId;
         String returnHref = "/chat/sessions/" + sessionId;
         String streamLabel = agent.name() != null ? agent.name() : "Agent";
-        var streamHeaders = new HttpHeaders();
-        streamHeaders.add("Sui-Stream-Channel", channelId);
-        streamHeaders.add("Sui-Stream-Return-Href", returnHref);
-        streamHeaders.add("Sui-Stream-Label", streamLabel);
         String pendingId  = "bot-pending-"  + sessionId;
         String thinkingId = "bot-thinking-" + sessionId;
 
@@ -946,12 +945,13 @@ public class ChatUiController {
         // reflects what's actually been persisted.
         ChatPage liveView = buildChatPage(session, agent);
 
-        // Per-channel multiplex bus + ring buffer. The original POST
-        // emitter attaches as the first subscriber; reconnect GETs from
-        // /chat/api/streams/{channelId}/sse subscribe later with their
-        // own emitters and replay missed events from the buffer.
-        var bus = new ai.mindconnect.chatui.service.StreamBus();
-        bus.attach(emitter, Long.MAX_VALUE);  // skip replay — this is the producer's own emitter
+        // The turn does not stream back to whoever submitted it. It
+        // publishes into the SESSION's stream, which every client of this
+        // session is already attached to — the submitter included. One path
+        // for everyone is what makes a second client see the same tokens at
+        // the same time, and it means this request can return as soon as the
+        // turn is queued.
+        var bus = sessionStreams.turnStarted(channelId);
 
         // Register the stream so the chat-page renderer (and the generic
         // /chat/api/streams endpoint) can see "this session is streaming".
@@ -965,15 +965,6 @@ public class ChatUiController {
                 java.time.Instant.now(),
                 () -> chatService.cancelChat(sessionId),
                 bus));
-        // Detach this emitter from the bus when the client goes away. We
-        // do NOT deregister the channel-level entry here — other
-        // subscribers (reconnect tabs) may still be on it, and the
-        // producer is the source of truth for "is this stream alive".
-        // The whenComplete handler below removes the channel from the
-        // registry once the producer is fully done.
-        emitter.onCompletion(() -> bus.detach(emitter));
-        emitter.onError(t -> bus.detach(emitter));
-        emitter.onTimeout(() -> bus.detach(emitter));
 
         // 0. Regenerate only: replace the message list with the trimmed
         //    (post-delete) history so the discarded messages vanish before the
@@ -1014,10 +1005,17 @@ public class ChatUiController {
                         // First token: drop the thinking indicator and append
                         // the streaming bot-reply placeholder BELOW any task
                         // cards that arrived during the thinking phase.
-                        publishPatch(bus, liveView.streamFirstToken(pendingId, thinkingId));
+                        // Kept as the catch-up frame: a client that opens the
+                        // page mid-turn has no bubble, and every token after
+                        // it is a REPLACE that would land nowhere.
+                        sessionStreams.rememberBubble(channelId,
+                                publishPatch(bus, liveView.streamFirstToken(pendingId, thinkingId)));
                         pendingAppended[0] = true;
                     }
-                    publishPatch(bus, liveView.streamToken(pendingId, cumulativeText.toString()));
+                    // Token patches carry the CUMULATIVE text, so the newest
+                    // one alone restores the full reply so far.
+                    sessionStreams.rememberText(channelId,
+                            publishPatch(bus, liveView.streamToken(pendingId, cumulativeText.toString())));
                 }
                 case StreamEvent.ApprovalRequested ar -> {
                     // Durable already (request message / store entry written
@@ -1080,12 +1078,11 @@ public class ChatUiController {
                 try {
                     bus.publish("error", message);
                 } catch (Exception ignored) {}
-                try { bus.closeAll(); } catch (Exception ignored) {}
-                try { emitter.complete(); } catch (Exception ignored) {}
-                // The producer is done — drop the channel so the next page
-                // render sees Send instead of Stop. Subscribers (incl.
-                // reconnects) already saw the error event via the bus.
+                // The stream stays open — it belongs to the session, not to
+                // this turn. Only the "a turn is running" entry goes, so the
+                // next page render shows Send instead of Stop.
                 activeStreams.deregister(channelId);
+                sessionStreams.turnEnded(channelId);
                 return;
             }
             try {
@@ -1095,25 +1092,24 @@ public class ChatUiController {
                 ChatPage finalView = buildChatPage(session, agent);
                 publishPatch(bus, finalView.streamDone());
 
+                // "done" ends the TURN, not the stream: subscribers stay
+                // attached and are still there when the next turn — possibly
+                // started by another client — begins.
                 bus.publish("done", "");
-                // Close every attached subscriber (incl. reconnect tabs)
-                // and the original POST emitter. emitter.complete() inside
-                // closeAll() is idempotent enough; explicit complete kept
-                // for clarity on the legacy path.
-                bus.closeAll();
-                try { emitter.complete(); } catch (Exception ignored) {}
             } catch (Exception e) {
                 log.error("SSE chat finalize error", e);
-                emitter.completeWithError(e);
             } finally {
-                // Producer fully done — drop the channel so subsequent page
-                // renders show Send instead of Stop. Subscribers see the
-                // final patch + done event via the bus before this fires.
+                // Drop the "a turn is running" entry so subsequent page
+                // renders show Send instead of Stop. Subscribers saw the
+                // final patch and the done event before this fires.
                 activeStreams.deregister(channelId);
+                sessionStreams.turnEnded(channelId);
             }
         });
 
-        return ResponseEntity.ok().headers(streamHeaders).body(emitter);
+        // Nothing to hand back: the turn's output travels on the session
+        // stream this client is already reading.
+        return ResponseEntity.ok(ai.mindconnect.ui.model.UiPatch.of());
     }
 
     /** Per-task state held while a turn is streaming. */
@@ -1338,12 +1334,14 @@ public class ChatUiController {
      * reconnect-GET emitters from {@code /streams/{id}/sse}) sees it; the
      * ring buffer keeps the last N for late joiners.
      */
-    private void publishPatch(ai.mindconnect.chatui.service.StreamBus bus, UiPatch patch) {
+    private String publishPatch(ai.mindconnect.chatui.service.StreamBus bus, UiPatch patch) {
         try {
             String json = objectMapper.writeValueAsString(patch);
             bus.publish("patch", json);
+            return json;
         } catch (Exception e) {
             log.warn("Failed to publish SSE patch", e);
+            return null;
         }
     }
 

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/StreamController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/StreamController.java
@@ -37,9 +37,13 @@ public class StreamController {
 
     private final ActiveStreams activeStreams;
 
+    private final ai.mindconnect.chatui.service.SessionStreams sessionStreams;
+
     @Autowired
-    public StreamController(ActiveStreams activeStreams) {
+    public StreamController(ActiveStreams activeStreams,
+                            ai.mindconnect.chatui.service.SessionStreams sessionStreams) {
         this.activeStreams = activeStreams;
+        this.sessionStreams = sessionStreams;
     }
 
     @GetMapping
@@ -87,28 +91,51 @@ public class StreamController {
      * <p>404 when the stream is no longer registered (already finished).
      */
     @GetMapping(value = "/{channelId}/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> resume(@PathVariable String channelId,
-                                             @RequestParam(name = "lastSeq", defaultValue = "0") long lastSeq) {
-        var handleOpt = activeStreams.findHandle(channelId);
-        if (handleOpt.isEmpty()) return ResponseEntity.notFound().build();
-        var handle = handleOpt.get();
+    public ResponseEntity<SseEmitter> resume(
+            @PathVariable String channelId,
+            @RequestParam(name = "lastSeq", defaultValue = "0") long lastSeq,
+            @RequestParam(name = "from", required = false) Long from) {
+        // `from` wins over `lastSeq`. The page renderer knows exactly what
+        // the page it just rendered already shows and puts that position in
+        // the resume URL; the client appends its own lastSeq=0 blindly, and
+        // honouring that would replay APPEND patches the page already has.
+        long cursor = from != null ? from : lastSeq;
 
-        // Long-lived: agent turns can take minutes. The handle's cancel
-        // path applies just like for the original POST connection.
+        // No 404 when nothing is running. The stream belongs to the SESSION,
+        // and a client attaches precisely so that it is already listening
+        // when a turn starts — turning it away while the session is quiet
+        // would defeat the purpose.
+        var bus = sessionStreams.bus(channelId);
+        var handleOpt = activeStreams.findHandle(channelId);
+
+        // Long-lived: agent turns can take minutes, and the connection
+        // outlives them. Idle time is covered by the heartbeat.
         var emitter = new SseEmitter(0L);
-        handle.bus().attach(emitter, lastSeq);
-        // Drop subscriber when the client goes away — same lifecycle hooks
-        // as the original POST, scoped to *this* emitter rather than the
-        // channel as a whole (the channel keeps producing while other
-        // subscribers stay attached).
-        emitter.onCompletion(() -> handle.bus().detach(emitter));
-        emitter.onError(t -> handle.bus().detach(emitter));
-        emitter.onTimeout(() -> handle.bus().detach(emitter));
+
+        // A client that arrives mid-turn has no streaming bubble in its DOM,
+        // so every cumulative token REPLACE would land nowhere. The catch-up
+        // frames create it and fill it with the reply so far.
+        var prelude = new java.util.ArrayList<ai.mindconnect.chatui.service.StreamBus.Event>();
+        sessionStreams.catchUp(channelId).ifPresent(c -> {
+            if (c.bubblePatch() != null) {
+                prelude.add(new ai.mindconnect.chatui.service.StreamBus.Event(0, "patch", c.bubblePatch()));
+            }
+            if (c.textPatch() != null) {
+                prelude.add(new ai.mindconnect.chatui.service.StreamBus.Event(0, "patch", c.textPatch()));
+            }
+        });
+        bus.attach(emitter, cursor, prelude);
+
+        emitter.onCompletion(() -> bus.detach(emitter));
+        emitter.onError(t -> bus.detach(emitter));
+        emitter.onTimeout(() -> bus.detach(emitter));
 
         var headers = new HttpHeaders();
-        headers.add("Sui-Stream-Channel",    handle.channelId());
-        headers.add("Sui-Stream-Return-Href", handle.returnHref());
-        headers.add("Sui-Stream-Label",      handle.label());
+        headers.add("Sui-Stream-Channel", channelId);
+        headers.add("Sui-Stream-Return-Href",
+                handleOpt.map(ActiveStreams.Handle::returnHref).orElse(""));
+        headers.add("Sui-Stream-Label",
+                handleOpt.map(ActiveStreams.Handle::label).orElse("Agent"));
         return ResponseEntity.ok().headers(headers).body(emitter);
     }
 

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/ChatActionUrlsTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/ChatActionUrlsTest.java
@@ -16,11 +16,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The chat composer and the per-message actions, pinned to the routes their
  * URL strings produced.
  *
- * <p>Two things here that the admin pages did not have. Send and Regenerate
- * are SSE triggers, so they go through {@code UiActions.streaming} and must
- * keep the STREAM behaviour — applying such a response in one go would break
- * live token rendering. And Delete-from-here carries two query parameters that
- * used to be concatenated by hand.
+ * <p>One thing here the admin pages did not have: Delete-from-here carries two
+ * query parameters that used to be concatenated by hand.
+ *
+ * <p>Send and Regenerate used to be SSE triggers. They are not any more — the
+ * turn's output travels on the session's stream, which every client of the
+ * session is already reading, so submitting is an ordinary request that
+ * returns as soon as the turn is queued.
  */
 class ChatActionUrlsTest {
 
@@ -40,12 +42,18 @@ class ChatActionUrlsTest {
         assertThat(out).contains("\"url\":\"/chat/api/sessions/" + SESSION + "/chat/stream\"");
     }
 
-    /** Send must stay a stream, not become an ordinary request. */
+    /**
+     * Send is an ordinary request. Streaming it back to whoever pressed it is
+     * exactly what stopped a second client from seeing anything: a stream that
+     * belongs to one submission can only ever reach the submitter. The tokens
+     * arrive on the session's stream instead, which every client of the
+     * session already holds open.
+     */
     @Test
-    void sendKeepsTheStreamingBehaviour() throws Exception {
+    void sendIsNotAStream() throws Exception {
         String out = json(new ChatFormComponent(SESSION, AGENT).render());
 
-        assertThat(out).contains("\"behavior\":\"STREAM\"");
+        assertThat(out).doesNotContain("\"behavior\":\"STREAM\"");
     }
 
     /** While a turn runs the composer shows Stop, which cancels the session's stream. */


### PR DESCRIPTION
Two browser tabs on the same chat now see the same tokens at the same moment.

## The problem

A chat's stream belonged to **one turn**: created when a turn started, closed
when it ended. A client could therefore only ever join a turn it had started
itself. A second tab had nothing to attach to between turns — and so no way to
find out that a turn had begun.

## The stream now belongs to the session

Clients attach when they open the session, while it is still quiet, and stay
attached across turns. That is the whole mechanism: you cannot be told about a
turn if you are not listening before it starts.

A heartbeat keeps the idle connection past the ~30s a proxy allows, and doubles
as the liveness check — a failed write is the only signal that a client went
away.

**Only the running turn is streamed.** Starting a turn clears the ring buffer,
so a client joining a quiet session replays nothing and reads the persisted
history, which is the truth. Carrying a finished turn across the boundary would
be actively wrong: the patches are APPENDs and the page already renders what
they would append, so every message would appear twice. A client that joins
*mid*-turn is handed the two frames that create the reply bubble and fill it,
because the cumulative token patches REPLACE a node it would otherwise not have.

**Submitting no longer streams back to the submitter.** The POST queues the turn
and returns; everything renders over the session stream every client is already
reading. One path for everyone is what makes the two directions symmetric —
with a per-turn POST stream the sender saw its own tokens but never a turn
started by someone else.

## The status indicator moved into this app

mc-semantic-ui used to draw the floating "agent running" toast itself, with its
own wording — including *"Open chat"*. A layer that moves bytes cannot know it
is carrying a chat rather than a report or an import.

[mc-semantic-ui#32](https://github.com/mindconnect-ai/mc-semantic-ui/pull/32),
released as **0.3.0**, publishes stream state (`onStreamStateChange`) instead.
The admin UI renders it: the indicator names the session — its title, or the
agent's name while the chat is untitled — and offers "Watch" while the agent
works, "Read it" once the answer is there.

It also stops lying. The framework marked a stream "running" from the moment the
socket opened, a fair proxy while streams lasted one turn. A session stream is
open almost all the time, so leaving a quiet chat announced an agent that was
not working. 0.3.0's `"idle"` state fixes that at the source.

`semantic-ui.version` moves 0.2.0 → 0.3.0.

## Verified

Two real browser tabs on one session:

| | |
|---|---|
| A sends → B sees tokens live | ✅ |
| B sends → A sees tokens live | ✅ — the symmetry the POST-stream design could not give |
| Duplicate messages | none; both tabs character-identical |
| Heartbeat, 70s idle | no failures, connections held |
| Toast: turn running, navigated away | "… is working… [Watch]" |
| Toast: turn finishes while away | "… answer ready [Read it]", then gone |
| Toast: nothing running, navigated away | no toast — previously it claimed one was |

Full lifecycle in one uninterrupted run:
`(none)` → `Hallo Welt Einfache Anfrage is working…` → `: answer ready` → `(none)`

`mvn -f agents/pom.xml test` against the released 0.3.0: **675 tests, 0 failures,
0 errors, 0 skipped.**

## Follow-up

`StreamBus.publish` sent to each subscriber inline under a lock, so a slow
client throttled the producer — harmless with one subscriber, less so now that
several are the point. Addressed in #28, which moves the fan-out onto the task
queue's `Channel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
