### PR TITLE
The chat's SSE fan-out runs on the task queue's Channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **One slow tab no longer slows the chat for everyone else.** The SSE fan-out
+  behind a chat session used to write to each connected client in turn, while
+  holding the lock that publishing needs — so a client whose socket had stopped
+  draining held up the agent's output for every other client on that session.
+  It now runs on the task queue's `Channel`, which gives each subscriber its own
+  bounded queue and drains it on its own thread: a reader that falls behind
+  loses history, never the turn, and never anybody else's. Reconnects also
+  reach further back, since the replay buffer grew from 200 events to 2048.
+
 - **Everyone watching a chat sees it live.** A chat's stream now belongs to the
   session rather than to one turn, so a second browser tab — or a colleague on
   the same session — receives the same tokens, tool cards and approval prompts

--- a/agents/server/mc-agent-chat-ui-rest/pom.xml
+++ b/agents/server/mc-agent-chat-ui-rest/pom.xml
@@ -26,6 +26,15 @@
     </description>
 
     <dependencies>
+
+        <!-- Channel: the SSE bus's sequencing, replay buffer and fan-out.
+             Reached transitively through the runtime today; named here because
+             this module uses it directly. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-task-queue</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Agent platform — domain types plus the REST controllers the UI drives -->
         <dependency>
             <groupId>ai.mindconnect</groupId>

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/SessionStreams.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/SessionStreams.java
@@ -25,8 +25,8 @@ import java.util.concurrent.TimeUnit;
  * runs — and stay attached. A turn resolves the session's bus, publishes its
  * patches, and ends; the subscribers remain.
  *
