### PR TITLE
Losing the server no longer leaves the chat silently stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **Losing the server no longer leaves the chat silently stuck.** When the
+  server went away mid-turn — a restart, a crash — the composer stayed on
+  "AI is thinking" and a half-streamed reply froze in place, with nothing to
+  say why: the browser noticed the connection drop and told no one. It now
+  shows a notice with a Reload button. A notice rather than an automatic
+  reload on purpose: a connection that keeps dropping would otherwise re-fetch
+  the page in a loop, and a person pressing Reload cannot.
 - **The chat no longer changes shape while it streams.** The reply spanned the
   full window as the tokens arrived and only snapped back into its column once
   the turn ended, taking the composer with it. Two causes, both to do with the

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -53,7 +53,62 @@ const bus = new SuiEventBus(renderer, main);
 bus.setFetcher(bffFetch)
    .setOnUnauthenticated(handle401)
    // App-defined SSE event: chat errors come over the same stream as patches.
-   .onStreamEvent("error", (msg) => showStreamError(msg));
+   .onStreamEvent("error", (msg) => showStreamError(msg))
+   // The framework tells us when a stream's state changes; what to do about
+   // a lost one is our call.
+   .onStreamStateChange(noticeLostStream);
+
+// ── "Connection lost" notice ─────────────────────────────────────────────────
+
+/**
+ * A session's stream never ends on its own while its page is mounted — it
+ * belongs to the session, not to a turn. So a stream that reaches "completed"
+ * or "errored" with its page still attached did not finish: the server went
+ * away (a restart, a crash) and took the running turn with it. The client
+ * registers that internally and would otherwise say nothing, leaving the
+ * composer on "AI is thinking" for good and a half-streamed reply frozen.
+ *
+ * This is a notice, deliberately not an automatic re-fetch of the page. A
+ * re-fetch would re-attach the stream, and a connection that keeps dropping —
+ * a proxy cutting idle connections, say — would then re-fetch the page in a
+ * loop. A person clicking Reload cannot loop.
+ */
+function noticeLostStream(streams) {
+    const lost = streams.some(s => s.pageAttached
+            && (s.state === "completed" || s.state === "errored"));
+    if (!lost || document.getElementById("stream-lost-banner")) return;
+
+    const banner = document.createElement("div");
+    banner.id = "stream-lost-banner";
+    banner.setAttribute("role", "alert");
+    banner.style.cssText = "position:fixed;top:16px;right:16px;max-width:480px;z-index:9999;"
+        + "display:flex;align-items:center;gap:12px;padding:10px 14px;"
+        + "background:#fef3c7;color:#92400e;border:1px solid #fcd34d;border-radius:6px;"
+        + "box-shadow:0 4px 12px rgba(0,0,0,.1);font-size:13px;line-height:1.4;";
+
+    const text = document.createElement("span");
+    text.textContent = "⚠ Connection to the server was lost. What you see may be out of date.";
+    banner.appendChild(text);
+
+    const reload = document.createElement("button");
+    reload.type = "button";
+    reload.textContent = "Reload";
+    reload.style.cssText = "font:inherit;font-weight:600;padding:4px 10px;border-radius:4px;"
+        + "border:1px solid #d97706;background:#fff;color:#92400e;cursor:pointer;";
+    reload.addEventListener("click", () => location.reload());
+    banner.appendChild(reload);
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.setAttribute("aria-label", "Dismiss");
+    close.textContent = "×";
+    close.style.cssText = "font:inherit;font-size:16px;line-height:1;padding:0 4px;border:none;"
+        + "background:none;color:inherit;cursor:pointer;";
+    close.addEventListener("click", () => banner.remove());
+    banner.appendChild(close);
+
+    document.body.appendChild(banner);
+}
 
 // ── Transient error banner used by the streaming chat ───────────────────────
 


### PR DESCRIPTION
Kill the server while a turn streams and the tab said nothing: the composer
stayed on "AI is thinking", the half-streamed reply froze, and — measured via
the request log — the tab made **zero** further requests. It had noticed: the
reader's `read()` returns when TCP closes and the state machine moved the
stream to `completed`/`errored`. It just did nothing with the knowledge. A
dropped connection is not an SSE event, so neither the app's error banner nor
the framework's fetch-error toast ever fired.

## The signal

A session's stream never ends on its own while its page is mounted — it
belongs to the session, not to a turn. So a stream reaching `completed` or
`errored` with `pageAttached` still true did not finish: the server went away.
`onStreamStateChange` (semantic-ui 0.3.0) delivers exactly that; the app shows
a notice with a **Reload** button.

## A notice, not an automatic re-fetch

Deliberately. Re-fetching the page would re-attach the stream, and a
connection that keeps dropping — a proxy cutting idle connections, say — would
re-fetch in a loop. A person pressing Reload cannot loop.

## Verified

Fresh tab, headless Chrome:

| | notice |
|---|---|
| turn ends normally | none |
| server killed mid-turn | **"⚠ Connection to the server was lost…" + Reload** |

The browser's own console named the path: `reconnect … aborted TypeError:
network error`. Also confirmed by hand in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
