### PR TITLE
The version is three properties, and a branch can carry its own suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       # poms (their parent isn't in that reactor), so replace the literal string
       # across every pom instead; it's complete and can't leave a mixed state.
       - name: Set release version
-        run: find . -name pom.xml -exec sed -i "s|<version>${{ steps.v.outputs.current }}</version>|<version>${{ steps.v.outputs.release }}</version>|g" {} +
+        run: sed -i "s|<revision>.*</revision>|<revision>${{ steps.v.outputs.release }}</revision>|; s|<changelist>.*</changelist>|<changelist></changelist>|" pom.xml mc-java-parent/pom.xml
 
       # Keep the copy-paste dependency snippets in the docs on the version people
       # can actually pull. Targets only a <version> that follows an mc-* artifactId,
@@ -135,7 +135,9 @@ jobs:
           git tag -a "v${{ steps.v.outputs.release }}" -m "Release v${{ steps.v.outputs.release }}"
 
       - name: Open next development version
-        run: find . -name pom.xml -exec sed -i "s|<version>${{ steps.v.outputs.release }}</version>|<version>${{ steps.v.outputs.next }}</version>|g" {} +
+        run: sed -i "s|<revision>.*</revision>|<revision>${NEXT%-SNAPSHOT}</revision>|; s|<changelist>.*</changelist>|<changelist>-SNAPSHOT</changelist>|" pom.xml mc-java-parent/pom.xml
+        env:
+          NEXT: ${{ steps.v.outputs.next }}
 
       # In the same commit as the version bump, so main always has somewhere to
       # write the next entry — the moment it does not, people stop writing them.

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -58,7 +58,7 @@ jobs:
           esac
           # A branch build carries the branch in its version, so two branches
           # never publish under the same name; main stays plain.
-          sha1=""; [ "$GITHUB_REF_NAME" = main ] || sha1="-$(echo "$GITHUB_REF_NAME" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.-\n' '-')"
+          sha1=""; [ "$GITHUB_REF_NAME" = main ] || sha1="-$(echo "$GITHUB_REF_NAME" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.\n-' '-')"
           echo "SHA1=$sha1" >> "$GITHUB_ENV"
           # The release each branch publishes to: main keeps the plain `snapshot`
           # channel the launcher reads; every other branch gets its own, named

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,10 +43,24 @@ jobs:
       # The agents reactor consumes workflow artifacts it does not build
       # itself, and needs the base parent as an installed artifact — the same
       # prerequisites build.yml sets up for the agents area.
+      # One version for the whole run. The areas are built by separate Maven
+      # invocations, and every one of them must see the same -Dsha1 — the
+      # agents reactor resolves the workflow area's jars from the local
+      # repository by their full version, suffix included.
+      - name: Pick the version suffix
+        run: |
+          set -euo pipefail
+          sha1=""; [ "$GITHUB_REF_NAME" = main ] || sha1="-$(echo "$GITHUB_REF_NAME" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.\n-' '-')"
+          echo "SHA1=$sha1" >> "$GITHUB_ENV"
+          # main keeps the plain `snapshot` channel the launcher reads; every
+          # other branch publishes to its own, so a branch run never replaces
+          # main's jars.
+          echo "TAG=snapshot$sha1" >> "$GITHUB_ENV"
+
       - name: Install parent + workflow artifacts
         run: |
-          mvn -B -ntp -N -f mc-java-parent/pom.xml install
-          mvn -B -ntp -f workflow/pom.xml clean install -DskipTests
+          mvn -B -ntp -N -f mc-java-parent/pom.xml install -Dsha1="$SHA1"
+          mvn -B -ntp -f workflow/pom.xml clean install -DskipTests -Dsha1="$SHA1"
 
       - name: Build the executable jars
         run: |
@@ -56,15 +70,7 @@ jobs:
             cli)          pl="client/mc-agent-cli" ;;
             *)            pl="server/mc-agent-admin-ui-app,client/mc-agent-cli" ;;
           esac