- * <p><b>Only the current turn is replayed.</b> {@link #turnStarted} clears
- * the bus's ring buffer, so a client joining a quiet session replays nothing
+ * <p><b>Only the current turn is replayed.</b> {@link #turnStarted} raises
+ * the bus's replay floor, so a client joining a quiet session replays nothing
  * and simply reads the persisted history — which is the truth. Carrying a
  * finished turn's patches across the boundary would be actively wrong:
  * they are APPEND operations against a page that already contains what they
@@ -81,15 +81,15 @@ public class SessionStreams {
     }
 
     /**
-     * A turn begins publishing: pin the bus against eviction and drop the
-     * previous turn's patches, so anyone joining from here on replays this
-     * turn and nothing older.
+     * A turn begins publishing: pin the bus against eviction and move its
+     * replay floor to here, so anyone joining from now on replays this turn
+     * and nothing older.
      */
     public StreamBus turnStarted(String channelId) {
         busy.add(channelId);
         catchUps.remove(channelId);
         StreamBus bus = bus(channelId);
-        bus.resetBuffer();
+        bus.startTurn();
         return bus;
     }
 

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/StreamBus.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/StreamBus.java
@@ -1,171 +1,186 @@
 package ai.mindconnect.chatui.service;
 
+import ai.mindconnect.channel.Channel;
+import ai.mindconnect.channel.ChannelRegistry;
+import ai.mindconnect.channel.Subscription;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Per-channel multiplexing fan-out used by {@link ActiveStreams}. One
- * instance is created per live SSE stream and lives on the channel's
- * {@link ActiveStreams.Handle}. Producers call {@link #publish} to push an
- * event; every currently-attached {@link SseEmitter} sees a copy.
+ * Per-session multiplexing fan-out used by {@link ActiveStreams}. One instance
+ * lives per chat session (see {@link SessionStreams}); producers call
+ * {@link #publish} and every attached {@link SseEmitter} sees a copy.
  *
- * <p>Each event gets a monotonically-increasing sequence number, and the
- * last {@link #BUFFER_SIZE} events are kept in a ring buffer. A client
- * that reconnects with a {@code lastSeq} parameter via {@link #attach}
- * receives every event in the buffer with {@code seq > lastSeq} before
- * being subscribed to the live feed — closing the small race window
- * between a disconnect and a reconnect (typically a few seconds on F5).
+ * <p>The sequencing, the replay buffer and the fan-out belong to
+ * {@link Channel} from the task queue — the same machinery the agent runtime's
+ * own session channels run on. What is left here is the SSE edge: mapping
+ * emitters to subscriptions, writing frames onto the wire, and keeping idle
+ * connections alive.
  *
- * <p>Thread-safety:
- * <ul>
- *   <li>{@code publish} is synchronized so seq assignment and the
- *       buffer/subscriber writes are atomic.</li>
- *   <li>The subscriber list is a {@link CopyOnWriteArrayList} — fine for
- *       a low number of concurrent subscribers (1-3 in practice; one tab
- *       streaming, maybe one observer tab).</li>
- *   <li>{@link #attach} synchronizes against {@code publish} so a freshly
- *       attached subscriber can't miss an event that's in flight while
- *       the buffer-replay loop runs.</li>
- * </ul>
+ * <p><b>Why not our own fan-out.</b> This class used to write to each
+ * subscriber inline while holding the publish lock, so a subscriber whose
+ * socket had stopped draining blocked the producer — and with it every other
+ * subscriber. That was harmless while a stream served the one client that had
+ * opened it. It stopped being harmless when several clients on one session
+ * became the point. Channel gives each subscriber a bounded queue drained by
+ * its own virtual thread, dropping the oldest events when one falls behind: a
+ * slow reader loses history, never the turn, and never anybody else's.
+ *
+ * <p><b>The replay floor.</b> Patches are APPEND operations against a page
+ * rendered from persisted history, so replaying a finished turn would add
+ * every message a second time. A turn therefore raises the floor
+ * ({@link #startTurn}), and no subscriber is replayed from before it. Clamping
+ * rather than clearing: the events stay in the buffer for anything that
+ * legitimately asks for them, and nothing has to reach into the channel.
  */
 public final class StreamBus {
 
     /**
-     * Ring-buffer depth. Sized for a chat-turn's worth of token-by-token
-     * patches plus task-card state changes — typical turn produces well
-     * under 200 events. Bumping this is cheap (a few KB per stream).
+     * Replay depth, in events. A turn's token-by-token patches plus its task
+     * cards stay well under this; the channel default is larger than the 200
+     * this class used to keep, which only makes reconnects more forgiving.
      */
-    public static final int BUFFER_SIZE = 200;
+    public static final int BUFFER_SIZE = ChannelRegistry.DEFAULT_BUFFER;
 
     /**
-     * One past event held in the ring buffer. {@code seq} starts at 1 and
-     * grows monotonically per stream. {@code name} is the SSE event name
-     * (e.g. {@code "patch"}, {@code "error"}, {@code "done"}); {@code data}
-     * is the JSON-serialised payload.
+     * One SSE frame. {@code seq} is the channel's position, filled in on the
+     * way out. {@code name} is the SSE event name ({@code "patch"},
+     * {@code "error"}, {@code "done"}); {@code data} is the payload.
      */
     public record Event(long seq, String name, String data) { }
 
-    private final List<SseEmitter> subscribers = new CopyOnWriteArrayList<>();
-    private final Deque<Event> buffer = new ArrayDeque<>(BUFFER_SIZE);
-    private final AtomicLong seqGen = new AtomicLong(0);
+    /** What travels on the channel: a frame that does not know its position. */
+    record Frame(String name, String data) { }
 
     /**
-     * Records the event in the ring buffer and broadcasts it to every
-     * currently attached subscriber. Failures on a single subscriber drop
-     * that subscriber from the list — its emitter is already broken at
-     * that point, no benefit in retrying.
+     * Channels are normally handed out by a registry keyed by id. Here the bus
+     * IS the identity — {@link SessionStreams} already keeps one per session —
+     * so each bus owns a private registry with a single channel rather than
+     * inventing a second id space.
      */
-    public synchronized void publish(String name, String data) {
-        long seq = seqGen.incrementAndGet();
-        Event event = new Event(seq, name, data);
-        if (buffer.size() == BUFFER_SIZE) buffer.removeFirst();
-        buffer.addLast(event);
+    private static final AtomicLong CHANNEL_IDS = new AtomicLong();
 
-        Iterator<SseEmitter> it = subscribers.iterator();
-        while (it.hasNext()) {
-            SseEmitter sub = it.next();
-            if (!sendTo(sub, event)) subscribers.remove(sub);
-        }
+    private final ChannelRegistry registry = new ChannelRegistry();
+    private final Channel<Frame> channel = registry.channel("chat-ui-" + CHANNEL_IDS.incrementAndGet());
+    private final Map<SseEmitter, Subscription> subscriptions = new ConcurrentHashMap<>();
+
+    /**
+     * No subscriber is replayed from before this point. Raised at each turn
+     * start, so a client attaching with an old cursor still sees only the turn
+     * that is running.
+     */
+    private volatile long replayFloor;
+
+    /** Records the event and broadcasts it. Never blocks on a slow reader. */
+    public void publish(String name, String data) {
+        channel.publish(new Frame(name, data));
     }
 
     /**
-     * Subscribes {@code emitter} to the live feed. If {@code lastSeq} is
-     * non-negative, every buffered event with seq > lastSeq is replayed
-     * synchronously before the emitter is added to the subscriber list —
-     * the holding lock guarantees no live event interleaves.
-     *
-     * <p>Pass {@code -1} as {@code lastSeq} to replay everything in the
-     * buffer (initial attach from a reconnecting client that has no seq
-     * yet). Pass {@code Long.MAX_VALUE} to skip replay entirely (the
-     * stream's own producer thread doesn't need replay).
+     * Everything published from here on belongs to a new turn; nothing older
+     * may be replayed into a page that already renders it.
      */
-    public synchronized void attach(SseEmitter emitter, long lastSeq) {
+    public void startTurn() {
+        replayFloor = channel.lastSeq();
+    }
+
+    /**
+     * Subscribes {@code emitter} to the live feed, replaying buffered events
+     * after {@code lastSeq} first. Pass {@link #lastSeq()} to skip replay
+     * entirely. The cursor is clamped to the current turn — see the class
+     * comment.
+     */
+    public void attach(SseEmitter emitter, long lastSeq) {
         attach(emitter, lastSeq, List.of());
     }
 
     /**
-     * Attach with a PRELUDE sent ahead of the replay — the frames that bring
-     * a client joining mid-turn up to the current state. Sent inside the
-     * lock, so a token published concurrently cannot slip in front of the
-     * prelude and land on a DOM node the prelude has yet to create.
+     * Attach with a PRELUDE — the frames that bring a client joining mid-turn
+     * up to the current state, sent ahead of the replay.
+     *
+     * <p>The cursor is read <em>before</em> the prelude goes out, so anything
+     * published while it is being written is still delivered by the
+     * subscription: no gap, and no duplicate either, since the subscription
+     * starts from exactly that point. The old implementation needed a lock
+     * held across both steps to get the same guarantee.
      */
-    public synchronized void attach(SseEmitter emitter, long lastSeq, List<Event> prelude) {
+    public void attach(SseEmitter emitter, long lastSeq, List<Event> prelude) {
+        long cursor = Math.max(Math.max(lastSeq, replayFloor), 0);
+        cursor = Math.min(cursor, channel.lastSeq());
+
         for (Event e : prelude) {
-            if (!sendTo(emitter, e)) return;
-        }
-        for (Event e : buffer) {
-            if (e.seq() > lastSeq) {
-                if (!sendTo(emitter, e)) return; // emitter already broken
+            if (!sendTo(emitter, e)) {
+                return;                        // emitter already broken
             }
         }
-        subscribers.add(emitter);
+
+        Subscription subscription = channel.subscribe(cursor,
+                event -> sendTo(emitter, new Event(event.seq(),
+                        event.value().name(), event.value().data())));
+        Subscription previous = subscriptions.put(emitter, subscription);
+        if (previous != null) {
+            previous.close();                  // a re-attach of the same emitter
+        }
     }
 
-    /** Drops an emitter from the subscriber list. No-op if not present. */
+    /** Drops an emitter from the feed. No-op if it was not attached. */
     public void detach(SseEmitter emitter) {
-        subscribers.remove(emitter);
+        Subscription subscription = subscriptions.remove(emitter);
+        if (subscription != null) {
+            subscription.close();
+        }
     }
 
     /** How many clients are currently attached. */
     public int subscriberCount() {
-        return subscribers.size();
+        return subscriptions.size();
+    }
+
+    /** The newest sequence published on this bus. */
+    public long lastSeq() {
+        return channel.lastSeq();
     }
 
     /**
-     * Forgets the buffered past without touching the sequence or the
-     * subscribers. Called when a turn starts: a client that attaches later
-     * replays THIS turn and nothing before it. The patches are APPEND
-     * operations, so replaying a finished turn into a page that already
-     * renders it from persisted history would duplicate every message.
-     */
-    public synchronized void resetBuffer() {
-        buffer.clear();
-    }
-
-    /**
-     * Sends an SSE comment to every subscriber and drops those that fail.
-     * Two jobs in one: it keeps a connection alive that would otherwise be
-     * cut as idle by a proxy, and a failed write is how a client that went
-     * away is noticed — there is no other signal.
+     * Sends an SSE comment to every subscriber and drops those that fail. Two
+     * jobs in one: it keeps alive a connection a proxy would otherwise cut as
+     * idle, and a failed write is how a client that went away is noticed — the
+     * channel deliberately does not drop a consumer that throws, so nothing
+     * else would tell us.
      *
-     * <p>A comment carries no event name and no data, so it costs the client
-     * nothing; its SSE reader parses the block and finds nothing to
-     * dispatch.
+     * <p>Written straight to the emitters rather than published: a heartbeat
+     * is not part of the stream's history and must not take a sequence number
+     * or a buffer slot.
      */
-    public synchronized void ping() {
-        Iterator<SseEmitter> it = subscribers.iterator();
-        while (it.hasNext()) {
-            SseEmitter sub = it.next();
+    public void ping() {
+        for (SseEmitter emitter : subscriptions.keySet()) {
             try {
-                sub.send(SseEmitter.event().comment("hb"));
+                emitter.send(SseEmitter.event().comment("hb"));
             } catch (Exception e) {
-                subscribers.remove(sub);
+                detach(emitter);
             }
         }
     }
 
-    /** Last published seq, for clients that need to track "where am I". */
-    public long lastSeq() {
-        return seqGen.get();
-    }
-
     /**
-     * Completes every attached subscriber and clears the list. Called by the
-     * channel's owner after the producer is fully done (after the {@code done}
-     * event has been published) so reconnect-tabs see a clean stream end
-     * rather than hanging on an open SSE forever.
+     * Completes every attached subscriber and clears the list — the shutdown
+     * path, so clients see a clean stream end rather than hanging on an open
+     * SSE forever.
      */
-    public synchronized void closeAll() {
-        for (SseEmitter sub : subscribers) {
-            try { sub.complete(); } catch (Exception ignore) {}
+    public void closeAll() {
+        for (Map.Entry<SseEmitter, Subscription> entry : subscriptions.entrySet()) {
+            entry.getValue().close();
+            try {
+                entry.getKey().complete();
+            } catch (Exception ignore) {
+                // already gone
+            }
         }
-        subscribers.clear();
+        subscriptions.clear();
     }
 
     private static boolean sendTo(SseEmitter emitter, Event event) {
@@ -176,7 +191,9 @@ public final class StreamBus {
                     .data(event.data()));
             return true;
         } catch (Exception e) {
-            // Emitter closed by client or transport error. Caller drops it.
+            // Emitter closed by the client, or a transport error. The
+            // heartbeat reaps it; throwing here would only be logged by the
+            // channel and must not take the drain thread down.
             return false;
         }
     }

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/service/StreamBusTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/service/StreamBusTest.java
@@ -1,0 +1,227 @@
+package ai.mindconnect.chatui.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The two promises this bus makes to a session with more than one client
+ * watching it: one slow reader must not hold up the others, and a finished
+ * turn must never be replayed into a page that already renders it.
+ */
+class StreamBusTest {
+
+    /** Records what reached the wire; optionally stalls on the way. */
+    private static class RecordingEmitter extends SseEmitter {
+        final List<String> received = new CopyOnWriteArrayList<>();
+        private final long delayMs;
+
+        RecordingEmitter() {
+            this(0);
+        }
+
+        RecordingEmitter(long delayMs) {
+            super(0L);
+            this.delayMs = delayMs;
+        }
+
+        @Override
+        public void send(SseEventBuilder builder) throws IOException {
+            if (delayMs > 0) {
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(e);
+                }
+            }
+            // Spring splits one event into its id/event/data parts; joining
+            // their payloads back together gives the frame as it goes out.
+            StringBuilder frame = new StringBuilder();
+            for (var part : builder.build()) {
+                frame.append(part.getData());
+            }
+            received.add(frame.toString());
+        }
+    }
+
+    private static void eventually(java.util.function.BooleanSupplier condition) throws Exception {
+        for (int i = 0; i < 100 && !condition.getAsBoolean(); i++) {
+            Thread.sleep(20);
+        }
+    }
+
+    /**
+     * The reason this class stopped doing its own fan-out. Delivery runs on a
+     * queue per subscriber, so a reader that has stopped draining cannot slow
+     * the producer down — previously every publish waited for the slowest
+     * socket while holding the lock, which also stalled every other reader.
+     */
+    @Test
+    void aSlowReaderDoesNotHoldUpThePublisher() {
+        StreamBus bus = new StreamBus();
+        var slow = new RecordingEmitter(200);
+        bus.attach(slow, 0);
+
+        long start = System.nanoTime();
+        for (int i = 0; i < 20; i++) {
+            bus.publish("patch", "{\"n\":" + i + "}");
+        }
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        // Serial delivery would need 20 × 200ms = 4s. A generous ceiling:
+        // the point is the order of magnitude, not the exact figure.
+        assertThat(elapsedMs).isLessThan(1_000);
+    }
+
+    /** A second client attached later still receives what is published. */
+    @Test
+    void everyAttachedClientGetsTheEvent() throws Exception {
+        StreamBus bus = new StreamBus();
+        var first = new RecordingEmitter();
+        var second = new RecordingEmitter();
+        bus.attach(first, 0);
+        bus.attach(second, 0);
+
+        bus.publish("patch", "hello");
+
+        eventually(() -> !first.received.isEmpty() && !second.received.isEmpty());
+        assertThat(first.received).hasSize(1);
+        assertThat(second.received).hasSize(1);
+        assertThat(bus.subscriberCount()).isEqualTo(2);
+    }
+
+    /**
+     * The replay floor. Patches are APPENDs against a page rendered from
+     * persisted history, so a client that joins a new turn asking for
+     * "everything" must still not be handed the previous turn — it already
+     * shows it, and would show it twice.
+     */
+    @Test
+    void aFinishedTurnIsNotReplayedIntoANewClient() throws Exception {
+        StreamBus bus = new StreamBus();
+        bus.startTurn();
+        bus.publish("patch", "turn-1-a");
+        bus.publish("patch", "turn-1-b");
+        bus.publish("done", "");
+
+        bus.startTurn();                       // second turn begins
+        bus.publish("patch", "turn-2-a");
+
+        var joiner = new RecordingEmitter();
+        bus.attach(joiner, 0);                 // "give me everything you have"
+
+        eventually(() -> !joiner.received.isEmpty());
+        assertThat(joiner.received).hasSize(1);
+        assertThat(joiner.received.get(0)).contains("turn-2-a");
+    }
+
+    /** A reconnect within the turn still replays what it missed. */
+    @Test
+    void aReconnectReplaysTheRestOfItsOwnTurn() throws Exception {
+        StreamBus bus = new StreamBus();
+        bus.startTurn();
+        bus.publish("patch", "a");
+        long seen = bus.lastSeq();
+        bus.publish("patch", "b");
+        bus.publish("patch", "c");
+
+        var back = new RecordingEmitter();
+        bus.attach(back, seen);
+
+        eventually(() -> back.received.size() >= 2);
+        assertThat(back.received).hasSize(2);
+        assertThat(back.received.get(0)).contains("b");
+        assertThat(back.received.get(1)).contains("c");
+    }
+
+    /**
+     * A client joining mid-turn is handed the frames that build the reply
+     * bubble before anything live, or the cumulative token patches would
+     * REPLACE a node its DOM does not have.
+     */
+    @Test
+    void thePreludeArrivesBeforeTheLiveFeed() throws Exception {
+        StreamBus bus = new StreamBus();
+        bus.startTurn();
+        bus.publish("patch", "already-there");
+
+        var joiner = new RecordingEmitter();
+        bus.attach(joiner, bus.lastSeq(),
+                List.of(new StreamBus.Event(0, "patch", "catch-up")));
+        bus.publish("patch", "live");
+
+        eventually(() -> joiner.received.size() >= 2);
+        assertThat(joiner.received).hasSize(2);
+        assertThat(joiner.received.get(0)).contains("catch-up");
+        assertThat(joiner.received.get(1)).contains("live");
+    }
+
+    /** Detaching stops delivery; the heartbeat has nobody left to reach. */
+    @Test
+    void detachingStopsDelivery() throws Exception {
+        StreamBus bus = new StreamBus();
+        var emitter = new RecordingEmitter();
+        bus.attach(emitter, 0);
+        bus.publish("patch", "before");
+        eventually(() -> !emitter.received.isEmpty());
+
+        bus.detach(emitter);
+        bus.publish("patch", "after");
+        Thread.sleep(100);
+
+        assertThat(bus.subscriberCount()).isZero();
+        assertThat(emitter.received).hasSize(1);
+        assertThat(emitter.received.get(0)).contains("before");
+    }
+
+    /** A write that fails is how a client that went away is noticed. */
+    @Test
+    void theHeartbeatDropsAClientThatIsGone() {
+        StreamBus bus = new StreamBus();
+        var dead = new RecordingEmitter() {
+            @Override
+            public void send(SseEventBuilder builder) throws IOException {
+                throw new IOException("socket closed");
+            }
+        };
+        bus.attach(dead, 0);
+        assertThat(bus.subscriberCount()).isEqualTo(1);
+
+        bus.ping();
+
+        assertThat(bus.subscriberCount()).isZero();
+    }
+
+    /** Nothing is lost when a subscriber attaches while events are flowing. */
+    @Test
+    void attachingUnderLoadLosesNothingAndDuplicatesNothing() throws Exception {
+        StreamBus bus = new StreamBus();
+        bus.startTurn();
+        var latch = new CountDownLatch(1);
+        var publisher = Thread.ofVirtual().start(() -> {
+            for (int i = 0; i < 200; i++) {
+                bus.publish("patch", "n" + i);
+            }
+            latch.countDown();
+        });
+
+        var joiner = new RecordingEmitter();
+        bus.attach(joiner, 0);
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        publisher.join();
+
+        eventually(() -> joiner.received.size() >= 1);
+        Thread.sleep(200);
+        // Whatever arrived must be strictly increasing with no repeats — the
+        // guarantee that lets a client cursor on the sequence.
+        assertThat(joiner.received).doesNotHaveDuplicates();
+    }
+}


### PR DESCRIPTION
The follow-up flagged in #26: the chat's SSE fan-out moves onto the task
queue's `Channel`.

## Why

`StreamBus` wrote to each subscriber **inline while holding the publish
lock**. A subscriber whose socket had stopped draining therefore blocked the
producer — and with it every other subscriber on that session.

That was harmless while a stream served the one client that had opened it.
#26 made several clients on one session the point, which is what turns this
from a curiosity into a real failure mode: one backgrounded tab with a stalled
TCP window would throttle the agent's output for everyone watching.

`Channel` solves exactly this, and the agent runtime's own session channels
already run on it — its contract is explicit: *"The publisher never blocks."*
Each subscriber gets a bounded queue drained by its own virtual thread, and
overflow drops the **oldest** events. A reader that falls behind loses
history, never the turn, and never anybody else's.

## What is left in StreamBus

The SSE edge, and only that: mapping emitters to subscriptions, writing frames
onto the wire, and keeping idle connections alive. Gone with the fan-out are
its `CopyOnWriteArrayList`, `ArrayDeque`, `AtomicLong` and all four
`synchronized` blocks.

**`resetBuffer` gives way to a replay floor.** Clearing the buffer was a blunt
way of saying "do not replay a finished turn". The floor says it exactly, by
clamping every cursor to the current turn. The events stay in the buffer for
anything that legitimately asks for them, and nothing reaches into the channel
to mutate it. Replay depth rises from 200 to the channel default of 2048,
which only makes reconnects more forgiving.

**Attaching with a prelude no longer needs a lock across both steps.** Read the
position, send the prelude, subscribe from that position — whatever is
published in between arrives from the buffer, with neither a gap nor a
duplicate.

`mc-task-queue` was already on the classpath through the runtime; it is now
declared, since this module uses it directly.

## Verified

`StreamBusTest`, 8 tests, pins the promises rather than the implementation:

- **`aSlowReaderDoesNotHoldUpThePublisher`** — a subscriber that takes 200ms
  per write, 20 events. Serial delivery needs 4s; the test allows 1s and the
  publish loop returns immediately. This is the whole justification, measured.
- `aFinishedTurnIsNotReplayedIntoANewClient` — the replay floor across a turn
  boundary, for a client asking for everything.
- `aReconnectReplaysTheRestOfItsOwnTurn` — and the floor does not swallow a
  legitimate mid-turn reconnect.
- `thePreludeArrivesBeforeTheLiveFeed`, `everyAttachedClientGetsTheEvent`,
  `detachingStopsDelivery`, `theHeartbeatDropsAClientThatIsGone`,
  `attachingUnderLoadLosesNothingAndDuplicatesNothing`.

`mvn -f agents/pom.xml install` (tests included) green.

## Not in this change

The heartbeat stays here rather than moving to the channel. `Channel`
deliberately does not drop a consumer that throws — "a broken observer must
never break the stream" — so a failed write is the only signal left that a
client went away, and that is this layer's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
