### PR TITLE
Drop the "still running" indicator, and end a failed turn properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Added
+
+- **A response reviewer says that it is running, and what it decided.** The
+  reviewers run *after* the answer is already on screen, so the conversation
+  sat there apparently finished while another model call was still going —
+  seconds of "AI is thinking" with nothing to explain them. The chat now shows
+  a card naming the reviewer while it checks, which then turns into its verdict
+  (passed, modified, blocked) with the reason where one was given. The events
+  had been in the stream all along; only the log was listening.
+
 ### Fixed
 
 - **A cancelled or failed turn no longer leaves the UI thinking it is still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A cancelled or failed turn no longer leaves the UI thinking it is still
+  running.** The stream now belongs to the session and outlives the turn, so
+  nothing closes it when a turn ends badly — and the error path forgot to say
+  the turn was over at all. A client that saw a turn fail therefore stayed in
+  streaming state for good, and the floating "agent running" indicator kept
+  announcing work that had long since stopped, for that session and then for
+  older ones as they piled up.
+
+### Removed
+
+- **The floating "still running" indicator is gone.** It existed so that a
+  turn started in one place was not lost when you looked elsewhere. Since a
+  session's stream is reattached the moment you open the conversation, there
+  is nothing left to lose, and the indicator was reporting from what the
+  browser last heard rather than from what the server knows — which is how it
+  came to claim that finished turns were working.
+
 ## [0.2.0] - 2026-09-01
 
 ### Added

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -659,35 +659,3 @@ body {
     cursor: pointer;
 }
 .group-picker-toggle:hover { border-color: var(--sui-color-border-strong); }