-          # A branch build carries the branch in its version, so two branches
-          # never publish under the same name; main stays plain.
-          sha1=""; [ "$GITHUB_REF_NAME" = main ] || sha1="-$(echo "$GITHUB_REF_NAME" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.\n-' '-')"
-          echo "SHA1=$sha1" >> "$GITHUB_ENV"
-          # The release each branch publishes to: main keeps the plain `snapshot`
-          # channel the launcher reads; every other branch gets its own, named
-          # after itself, so a branch run never replaces main's jars.
-          echo "TAG=snapshot$sha1" >> "$GITHUB_ENV"
-          mvn -B -ntp -f agents/pom.xml clean install -DskipTests -pl "$pl" -am -Dsha1="$sha1"
+          mvn -B -ntp -f agents/pom.xml clean install -DskipTests -pl "$pl" -am -Dsha1="$SHA1"
 
       # The assets keep the version in their name — a jar sitting in a Downloads
       # folder has to be able to say what it is. That name is stable for as long

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -56,7 +56,11 @@ jobs:
             cli)          pl="client/mc-agent-cli" ;;
             *)            pl="server/mc-agent-admin-ui-app,client/mc-agent-cli" ;;
           esac
-          mvn -B -ntp -f agents/pom.xml clean install -DskipTests -pl "$pl" -am
+          # A branch build carries the branch in its version, so two branches
+          # never publish under the same name; main stays plain.
+          sha1=""; [ "$GITHUB_REF_NAME" = main ] || sha1="-$(echo "$GITHUB_REF_NAME" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.-\n' '-')"
+          echo "SHA1=$sha1" >> "$GITHUB_ENV"
+          mvn -B -ntp -f agents/pom.xml clean install -DskipTests -pl "$pl" -am -Dsha1="$sha1"
 
       # The assets keep the version in their name — a jar sitting in a Downloads
       # folder has to be able to say what it is. That name is stable for as long
@@ -67,7 +71,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p snapshot-assets
-          ver=$(mvn -B -q -ntp -DforceStdout help:evaluate -Dexpression=project.version)
+          ver=$(mvn -B -q -ntp -DforceStdout help:evaluate -Dexpression=project.version -Dsha1="$SHA1")
           echo "VERSION=$ver" >> "$GITHUB_ENV"
           for m in server/mc-agent-admin-ui-app:mc-agent-admin-ui-app \
                    client/mc-agent-cli:mc-agent-cli; do

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -23,7 +23,7 @@ permissions:
   contents: write   # move the `snapshot` tag and write its release
 
 concurrency:
-  group: snapshot
+  group: snapshot-${{ github.ref_name }}   # one channel per branch, so branches do not queue behind each other
   cancel-in-progress: false
 
 jobs:
@@ -60,6 +60,10 @@ jobs:
           # never publish under the same name; main stays plain.
           sha1=""; [ "$GITHUB_REF_NAME" = main ] || sha1="-$(echo "$GITHUB_REF_NAME" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.-\n' '-')"
           echo "SHA1=$sha1" >> "$GITHUB_ENV"
+          # The release each branch publishes to: main keeps the plain `snapshot`
+          # channel the launcher reads; every other branch gets its own, named
+          # after itself, so a branch run never replaces main's jars.
+          echo "TAG=snapshot$sha1" >> "$GITHUB_ENV"
           mvn -B -ntp -f agents/pom.xml clean install -DskipTests -pl "$pl" -am -Dsha1="$sha1"
 
       # The assets keep the version in their name — a jar sitting in a Downloads
