### PR TITLE
The connection-lost notice asks the server, then heals the tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **The "connection lost" notice no longer appears while the server is fine.**
+  It fired on any stream that ended while its page was mounted — but the
+  framework also marks a stream that way when a turn finishes while you are on
+  another page, and keeps it so for a few seconds after you come back. The
+  notice now asks the server before claiming it is gone: a reachable server
+  means nothing was lost, and a dead one cannot answer.
+
+
 - **Losing the server no longer leaves the chat silently stuck.** When the
   server went away mid-turn — a restart, a crash — the composer stayed on
   "AI is thinking" and a half-streamed reply froze in place, with nothing to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,10 @@ fresh empty one, so nothing has to be moved by hand at release time.
   framework also marks a stream that way when a turn finishes while you are on
   another page, and keeps it so for a few seconds after you come back. The
   notice now asks the server before claiming it is gone: a reachable server
-  means nothing was lost, and a dead one cannot answer.
+  means nothing was lost, and a dead one cannot answer. And once it *is* gone,
+  the tab heals itself: it keeps asking with a growing interval, and when the
+  server answers again it re-requests the page — composer back to Send, stream
+  re-attached, notice gone — without anybody clicking Reload.
 
 
 - **Losing the server no longer leaves the chat silently stuck.** When the

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -83,10 +83,45 @@ function noticeLostStream(streams) {
     // like a lost connection. So ask the server before claiming it is gone:
     // a reachable server means nothing was lost; a dead one cannot answer.
     noticeLostStream._probing = true;
-    fetch("/chat/api/streams", { headers: { Accept: "application/json" }, cache: "no-store" })
-        .then(res => { if (!res.ok && res.status >= 500) showLostStreamBanner(); })
-        .catch(showLostStreamBanner)
+    probeServer()
+        .then(alive => { if (!alive) connectionLost(); })
         .finally(() => { noticeLostStream._probing = false; });
+}
+
+/** True when the server answers at all — any HTTP status below 500 is a live server. */
+function probeServer() {
+    return fetch("/chat/api/streams", { headers: { Accept: "application/json" }, cache: "no-store" })
+        .then(res => res.status < 500)
+        .catch(() => false);
+}
+
+/**
+ * The server is gone. Show the notice, then keep asking with a growing
+ * interval until it answers again — and when it does, re-request the current
+ * page once. That renders the composer from what the server actually knows
+ * (a turn that died with it is no longer "running") and re-attaches the
+ * session stream, so the tab heals without anybody clicking.
+ *
+ * The earlier worry about re-fetch loops was about re-fetching on every
+ * stream end. This re-fetches once per recovery, only after a real outage,
+ * and the backoff bounds the rate under a server that keeps flapping.
+ */
+function connectionLost() {
+    if (connectionLost._polling) return;
+    connectionLost._polling = true;
+    showLostStreamBanner();
+    let delay = 2000;
+    const tick = () => probeServer().then(alive => {
+        if (alive) {
+            connectionLost._polling = false;
+            document.getElementById("stream-lost-banner")?.remove();
+            void bus.navigate(window.location.pathname + window.location.search);
+            return;
+        }
+        delay = Math.min(delay * 2, 30000);
+        setTimeout(tick, delay);
+    });
+    setTimeout(tick, delay);
 }
 
 function showLostStreamBanner() {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -74,9 +74,23 @@ bus.setFetcher(bffFetch)
  * loop. A person clicking Reload cannot loop.
  */
 function noticeLostStream(streams) {
-    const lost = streams.some(s => s.pageAttached
+    const suspect = streams.some(s => s.pageAttached
             && (s.state === "completed" || s.state === "errored"));
-    if (!lost || document.getElementById("stream-lost-banner")) return;
+    if (!suspect || document.getElementById("stream-lost-banner") || noticeLostStream._probing) return;
+    // "completed" is not proof. The framework also uses it for a turn that
+    // finished while the page was away, and the handle keeps that state for a
+    // few seconds after the page comes back — long enough to look exactly
+    // like a lost connection. So ask the server before claiming it is gone:
+    // a reachable server means nothing was lost; a dead one cannot answer.
+    noticeLostStream._probing = true;
+    fetch("/chat/api/streams", { headers: { Accept: "application/json" }, cache: "no-store" })
+        .then(res => { if (!res.ok && res.status >= 500) showLostStreamBanner(); })
+        .catch(showLostStreamBanner)
+        .finally(() => { noticeLostStream._probing = false; });
+}
+
+function showLostStreamBanner() {
+    if (document.getElementById("stream-lost-banner")) return;
 
     const banner = document.createElement("div");
     banner.id = "stream-lost-banner";


### PR DESCRIPTION
Follow-up to #32. The "connection lost" notice fired while the server was
fine, and once it had fired it stayed until somebody clicked. Two commits.

## Ask the server before claiming it is gone

The trigger was any stream reaching `completed`/`errored` with its page
mounted — but `completed` is not proof of loss. The framework also uses it for
a turn that finished while the page was away, and keeps that state for a few
seconds after the page comes back; from where the app stands that looks exactly
like a dropped connection.

The app now measures instead of inferring: on the trigger it fetches
`/chat/api/streams`. A reachable server means nothing was lost. A dead one
cannot answer — the probe runs while the port is still closed — so a real loss
is never missed.

## The tab heals itself once the server is back

After the notice, the tab keeps probing with a growing interval (2 s → 30 s).
When the server answers again it removes the notice and re-requests the current
page **once** through the bus — an SPA page apply, not a browser reload. That
renders the composer from what the server actually knows (a turn that died with
it is no longer "running" → back to Send) and re-attaches the session stream.
Nobody clicks anything.

This is not the re-fetch-on-every-stream-end that was rejected earlier: it
re-fetches once per recovery, only after a real outage, and the backoff bounds
the rate under a flapping server. The Reload button stays as a manual escape
while the outage lasts.

## Verified

| scenario | notice |
|---|---|
| turn ends while away, page re-mounted within the reap window | none |
| 31 s idle across a heartbeat | none |
| turn ends normally | none |
| **server killed mid-turn** | **within 2 s** (`network error` in the console) |
| server back after the kill | **gone by +15 s, composer on Send, no click** |

Rebased on #33; the branch builds under its own coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