-
-/* ── Floating "still running" indicator ──────────────────────────────────────
-   Ours, not the framework's: what a live stream should look like — and what to
-   call it — is an application decision. Mounted on body rather than in the
-   toast container so it survives navigation independently of the regular
-   toast queue. Rendered by renderStreamStatus() in app.js. */
-.stream-status {
-    position: fixed;
-    bottom: 16px;
-    right: 16px;
-    z-index: 1500;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 14px;
-    background: var(--sui-color-surface, #fff);
-    border: 1px solid var(--sui-color-border, #d4d4d8);
-    border-left-width: 4px;
-    border-left-color: var(--sui-color-primary, #3b82f6);
-    border-radius: 6px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    font-size: 14px;
-}
-.stream-status .sui-toast-link {
-    background: none;
-    border: none;
-    color: var(--sui-color-primary, #3b82f6);
-    cursor: pointer;
-    font-weight: 600;
-    padding: 0;
-}
-.stream-status .sui-toast-link:hover { text-decoration: underline; }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -53,59 +53,7 @@ const bus = new SuiEventBus(renderer, main);
 bus.setFetcher(bffFetch)
    .setOnUnauthenticated(handle401)
    // App-defined SSE event: chat errors come over the same stream as patches.
-   .onStreamEvent("error", (msg) => showStreamError(msg))
-   // The framework publishes stream state; what it looks like is ours.
-   .onStreamStateChange(renderStreamStatus);
-
-// ── Floating "still running" indicator ──────────────────────────────────────
-
-/**
- * Shows what is running somewhere the user cannot see. Only streams whose
- * page is NOT mounted qualify: while you are looking at the chat, the chat
- * itself is the status display.
- *
- * The wording lives here rather than in the framework, which moves bytes and
- * has no idea whether a stream carries a chat, a report or an import. The
- * destination names itself through `returnLabel` (the chat page sends its
- * session title); `returnHref` is where the button goes.
- */
-function renderStreamStatus(streams) {
-    const away = streams.filter(s => !s.pageAttached);
-    const running = away.filter(s => s.state === "running");
-    const finished = away.filter(s => s.state === "completed" || s.state === "errored");
-
-    const existing = document.getElementById("stream-status-toast");
-    if (running.length === 0 && finished.length === 0) {
-        if (existing) existing.remove();
-        return;
-    }
-
-    // Prefer what still needs waiting for; an answer already sitting there
-    // can wait a moment longer.
-    const isRunning = running.length > 0;
-    const focus = isRunning ? running[0] : finished[0];
-    const what = focus.returnLabel || focus.label || "Agent";
-
-    const toast = existing || document.createElement("div");
-    if (!existing) {
-        toast.id = "stream-status-toast";
-        toast.className = "sui-toast sui-toast--info stream-status";
-        toast.setAttribute("role", "status");
-        document.body.appendChild(toast);
-    }
-    toast.replaceChildren();
-
-    const text = document.createElement("span");
-    text.textContent = isRunning ? `${what} is working…` : `${what}: answer ready`;
-    toast.appendChild(text);
-
-    const link = document.createElement("button");
-    link.type = "button";
-    link.className = "sui-toast-link";
-    link.textContent = isRunning ? "Watch" : "Read it";
-    link.addEventListener("click", () => { void bus.navigate(focus.returnHref); });
-    toast.appendChild(link);
-}
+   .onStreamEvent("error", (msg) => showStreamError(msg));
 
 // ── Transient error banner used by the streaming chat ───────────────────────
 

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/TaskCardComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/TaskCardComponent.java
@@ -139,6 +139,28 @@ public final class TaskCardComponent implements UiComponent {
                 false);
     }
 
+    /**
+     * Card for a reviewer that has just started. Reviewers run AFTER the
+     * answer is on screen, so without this the chat sits on "thinking" with
+     * nothing to show for it — see the body, which names what is being
+     * checked rather than leaving the reader to guess.
+     */
+    public static TaskCardComponent runningReviewer(String nodeId, String reviewerName) {
+        return new TaskCardComponent(nodeId,
+                runningReviewerHeader(reviewerName),
+                taskCardBody("Checking the answer before it is final.", null),
+                true);
+    }
+
+    /** Card for a reviewer that has reached a verdict. */
+    public static TaskCardComponent doneReviewer(String nodeId, String reviewerName,
+                                                 String verdict, String detail) {
+        return new TaskCardComponent(nodeId,
+                reviewerVerdictHeader(reviewerName, verdict),
+                taskCardBody("Checking the answer before it is final.", detail),
+                false);
+    }
+
     /** Card representing a tool call that failed. */
     public static TaskCardComponent failedTool(String nodeId, String toolName,
                                                Object arguments, String error, long durationMs) {
@@ -286,6 +308,25 @@ public final class TaskCardComponent implements UiComponent {
     /** "⏳ toolName — running…". */
     public static String runningToolHeader(String toolName) {
         return "⏳ " + toolName + " — running…";
+    }
+
+    /** "⏳ reviewerName — reviewing…". */
+    public static String runningReviewerHeader(String reviewerName) {
+        return "⏳ " + reviewerName + " — reviewing…";
+    }
+
+    /**
+     * The verdict, with the mark the reader already knows from tool cards:
+     * a pass is a tick, a rewrite is a pencil, a block is a cross.
+     */
+    public static String reviewerVerdictHeader(String reviewerName, String verdict) {
+        String mark = switch (verdict) {
+            case "PASSED" -> "✓";
+            case "MODIFIED" -> "✎";
+            case "BLOCKED" -> "✗";
+            default -> "•";
+        };
+        return mark + " " + reviewerName + "  (" + verdict.toLowerCase(java.util.Locale.ROOT) + ")";
     }
 
     /** "✓ toolName (123 ms)". */

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -996,6 +996,11 @@ public class ChatUiController {
         // correlated only by taskId, so this is how we resolve their
         // container's session-keyed id.
         java.util.Map<java.util.UUID, java.util.UUID> taskToSession = new java.util.concurrent.ConcurrentHashMap<>();
+        // Why a reviewer rewrote or blocked the answer, keyed by reviewer.
+        // ResponseRevised arrives before the decision it explains.
+        java.util.Map<String, String> reviewerDetail = new java.util.concurrent.ConcurrentHashMap<>();
+        java.util.List<ai.mindconnect.chatui.ui.component.TaskCardComponent> reviewerVerdicts =
+                new java.util.concurrent.CopyOnWriteArrayList<>();
 
         ChatTurnHandle turn = turnStarter.apply(event -> {
             switch (event) {
@@ -1054,6 +1059,34 @@ public class ChatUiController {
                             sErr.taskId(), sErr.agentName(), null, sErr.error());
                 case StreamEvent.SubAgentEvent wrapper ->
                     handleSubAgentInner(wrapper, liveView, liveTasks, openTaskNodeId, bus, taskToSession);
+                // Reviewers run AFTER the answer is already on screen. Without
+                // a card the chat just sits there, which is what made a
+                // finished-looking turn feel stuck.
+                case StreamEvent.Reviewing rv -> {
+                    String node = reviewerNodeId(sessionId, rv.reviewerName());
+                    publishPatch(bus, appendCard(liveView, null,
+                            ai.mindconnect.chatui.ui.component.TaskCardComponent
+                                    .runningReviewer(node, rv.reviewerName())));
+                    openTaskNodeId[0] = node;
+                }
+                case StreamEvent.ReviewerDecision rd -> {
+                    var verdictCard = ai.mindconnect.chatui.ui.component.TaskCardComponent.doneReviewer(
+                            reviewerNodeId(sessionId, rd.reviewerName()),
+                            rd.reviewerName(), String.valueOf(rd.verdict()),
+                            reviewerDetail.get(LAST_REVISION));
+                    publishPatch(bus, liveView.streamTaskUpdate(verdictCard));
+                    // Kept for after the turn: streamDone rebuilds the list
+                    // from persisted history, and a reviewer run is not part
+                    // of it, so the verdict would vanish the moment it
+                    // arrived. Re-appending is not persistence — a reload
+                    // still loses it — but the reader gets to see it.
+                    reviewerVerdicts.add(verdictCard);
+                }
+                // A reviewer that rewrote or blocked the answer says why; the
+                // verdict card is where that belongs, so keep it for the
+                // decision event that follows.
+                case StreamEvent.ResponseRevised rev ->
+                    reviewerDetail.put(LAST_REVISION, rev.reason());
                 default -> {}
             }
             logEvent(event, agent.name());
@@ -1098,6 +1131,11 @@ public class ChatUiController {
                 // (assistant message, historic task cards, updated tokens).
                 ChatPage finalView = buildChatPage(session, agent);
                 publishPatch(bus, finalView.streamDone());
+                // After the rebuild, or they would be wiped by it. They sit
+                // below the answer, which is also when they ran.
+                for (var verdict : reviewerVerdicts) {
+                    publishPatch(bus, finalView.streamTaskStart(verdict));
+                }
 
                 // "done" ends the TURN, not the stream: subscribers stay
                 // attached and are still there when the next turn — possibly
@@ -1206,6 +1244,18 @@ public class ChatUiController {
         // Fall back to the taskId itself if the mapping is somehow missing —
         // still consistent within this live stream.
         return (sid != null ? sid : parentTaskId).toString();
+    }
+
+    /** Marker key under which a pending revision reason is parked. */
+    private static final String LAST_REVISION = "__revision__";
+
+    /**
+     * One node per reviewer and session, so the running card and the verdict
+     * card are the same node — the verdict REPLACEs the "reviewing…" header
+     * instead of appending a second entry.
+     */
+    private static String reviewerNodeId(UUID sessionId, String reviewerName) {
+        return "task-review-" + sessionId + "-" + reviewerName.replaceAll("[^A-Za-z0-9_-]", "-");
     }
 
     private void startToolCard(ChatPage liveView,

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -1078,6 +1078,13 @@ public class ChatUiController {
                 try {
                     bus.publish("error", message);
                 } catch (Exception ignored) {}
+                try {
+                    // "done" says the TURN is over, not that it succeeded. A
+                    // failed turn is over too, and a subscriber that never
+                    // hears so stays in streaming state for good — the stream
+                    // outlives the turn now, so nothing else ends it.
+                    bus.publish("done", "");
+                } catch (Exception ignored) {}
                 // The stream stays open — it belongs to the session, not to
                 // this turn. Only the "a turn is running" entry goes, so the
                 // next page render shows Send instead of Stop.


### PR DESCRIPTION
The floating "agent running" indicator kept announcing work that had stopped —
first for one session, then for several as they piled up. Two things met.

## Why it lied

The stream belongs to the session now and outlives the turns publishing into
it, so nothing closes it when a turn ends. And the error path never said the
turn was over: it published the `error` event and deregistered the "a turn is
running" entry, but no `done`.

While a stream lasted exactly one turn, that omission was invisible — closing
the stream ended the client's reader, and its state machine settled by itself
in the reader's `finally`. It stopped being invisible the moment the stream
survived the turn. Every cancelled or failed turn left its client in streaming
state permanently, and the indicator read exactly that state.

Measured on the running server while reproducing it: `GET /chat/api/streams`
returned `[]` throughout, while the browser showed *"… is working…"* — and on
the second reproduction the indicator had moved on to naming a different,
older session.

## Why it goes rather than gets fixed

It was a crutch for a stream that lasted one turn: work started in one place
would be lost if you looked elsewhere. A session's stream is reattached the
moment the conversation is opened, so there is nothing left to lose.

It also read the wrong source — what this browser last heard, rather than what
the server knows. That is the flaw that let it lie at all, and no amount of
patching the state machine removes it. A replacement that asks
`GET /chat/api/streams` cannot have this class of bug; a jobs indicator along
those lines is the intended follow-up.

Removed: 50 lines of renderer from `app.js`, 31 lines from `app.css`, and the
`onStreamStateChange` registration.

## `done` is published on the error path regardless

It says the TURN is over, not that it succeeded, and nothing else ends one now.
No consumer is left in this repo, but leaving a documented state machine
permanently wrong is a trap for whoever reaches for `onStreamStateChange` next.

## Verified

Reproduced the original failure, then re-ran it on the fix:

| | |
|---|---|
| Server during the run | 1 running turn |
| Server after cancel | 0 |
| Cancel via the Stop button | 204 |
| Indicator after navigating away mid-run | none |
| **Staying on the page and pressing Stop** | **composer returns to Send; no Stop left** |

That last row is the one that matters beyond the indicator: a client that stays
on the conversation now recovers from a cancelled turn. It used to be left with
the composer stuck in Stop mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
