### PR TITLE
The admin-ui jar carries the repository's changelog and build info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
   defining a bean of that type, an embedder via
   `AgentRuntimeBuilder.llmMessageMapper(...)`. The read-side extension point
   for how a conversation reads to the model — one place, every message type.
+- **agents:** the admin-ui server jar carries the repository's `CHANGELOG.md`
+  as `META-INF/CHANGELOG.md`, plus Spring Boot build info
+  (`META-INF/build-info.properties`: version and build time). Whoever holds a
+  build — the desktop launcher, for one — can show what it changes without
+  asking GitHub, and a branch build carries its own `[Unreleased]` section:
+  the description of the very fix one installs it to try.
 
 ## [0.3.0] - 2026-09-03
 

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -140,12 +140,39 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- The repository's changelog rides inside the jar, so whoever
+                 holds a build - the desktop launcher, say - can show what it
+                 changes without asking GitHub. A branch build carries its own
+                 [Unreleased] section: the description of the very fix one
+                 installs it to try. Lands in META-INF/ of the plain jar and
+                 of the exec jar alike - repackaging keeps META-INF at the
+                 root. -->
+            <resource>
+                <directory>${project.basedir}/../../..</directory>
+                <includes>
+                    <include>CHANGELOG.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <executions>
+                    <!-- Version and build time next to the changelog, as
+                         META-INF/build-info.properties - the same file the
+                         actuator's /info reads. -->
                     <execution>
+                        <id>build-info</id>
+                        <goals><goal>build-info</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>repackage</id>
                         <goals><goal>repackage</goal></goals>
                         <configuration>
                             <!-- The plain jar stays the main artifact (that is


### PR DESCRIPTION
## What

`mc-agent-admin-ui-app` now packages the repository's `CHANGELOG.md` as `META-INF/CHANGELOG.md` and, via the Boot plugin's `build-info` goal, `META-INF/build-info.properties` (version and build time). Both sit at the root of the plain jar and of the `-exec` jar alike — repackaging keeps `META-INF` where it is.

## Why

Whoever holds a build can show what it changes without asking GitHub. The desktop launcher in [mc-clients](https://github.com/mindconnect-ai/mc-clients) opens the matching section on a click: `## [<version>]` for a release, `## [Unreleased]` for a snapshot — and a branch build carries its own `[Unreleased]`, the description of the very fix one installs it to try. For jars from before this change the launcher falls back to the release note GitHub attached to the tag.

## Verified

Built the module on this branch (`0.3.1-feature-changelog-in-jar-SNAPSHOT`) and listed both jars:

```
META-INF/CHANGELOG.md
META-INF/build-info.properties
```

`build-info.properties` reads `build.version=0.3.1-feature-changelog-in-jar-SNAPSHOT` with `build.time`; the changelog inside the jar shows this PR's own entry under `[Unreleased]`.

No workflow changes — snapshot and release builds run the same Maven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)