@@ -98,15 +102,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          base="https://github.com/$GITHUB_REPOSITORY/releases/download/snapshot"
-          gh release delete snapshot --yes --cleanup-tag || true
-          gh release create snapshot snapshot-assets/* \
+          base="https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG"
+          gh release delete "$TAG" --yes --cleanup-tag || true
+          gh release create "$TAG" snapshot-assets/* \
             --prerelease \
             --target "$GITHUB_SHA" \
-            --title "Snapshot $VERSION ($(date -u +%Y-%m-%d))" \
+            --title "Snapshot $GITHUB_REF_NAME · $VERSION ($(date -u +%Y-%m-%d))" \
             --notes "Version \`$VERSION\`, built from \`$GITHUB_REF_NAME\` at ${GITHUB_SHA::7}.
 
-          Not a release: these assets are replaced in place whenever the snapshot workflow runs. For something that stays put, take a version from [Maven Central](https://central.sonatype.com/namespace/ai.mindconnect) or a tagged release.
+          Not a release: these assets are replaced in place whenever the snapshot workflow runs for this branch. \`main\` publishes to \`snapshot\`; any other branch to \`snapshot-<branch>\`, with \`/\` in the name turned into \`-\`. For something that stays put, take a version from [Maven Central](https://central.sonatype.com/namespace/ai.mindconnect) or a tagged release.
 
           \`\`\`bash
           curl -LO $base/mc-agent-admin-ui-app-$VERSION-exec.jar

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ semantic-ui/editor/mc-sui-editor/src/main/sui/
 # Marketing drafts: the LinkedIn post, its kit and its screenshots. Written
 # here because that is where the app is, published from somewhere else.
 /website/docs/agents/posts/
+
+# CI-friendly versions: flatten writes these beside each pom; the branch suffix lives per clone
+.flattened-pom.xml
+/.mvn/maven.config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ mvn -f <module-path>/pom.xml clean install
 # Working on a branch: give the clone its own version suffix ONCE, and every
 # build in it installs as 0.x.y-<branch>-SNAPSHOT — parallel branches never
 # overwrite each other in the shared ~/.m2. The file is git-ignored.
-echo "-Dsha1=-$(git rev-parse --abbrev-ref HEAD | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.-\n' '-')" > .mvn/maven.config
+echo "-Dsha1=-$(git rev-parse --abbrev-ref HEAD | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.\n-' '-')" > .mvn/maven.config
 
 # If you change a core/shared module, rebuild it before dependent modules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,10 +134,11 @@ mvn -f taskqueue/pom.xml clean install -DskipTests
 # Build a single module
 mvn -f <module-path>/pom.xml clean install
 
-# Working on a branch: give the clone its own version suffix ONCE, and every
-# build in it installs as 0.x.y-<branch>-SNAPSHOT — parallel branches never
-# overwrite each other in the shared ~/.m2. The file is git-ignored.
-echo "-Dsha1=-$(git rev-parse --abbrev-ref HEAD | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.\n-' '-')" > .mvn/maven.config
+# Working on a branch: run this ONCE after creating (or checking out) the
+# branch. It writes the git-ignored .mvn/maven.config, and from then on every
+# build in this checkout installs as 0.x.y-<branch>-SNAPSHOT — parallel
+# branches never overwrite each other in the shared ~/.m2. Safe to re-run.
+./after-branch-creation.sh
 
 # If you change a core/shared module, rebuild it before dependent modules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,11 @@ mvn -f taskqueue/pom.xml clean install -DskipTests
 # Build a single module
 mvn -f <module-path>/pom.xml clean install
 
+# Working on a branch: give the clone its own version suffix ONCE, and every
+# build in it installs as 0.x.y-<branch>-SNAPSHOT — parallel branches never
+# overwrite each other in the shared ~/.m2. The file is git-ignored.
+echo "-Dsha1=-$(git rev-parse --abbrev-ref HEAD | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.-\n' '-')" > .mvn/maven.config
+
 # If you change a core/shared module, rebuild it before dependent modules
 
 # Release to Maven Central (CI: .github/workflows/release.yml; needs the

--- a/after-branch-creation.sh
+++ b/after-branch-creation.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Gives this checkout its own Maven version suffix, derived from the branch.
+#
+# Every pom declares its version as ${revision}${sha1}${changelist}. This script
+# writes the middle part into .mvn/maven.config, which Maven reads for every
+# invocation inside this tree (start.sh included), so a branch builds and
+# installs as 0.x.y-<branch>-SNAPSHOT — and parallel branches stop overwriting
+# each other in the one shared ~/.m2. The file is git-ignored: the pom is
+# identical on every branch, and nothing has to be undone before a merge.
+#
+# Run it once after creating (or checking out) a branch, from anywhere inside
+# the repository. Safe to re-run. `main` gets an explicitly empty suffix, so a
+# clone that moves back to main builds the plain version again.
+#
+#   ./after-branch-creation.sh              # suffix from the current branch
+#   ./after-branch-creation.sh fix/thing    # suffix for a branch by name
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+branch=${1:-$(git -C "$root" rev-parse --abbrev-ref HEAD)}
+if [ "$branch" = HEAD ]; then
+    echo "after-branch-creation: detached HEAD — pass the branch name as an argument" >&2
+    exit 1
+fi
+
+# The same slug the snapshot workflow derives from GITHUB_REF_NAME: prefixes
+# such as fix/ or feature/ become part of it, '/' turns into '-', everything
+# else that is not [a-z0-9.-] is folded to '-'. The dash sits last in the tr
+# set on purpose — anywhere else GNU tr reads it as a range.
+if [ "$branch" = main ]; then
+    sha1=""
+else
+    sha1="-$(printf '%s' "$branch" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.\n-' '-')"
+fi
+
+config="$root/.mvn/maven.config"
+mkdir -p "$root/.mvn"
+# Replace only our own line; other options someone put there stay.
+{ [ -f "$config" ] && grep -v '^-Dsha1=' "$config" || true; echo "-Dsha1=$sha1"; } > "$config.tmp"
+mv "$config.tmp" "$config"
+
+echo "branch:  $branch"
+echo "written: ${config#"$root"/}  ->  -Dsha1=$sha1"
+if version=$(cd "$root" && mvn -q -ntp help:evaluate -Dexpression=project.version -DforceStdout 2>/dev/null); then
+    echo "version: $version"
+fi

--- a/agents/builder/mc-agent-runtime-builder/pom.xml
+++ b/agents/builder/mc-agent-runtime-builder/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-admin-rest</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/agents/client/mc-agent-cli/pom.xml
+++ b/agents/client/mc-agent-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-memory-strategies/pom.xml
+++ b/agents/core/mc-agent-memory-strategies/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-protocol-mc-runtime/pom.xml
+++ b/agents/core/mc-agent-protocol-mc-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-protocol-openai/pom.xml
+++ b/agents/core/mc-agent-protocol-openai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-protocol/pom.xml
+++ b/agents/core/mc-agent-protocol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-runtime-core/pom.xml
+++ b/agents/core/mc-agent-runtime-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-runtime/pom.xml
+++ b/agents/core/mc-agent-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-tool-spi/pom.xml
+++ b/agents/core/mc-agent-tool-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-tools-code/pom.xml
+++ b/agents/core/mc-agent-tools-code/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-tools-document/pom.xml
+++ b/agents/core/mc-agent-tools-document/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-tools-gmail/pom.xml
+++ b/agents/core/mc-agent-tools-gmail/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-tools-web-browser/pom.xml
+++ b/agents/core/mc-agent-tools-web-browser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-tools-web/pom.xml
+++ b/agents/core/mc-agent-tools-web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-agent-tools-workflow/pom.xml
+++ b/agents/core/mc-agent-tools-workflow/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 
@@ -24,22 +24,22 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-persistence</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-spi-lookup</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-schema</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/agents/core/mc-agent-tools/pom.xml
+++ b/agents/core/mc-agent-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-credentials/pom.xml
+++ b/agents/core/mc-credentials/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-llm-gateway-core/pom.xml
+++ b/agents/core/mc-llm-gateway-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-llm-gateway/pom.xml
+++ b/agents/core/mc-llm-gateway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-mcp-proxy/pom.xml
+++ b/agents/core/mc-mcp-proxy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-message-repository-core/pom.xml
+++ b/agents/core/mc-message-repository-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/core/mc-message-repository/pom.xml
+++ b/agents/core/mc-message-repository/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/demo/mc-agent-simple-demo/pom.xml
+++ b/agents/demo/mc-agent-simple-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/mc-agents-parent/pom.xml
+++ b/agents/mc-agents-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 
@@ -34,132 +34,132 @@
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-common</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-task-queue</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-llm-gateway-core</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-llm-gateway</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-credentials</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-message-repository-core</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-message-repository</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-runtime-core</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-memory-strategies</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-runtime</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tool-spi</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tools</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tools-web</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tools-web-browser</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tools-code</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-vector-store</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-vector-store-pgvector</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-vector-store-tools</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-file-store</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-runtime-builder</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tools-document</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tools-workflow</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-mcp-proxy</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-tools-gmail</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-api-rest</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-agent-api-app</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
 
             <!-- SpringDoc OpenAPI -->

--- a/agents/pom.xml
+++ b/agents/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-javascript</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-initial-data</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/agents/server/mc-agent-admin-ui-rest/pom.xml
+++ b/agents/server/mc-agent-admin-ui-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-agent-chat-ui-rest</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <!-- Tool providers (discovered via ServiceLoader SPI) -->
         <dependency>
@@ -66,14 +66,14 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-admin-rest</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <!-- Code steps in workflows need a script engine (same choice as the standalone admin app) -->
         <!-- Seeds the bundled example workflows into the store on startup -->
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-initial-data</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/agents/server/mc-agent-api-app/pom.xml
+++ b/agents/server/mc-agent-api-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/server/mc-agent-api-rest/pom.xml
+++ b/agents/server/mc-agent-api-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-admin-rest</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <!-- Word/PDF text extraction for direct ingestion; optional — hosts
              without it fall back to UTF-8 (reflective guard). -->

--- a/agents/server/mc-agent-chat-ui-rest/pom.xml
+++ b/agents/server/mc-agent-chat-ui-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/vectorstore/mc-file-store/pom.xml
+++ b/agents/vectorstore/mc-file-store/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/vectorstore/mc-vector-store-pgvector/pom.xml
+++ b/agents/vectorstore/mc-vector-store-pgvector/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/vectorstore/mc-vector-store-tools/pom.xml
+++ b/agents/vectorstore/mc-vector-store-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/agents/vectorstore/mc-vector-store/pom.xml
+++ b/agents/vectorstore/mc-vector-store/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-agents-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-agents-parent/pom.xml</relativePath>
     </parent>
 

--- a/common/mc-common/pom.xml
+++ b/common/mc-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/common/mc-file-manager/pom.xml
+++ b/common/mc-file-manager/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-file-manager</artifactId>
     <name>mc-file-manager</name>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <description>microservice lib to upload, list and download files namespace aware</description>
     <packaging>jar</packaging>
     <properties>

--- a/common/mc-initial-data/pom.xml
+++ b/common/mc-initial-data/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/common/mc-pathaccessor/pom.xml
+++ b/common/mc-pathaccessor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/common/mc-schema/pom.xml
+++ b/common/mc-schema/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/common/mc-script-mini/pom.xml
+++ b/common/mc-script-mini/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/common/mc-webscraper/pom.xml
+++ b/common/mc-webscraper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/mc-java-parent/pom.xml
+++ b/mc-java-parent/pom.xml
@@ -35,6 +35,11 @@
     </scm>
 
     <properties>
+        <!-- CI-friendly version: Maven permits exactly these three placeholders in
+             <version>. revision is the number, changelist is -SNAPSHOT or empty for a
+             release, and sha1 - Maven's name, meant for a commit hash - is the one that
+             is free, so it carries the branch suffix: -Dsha1=-feature-x, written by
+             ./after-branch-creation.sh into the git-ignored .mvn/maven.config. -->
         <revision>0.2.2</revision>
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>

--- a/mc-java-parent/pom.xml
+++ b/mc-java-parent/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-java-parent</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>pom</packaging>
     <name>mc-java-parent</name>
     <description>Lightweight parent for pure Java modules — no Spring, no framework</description>
@@ -35,6 +35,9 @@
     </scm>
 
     <properties>
+        <revision>0.2.2</revision>
+        <sha1></sha1>
+        <changelist>-SNAPSHOT</changelist>
         <!-- Version of the published semantic-ui artifacts (their own repo:
              mindconnect-ai/mc-semantic-ui) consumed across the monorepo. -->
         <semantic-ui.version>0.3.0</semantic-ui.version>
@@ -118,6 +121,21 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution><id>flatten</id><phase>process-resources</phase><goals><goal>flatten</goal></goals></execution>
+                    <execution><id>flatten-clean</id><phase>clean</phase><goals><goal>clean</goal></goals></execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,11 @@
     <description>Release reactor — every publishable module exactly once (whole-repo build &amp; deploy)</description>
 
     <properties>
+        <!-- CI-friendly version: Maven permits exactly these three placeholders in
+             <version>. revision is the number, changelist is -SNAPSHOT or empty for a
+             release, and sha1 - Maven's name, meant for a commit hash - is the one that
+             is free, so it carries the branch suffix: -Dsha1=-feature-x, written by
+             ./after-branch-creation.sh into the git-ignored .mvn/maven.config. -->
         <revision>0.2.2</revision>
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,15 @@
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mindconnect</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>pom</packaging>
     <name>mindconnect</name>
     <description>Release reactor — every publishable module exactly once (whole-repo build &amp; deploy)</description>
 
     <properties>
+        <revision>0.2.2</revision>
+        <sha1></sha1>
+        <changelist>-SNAPSHOT</changelist>
         <!-- The root aggregator itself is never published. -->
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
@@ -106,4 +109,21 @@
         <module>agents/client/mc-agent-cli</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution><id>flatten</id><phase>process-resources</phase><goals><goal>flatten</goal></goals></execution>
+                    <execution><id>flatten-clean</id><phase>clean</phase><goals><goal>clean</goal></goals></execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/taskqueue/mc-task-queue-jdbc/pom.xml
+++ b/taskqueue/mc-task-queue-jdbc/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/taskqueue/mc-task-queue-schedule/pom.xml
+++ b/taskqueue/mc-task-queue-schedule/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/taskqueue/mc-task-queue/pom.xml
+++ b/taskqueue/mc-task-queue/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/taskqueue/mc-taskqueue-cluster-demo/pom.xml
+++ b/taskqueue/mc-taskqueue-cluster-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/taskqueue/mc-taskqueue-demo-app/pom.xml
+++ b/taskqueue/mc-taskqueue-demo-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 

--- a/taskqueue/pom.xml
+++ b/taskqueue/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-java-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>mc-task-queue-aggregator</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>pom</packaging>
     <description>
         Multi-module build for the task queue: the ports and their local

--- a/workflow/mc-workflow-admin-app/pom.xml
+++ b/workflow/mc-workflow-admin-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 

--- a/workflow/mc-workflow-admin-rest/pom.xml
+++ b/workflow/mc-workflow-admin-rest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 

--- a/workflow/mc-workflow-code-beanshell/pom.xml
+++ b/workflow/mc-workflow-code-beanshell/pom.xml
@@ -6,7 +6,7 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
     <artifactId>mc-workflow-code-beanshell</artifactId>
     <name>mc-workflow-code-beanshell</name>
     <description>BeanShell script step support for the workflow engine</description>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!--

--- a/workflow/mc-workflow-code-groovy/pom.xml
+++ b/workflow/mc-workflow-code-groovy/pom.xml
@@ -6,7 +6,7 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
     <artifactId>mc-workflow-code-groovy</artifactId>
     <name>mc-workflow-code-groovy</name>
     <description>Groovy script step support for the workflow engine</description>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!--

--- a/workflow/mc-workflow-code-javascript/pom.xml
+++ b/workflow/mc-workflow-code-javascript/pom.xml
@@ -6,7 +6,7 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
     <artifactId>mc-workflow-code-javascript</artifactId>
     <name>mc-workflow-code-javascript</name>
     <description>JavaScript (Nashorn) script step support for the workflow engine</description>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!--

--- a/workflow/mc-workflow-code-jython/pom.xml
+++ b/workflow/mc-workflow-code-jython/pom.xml
@@ -6,7 +6,7 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
     <artifactId>mc-workflow-code-jython</artifactId>
     <name>mc-workflow-code-jython</name>
     <description>Python (Jython) script step support for the workflow engine</description>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!--

--- a/workflow/mc-workflow-dsl-puml/pom.xml
+++ b/workflow/mc-workflow-dsl-puml/pom.xml
@@ -6,14 +6,14 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-workflow-dsl-puml</artifactId>
     <name>mc-workflow-dsl-puml</name>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <description>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <!-- Lombok — compile-time only -->
         <dependency>

--- a/workflow/mc-workflow-jackson/pom.xml
+++ b/workflow/mc-workflow-jackson/pom.xml
@@ -6,7 +6,7 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
     <artifactId>mc-workflow-jackson</artifactId>
     <name>mc-workflow-jackson</name>
     <description>JSON (de)serialization of workflow definitions</description>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Jackson — the whole point of this module -->

--- a/workflow/mc-workflow-parent/pom.xml
+++ b/workflow/mc-workflow-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../mc-java-parent/pom.xml</relativePath>
     </parent>
 
@@ -21,52 +21,52 @@
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-jackson</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-persistence</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-dsl-puml</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-spi-lookup</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-ui-diagram</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-code-javascript</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-code-groovy</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-code-beanshell</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-workflow-code-jython</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/workflow/mc-workflow-persistence/pom.xml
+++ b/workflow/mc-workflow-persistence/pom.xml
@@ -6,14 +6,14 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-workflow-persistence</artifactId>
     <name>mc-workflow-persistence</name>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <description>
@@ -37,14 +37,14 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Existing Jackson serializer + ObjectMapper factory for WorkflowData. -->
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-jackson</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Jackson — execution-state serialization goes via WorkflowObjectMapperFactory. -->

--- a/workflow/mc-workflow-spi-lookup/pom.xml
+++ b/workflow/mc-workflow-spi-lookup/pom.xml
@@ -6,14 +6,14 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-workflow-spi-lookup</artifactId>
     <name>mc-workflow-spi-lookup</name>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <description>
@@ -34,20 +34,20 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- TEST: verify discovery with a real subset of modules on the classpath -->
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-javascript</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-groovy</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/workflow/mc-workflow-step-form/pom.xml
+++ b/workflow/mc-workflow-step-form/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 

--- a/workflow/mc-workflow-swing-ui/pom.xml
+++ b/workflow/mc-workflow-swing-ui/pom.xml
@@ -6,14 +6,14 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-workflow-swing-ui</artifactId>
     <name>mc-workflow-swing-ui</name>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <description>
@@ -31,17 +31,17 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-jackson</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-dsl-puml</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!--
@@ -69,25 +69,25 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-beanshell</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-jython</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-javascript</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-groovy</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/workflow/mc-workflow-test/pom.xml
+++ b/workflow/mc-workflow-test/pom.xml
@@ -6,14 +6,14 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-workflow-test</artifactId>
     <name>mc-workflow-test</name>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <description>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-jackson</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-javascript</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-beanshell</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-jython</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-code-groovy</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/workflow/mc-workflow-ui-diagram-app/pom.xml
+++ b/workflow/mc-workflow-ui-diagram-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-ui-diagram</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <!--
             mc-semantic-ui-ext-diagram and mc-semantic-ui-core are transitive
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-jackson</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/workflow/mc-workflow-ui-diagram/pom.xml
+++ b/workflow/mc-workflow-ui-diagram/pom.xml
@@ -6,14 +6,14 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>ai.mindconnect</groupId>
     <artifactId>mc-workflow-ui-diagram</artifactId>
     <name>mc-workflow-ui-diagram</name>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <description>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <!-- The UiDiagram node type we're producing. -->
         <dependency>

--- a/workflow/mc-workflow/pom.xml
+++ b/workflow/mc-workflow/pom.xml
@@ -6,7 +6,7 @@
 <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-workflow-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-workflow-parent/pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
     <artifactId>mc-workflow</artifactId>
     <name>mc-workflow</name>
     <description>Core workflow engine: steps, execution, variable scopes, expression resolution</description>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -41,12 +41,12 @@
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-pathaccessor</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-script-mini</artifactId>
-            <version>0.2.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- TEST -->

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>ai.mindconnect</groupId>
         <artifactId>mc-java-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../mc-java-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>mc-workflow-aggregator</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>pom</packaging>
     <description>Multi-module build for all mc-workflow modules</description>
 


### PR DESCRIPTION
Five agents work on five branches, all installing `ai.mindconnect:*:0.2.2-SNAPSHOT`
into the one shared `~/.m2`. Whoever builds last wins, silently — a server once ran
for an hour on stale tool code because a sibling clone had installed over it.

## What changes

Every pom declares `<version>${revision}${sha1}${changelist}</version>` — the three
placeholders Maven allows in `<version>` — defined once in each root pom
(`revision` 0.2.2, `sha1` empty, `changelist` `-SNAPSHOT`). Sibling dependencies
use `${project.version}`.

A clone gives itself a suffix **once** by running `./after-branch-creation.sh`, which
writes the git-ignored `.mvn/maven.config`:

```
-Dsha1=-feature-session-stream
```

From then on every `mvn` in that tree — `start.sh` included — builds and installs
`0.2.2-feature-session-stream-SNAPSHOT`. Branches stop overwriting each other, and
there is **nothing to remember before a merge**: the pom is identical on every
branch; the suffix never enters it. (Documented in CLAUDE.md, with the one-liner
that derives the suffix from the branch name — `fix/`, `feature/`, `chore/` become
part of it, `/` turns into `-`.)

`flatten-maven-plugin` (`resolveCiFriendliesOnly`) writes the resolved version into
the pom that gets signed and uploaded — Central cannot resolve `${revision}`.
Ordinary properties such as `${semantic-ui.version}` stay, as they always have.

`release.yml` now bumps `<revision>`/`<changelist>` in the two root poms instead
of sed-ing 67 files. `snapshot.yml` passes the branch as `-Dsha1`, so a branch
snapshot is named after its branch while `main` stays plain.

## Verified

Fresh clone, suffix set:

| | |
|---|---|
| full reactor `install` | green, 0 errors |
| `~/.m2/ai/mindconnect/mc-agent-runtime-core/` | `0.2.2-SNAPSHOT` **and** `0.2.2-chore-ci-friendly-versions-SNAPSHOT`, side by side |
| installed pom `<version>` | literal `0.2.2-chore-ci-friendly-versions-SNAPSHOT` |
| `mvn -Dsha1=` | `0.2.2-SNAPSHOT` |
| `mvn -Dsha1= -Dchangelist=` | `0.2.2` (the release shape) |
| `mc-agent-chat-ui-rest` tests | green |
| 64 `.flattened-pom.xml` on disk | 0 seen by git |

Not verified: an actual `-Prelease deploy` — that is the release test run the
sandbox TODO asks for; the flattened pom is what it would upload.

## Also in here: a snapshot channel per branch

`snapshot.yml` could always be dispatched on a branch, but it published to the one
rolling release `snapshot` — deleting and recreating it, so a branch run replaced
main's jars in exactly the channel the launcher reads. Each branch now gets
`snapshot-<slug>` (the slug the version already carries); `main` keeps `snapshot`.
Concurrency is per branch. Orphan cleanup on branch deletion is a separate, later
workflow.

**Proven end to end** by dispatching the workflow on this branch
([run](https://github.com/mindconnect-ai/mindconnect/actions/runs/33767460785)):

| | |
|---|---|
| new release `snapshot-chore-ci-friendly-versions` | `mc-agent-admin-ui-app-0.2.2-chore-ci-friendly-versions-SNAPSHOT-exec.jar` + `snapshot.txt` (`version`, `commit`, `branch`, `built`) |
| main's `snapshot` before vs. after | byte-identical — target `937e691`, published 2026-09-02T10:36Z, same three assets |

Running it surfaced two things a local build could not: GNU `tr` on the Linux
runner reads `'a-z0-9.-\n'` as a reverse range (the dash now sits last, in the
workflow and in the CLAUDE.md one-liner), and the run builds the areas in separate
Maven invocations, every one of which must see the same `-Dsha1` — the workflow
area had installed unsuffixed while the agents reactor asked for the suffixed jars.

## Follow-ups this enables

An index of the snapshot channels so the launcher can list them, and stamping git
metadata into the jars. Both build on this; neither is in it.

Build plumbing only — no user-visible change, hence `no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



