### PR TITLE
The chat keeps its shape while it streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **The chat no longer changes shape while it streams.** The reply spanned the
+  full window as the tokens arrived and only snapped back into its column once
+  the turn ended, taking the composer with it. Two causes, both to do with the
+  live patches not matching what the finished page renders: the streaming reply
+  and its list item shared one id, so the first token replaced the item instead
+  of filling it, and the composer's width was tied to a selector that only its
+  idle state matched.
+
+
 - **A cancelled or failed turn no longer leaves the UI thinking it is still
   running.** The stream now belongs to the session and outlives the turn, so
   nothing closes it when a turn ends badly — and the error path forgot to say

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
@@ -333,9 +333,22 @@ public final class MessageListComponent implements UiComponent {
         String time = DT_FMT.format(java.time.Instant.now());
         var wrapper = UiList.of("bot-pending-wrapper", null);
         wrapper.item(UiList.Item.of(pendingId, agentName + "  [" + time + "]")
-                .content(UiMarkdown.of(pendingId, "…")
+                .content(UiMarkdown.of(pendingBodyId(pendingId), "…")
                         .<UiMarkdown>withCssClass("bot-message")));
         return UiPatch.Operation.append(id(), wrapper);
+    }
+
+    /**
+     * The id of the pending reply's BODY, distinct from the list item that
+     * holds it. They used to share one id, and a REPLACE resolves the
+     * outermost match — so the first token replaced the whole {@code <li>}
+     * with a bare markdown div. The reply then sat directly in the
+     * {@code <ul>}, losing the list item's width and spacing until the turn
+     * ended and the page was rebuilt from history. Same convention the
+     * persisted messages use: item id, and {@code msg-} + it for the body.
+     */
+    private static String pendingBodyId(String pendingId) {
+        return "msg-" + pendingId;
     }
 
     /**
@@ -344,8 +357,8 @@ public final class MessageListComponent implements UiComponent {
      * {@link #appendBotPending(String, String)}.
      */
     public UiPatch.Operation replaceBotPending(String pendingId, String cumulativeText) {
-        return UiPatch.Operation.replace(pendingId,
-                UiMarkdown.of(pendingId, cumulativeText)
+        return UiPatch.Operation.replace(pendingBodyId(pendingId),
+                UiMarkdown.of(pendingBodyId(pendingId), cumulativeText)
                         .<UiMarkdown>withCssClass("bot-message"));
     }
 

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
@@ -601,10 +601,18 @@
    The absolute-positioning of the footer row (further up this file) is what
    makes this possible and is also why it is fiddly — a chat-composer variant
    in the framework would render this shape directly instead. */
-.chat-form.sui-form {
+/* The measure belongs to BOTH states of the composer. It used to sit on
+   .chat-form.sui-form alone — but the streaming state is a stack, not a
+   form, so while a turn ran the composer lost its width and stretched across
+   the whole panel while the conversation stayed in its column. The card look
+   below is the idle form's own; the streaming state brings its own. */
+.chat-form {
     width: 100%;
     max-width: var(--chat-measure, 48rem);
     margin-inline: auto;
+}
+
+.chat-form.sui-form {
     background: var(--sui-color-surface);
     border: 1px solid var(--sui-color-border);
     /* The same corner every other input in the app has. It was 20px, which


### PR DESCRIPTION
Re-opens #30 against `main`. #30 was stacked on `fix/drop-stream-status-toast`
and got merged into that branch — after #29 had already carried the branch into
`main`. The layout commit therefore landed on a branch `main` never reads again;
`main` does not have it. This PR is that one commit, nothing else.

While tokens arrived, the reply ran the full width of the window — on a long
answer past its right edge — and the composer stretched with it. Both snapped
back into the centred column the moment the turn ended. Two separate causes,
one theme: **what the live patches built did not match what the finished page
renders.**

## The reply lost its list item on the first token

The pending reply and the list item holding it were given the **same id**. A
REPLACE resolves the outermost match, so the first token patch replaced the
whole `<li>` with a bare markdown div. From then on the reply sat directly in
the `<ul>` — no list-item width, no spacing, no header naming the agent — until
`streamDone` rebuilt the list from history. Persisted messages already keep the
two apart (item id, and `msg-` plus it for the body); the pending reply now
follows the same convention.

```
before:  div.bot-message → ul
after:   div.bot-message → div.sui-list-item-main → li.sui-list-item → ul
```

## The composer's measure only matched its idle state

The width constraint sat on `.chat-form.sui-form`. The idle composer is a form
and matched; the streaming one is a `UiStack` and did not — so for exactly as
long as a turn ran, it lost `max-width` and its centring. The measure now sits
on `.chat-form`, which both states carry.

## Verified

1300px viewport, idle against streaming: composer 768 / **768**, reply bubble
728 / **728**, reply inside `<li>` yes / **yes**, horizontal overflow none /
**none**. Task cards checked at 1300 and 1800 px: same width, same x as the
messages.

## Not in this change

A tab whose turn dies **with the server** is left with its composer in Stop
mode. Measured: after killing and restarting the server mid-stream, the tab made
**zero** requests — it never talks to the server again, so no server-side fix
can reach it. Client-side reconnect is a semantic-ui matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
