### PR TITLE
The admin UI says which server it is: version in the header, About on a click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
   defining a bean of that type, an embedder via
   `AgentRuntimeBuilder.llmMessageMapper(...)`. The read-side extension point
   for how a conversation reads to the model — one place, every message type.
+- **agents:** the admin UI shows which server it is: the version stands in
+  the header, small, right of the brand — `v0.3.1` for a release,
+  `0.3.1-SNAPSHOT · dd8d540` for a snapshot — and a click opens About with
+  the full version, build time, commit, branch and the changelog section of
+  this very build. Not a packaged build, like a run from the IDE, shows no
+  label.
 - **agents:** the admin-ui server jar carries the repository's `CHANGELOG.md`
   as `META-INF/CHANGELOG.md`, plus Spring Boot build info
   (`META-INF/build-info.properties`: version and build time). Whoever holds a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
   defining a bean of that type, an embedder via
   `AgentRuntimeBuilder.llmMessageMapper(...)`. The read-side extension point
   for how a conversation reads to the model — one place, every message type.
+- **agents:** the admin-ui server jar carries the repository's `CHANGELOG.md`
+  as `META-INF/CHANGELOG.md`, plus Spring Boot build info
+  (`META-INF/build-info.properties`: version and build time). Whoever holds a
+  build — the desktop launcher, for one — can show what it changes without
+  asking GitHub, and a branch build carries its own `[Unreleased]` section:
+  the description of the very fix one installs it to try.
 
 ## [0.3.0] - 2026-09-03
 

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -160,6 +160,33 @@
             </resource>
         </resources>
         <plugins>
+            <!-- Commit and branch of the build, as git.properties next to the
+                 build info; Spring Boot turns it into a GitProperties bean,
+                 and the admin UI's About dialog shows it. A source tarball
+                 without .git builds without the file rather than failing. -->
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.1</version>
+                <executions>
+                    <execution>
+                        <id>git-info</id>
+                        <goals><goal>revision</goal></goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>git.branch</includeOnlyProperty>
+                        <includeOnlyProperty>git.commit.id.abbrev</includeOnlyProperty>
+                        <includeOnlyProperty>git.commit.time</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <offline>true</offline>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -140,12 +140,39 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <!-- The repository's changelog rides inside the jar, so whoever
+                 holds a build - the desktop launcher, say - can show what it
+                 changes without asking GitHub. A branch build carries its own
+                 [Unreleased] section: the description of the very fix one
+                 installs it to try. Lands in META-INF/ of the plain jar and
+                 of the exec jar alike - repackaging keeps META-INF at the
+                 root. -->
+            <resource>
+                <directory>${project.basedir}/../../..</directory>
+                <includes>
+                    <include>CHANGELOG.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <executions>
+                    <!-- Version and build time next to the changelog, as
+                         META-INF/build-info.properties - the same file the
+                         actuator's /info reads. -->
                     <execution>
+                        <id>build-info</id>
+                        <goals><goal>build-info</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>repackage</id>
                         <goals><goal>repackage</goal></goals>
                         <configuration>
                             <!-- The plain jar stays the main artifact (that is

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.adminui.ui;
 
 import ai.mindconnect.ui.model.UiAppShell;
+import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.ui.model.UiHeader;
 import ai.mindconnect.ui.model.UiLink;
 import ai.mindconnect.ui.model.UiMenu;
@@ -22,15 +23,19 @@ public final class AdminLayout {
 
     private final String userName;
     private final boolean authEnabled;
+    private final String versionLabel;
 
     /**
      * @param userName    display name of the current user (e.g. {@code "mc_user"})
      * @param authEnabled whether Keycloak auth is on; the logout link is shown
      *                    only then (with auth off the user is a fixed dev user)
+     * @param versionLabel the build's short version for the header, or null
+     *                     when this is not a packaged build
      */
-    public AdminLayout(String userName, boolean authEnabled) {
+    public AdminLayout(String userName, boolean authEnabled, String versionLabel) {
         this.userName = userName;
         this.authEnabled = authEnabled;
+        this.versionLabel = versionLabel;
     }
 
     /**
@@ -61,6 +66,15 @@ public final class AdminLayout {
         // logout), so it's a plain link, not a semantic-ui action. Shown only
         // when auth is enabled — with auth off there's a fixed dev user and
         // nothing to log out of.
+        // The build's version, small and muted, right of the brand: status,
+        // not identity, so it sits beside the user widget rather than in it.
+        // A click opens the About dialog with build time, commit, branch and
+        // the changelog section of this build.
+        if (versionLabel != null) {
+            header.extra(UiAction.link("about-version", versionLabel)
+                    .dispatch("GET", "/admin/api/about")
+                    .withCssClass("sui-hint"));
+        }
         if (authEnabled) {
             header.extra(UiLink.of("logout", "/admin/logout", "Logout"));
         }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
@@ -18,14 +18,17 @@ import org.springframework.stereotype.Component;
 public class AdminLayoutFactory {
 
     private final boolean authEnabled;
+    private final BuildInfo buildInfo;
 
-    public AdminLayoutFactory(@Value("${mindconnect.auth.enabled:false}") boolean authEnabled) {
+    public AdminLayoutFactory(@Value("${mindconnect.auth.enabled:false}") boolean authEnabled,
+                              BuildInfo buildInfo) {
         this.authEnabled = authEnabled;
+        this.buildInfo = buildInfo;
     }
 
     /** Layout for the user currently in the {@link SecurityContextHolder}. */
     public AdminLayout current() {
-        return new AdminLayout(currentUserName(), authEnabled);
+        return new AdminLayout(currentUserName(), authEnabled, buildInfo.label());
     }
 
     private String currentUserName() {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/BuildInfo.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/BuildInfo.java
@@ -1,0 +1,131 @@
+package ai.mindconnect.adminui.ui;
+
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+/**
+ * What this server build is, for the header's version label and the About
+ * dialog behind it. Everything comes out of the jar: Spring Boot's
+ * {@code META-INF/build-info.properties} (version, build time),
+ * {@code git.properties} (commit, branch) and the repository's
+ * {@code META-INF/CHANGELOG.md} — the admin-ui app packages all three. An IDE
+ * run has none of them; then there is no label and the dialog says so.
+ */
+@Component
+public class BuildInfo {
+
+    private static final DateTimeFormatter MINUTE_UTC =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'").withZone(ZoneOffset.UTC);
+
+    private final BuildProperties build;
+    private final GitProperties git;
+    private final String changelog;
+
+    public BuildInfo(Optional<BuildProperties> build, Optional<GitProperties> git) {
+        this.build = build.orElse(null);
+        this.git = git.orElse(null);
+        this.changelog = readChangelog();
+    }
+
+    /** False for a run straight from the IDE, where nothing was packaged. */
+    public boolean isKnown() {
+        return build != null;
+    }
+
+    public String version() {
+        return build == null ? null : build.getVersion();
+    }
+
+    /**
+     * The header label — short, because the header is: {@code v0.3.1} for a
+     * release, {@code 0.3.1-SNAPSHOT · dd8d540} for a snapshot. A branch
+     * build's branch is in the dialog; in the header it would take the room
+     * of the whole brand.
+     */
+    public String label() {
+        String version = version();
+        if (version == null) return null;
+        if (!version.endsWith("-SNAPSHOT")) return "v" + version;
+        String base = version.substring(0, version.indexOf('-')) + "-SNAPSHOT";
+        String commit = commit();
+        return commit == null ? base : base + " · " + commit;
+    }
+
+    public String builtAt() {
+        if (build == null) return null;
+        Instant time = build.getTime();
+        return time == null ? null : MINUTE_UTC.format(time);
+    }
+
+    public String commit() {
+        return git == null ? null : git.getShortCommitId();
+    }
+
+    public String branch() {
+        return git == null ? null : git.getBranch();
+    }
+
+    /**
+     * The changelog section that belongs to this build: {@code [<version>]}
+     * for a release, {@code [Unreleased]} for a snapshot — what the branch has
+     * changed and not released yet. Null when the jar carries no changelog.
+     */
+    public String changelogSection() {
+        return changelog == null || version() == null ? null : section(changelog, version());
+    }
+
+    private static String readChangelog() {
+        ClassPathResource resource = new ClassPathResource("META-INF/CHANGELOG.md");
+        if (!resource.exists()) return null;
+        try {
+            return resource.getContentAsString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /** One section of a Keep-a-Changelog file; the heading line is kept. */
+    static String section(String changelog, String version) {
+        String heading = version.endsWith("-SNAPSHOT") ? "## [Unreleased]" : "## [" + version + "]";
+        String out = between(changelog, heading);
+        // The release workflow renames [Unreleased] to the version before it
+        // builds the jar, so a release normally finds its own heading. A
+        // release built by hand has not been renamed - then [Unreleased] is
+        // the section that was about to become it.
+        if (out.isEmpty() && !version.endsWith("-SNAPSHOT")) {
+            heading = "## [Unreleased]";
+            out = between(changelog, heading);
+        }
+        if (out.isEmpty()) return heading + "\n\nNo such section in the changelog this build carries.";
+        if (out.lines().skip(1).allMatch(String::isBlank)) {
+            return out.strip() + "\n\nNo entries — nothing is written up for this build yet.";
+        }
+        return out.strip();
+    }
+
+    /** The heading line and everything up to the next version heading; empty when absent. */
+    private static String between(String changelog, String heading) {
+        StringBuilder out = new StringBuilder();
+        boolean inside = false;
+        for (String line : changelog.split("\\R")) {
+            if (line.startsWith(heading)) {
+                inside = true;
+                out.append(line).append('\n');
+            } else if (inside && line.startsWith("## [")) {
+                break;
+            } else if (inside) {
+                out.append(line).append('\n');
+            }
+        }
+        return out.toString();
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AboutUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AboutUiController.java
@@ -1,0 +1,71 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.adminui.ui.BuildInfo;
+import ai.mindconnect.ui.ext.markdown.UiMarkdown;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiDetail;
+import ai.mindconnect.ui.model.UiDialog;
+import ai.mindconnect.ui.model.UiField;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiStack;
+import ai.mindconnect.ui.model.UiText;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The About dialog behind the header's version label: what build this is
+ * and what it changes. Opened and closed as patches on the body-level dialog
+ * host, the same way the tool-test dialog works — the page underneath is
+ * left alone.
+ */
+@RestController
+@RequestMapping("/admin/api/about")
+public class AboutUiController {
+
+    static final String DIALOG_ID = "about-dialog";
+
+    private final BuildInfo info;
+
+    public AboutUiController(BuildInfo info) {
+        this.info = info;
+    }
+
+    @GetMapping
+    public UiPatch open() {
+        UiDialog dialog = UiDialog.of(info.isKnown() ? "Version " + info.version() : "About", null, body());
+        dialog.setId(DIALOG_ID);
+        return UiPatch.of()
+                .patch(UiPatch.Operation.remove(DIALOG_ID))
+                .patch(UiPatch.Operation.append("sui-dialogs", dialog));
+    }
+
+    @PostMapping("/close")
+    public UiPatch close() {
+        return UiPatch.of().patch(UiPatch.Operation.remove(DIALOG_ID));
+    }
+
+    private UiStack body() {
+        var build = UiDetail.of("about-build", "This server");
+        if (info.isKnown()) {
+            build.field(UiField.text("version", "Version", info.version()));
+            if (info.builtAt() != null) build.field(UiField.text("built", "Built", info.builtAt()));
+            if (info.commit() != null) build.field(UiField.text("commit", "Commit", info.commit()));
+            if (info.branch() != null) build.field(UiField.text("branch", "Branch", info.branch()));
+        } else {
+            build.field(UiField.text("version", "Version",
+                    "unknown — not a packaged build (started from the IDE?)"));
+        }
+        var stack = UiStack.of("about-stack").child(build);
+        String section = info.changelogSection();
+        stack.child(section != null
+                ? UiMarkdown.of("about-changelog", section)
+                : UiText.of("This build carries no changelog."));
+        // Close at the very end, after the changelog — the natural exit once
+        // one has read down to it; the dialog's own X covers the impatient.
+        stack.child(UiAction.secondary("about-close", "Close").icon("close")
+                .dispatch("POST", "/admin/api/about/close"));
+        return stack;
+    }
+}


### PR DESCRIPTION
Stacked on #37 (the changelog and build info in the jar) — merge that first; this PR then reduces to its own commit.

## What

- The header shows the build's version, small and muted, right of the brand and left of the theme toggle and user widget: `v0.3.1` for a release, `0.3.1-SNAPSHOT · dd8d540` for a snapshot. On a narrow screen it folds into the header's overflow.
- A click opens an **About** dialog: full version, build time, commit, branch, and the changelog section of this very build — `## [<version>]` for a release, `## [Unreleased]` for a snapshot (a branch build thereby describes the fix one installs it to try). Close at the end, after the changelog.
- `git-commit-id-maven-plugin` writes `git.properties` (branch, short commit, commit time) into `mc-agent-admin-ui-app`; Spring Boot turns it into `GitProperties`. A source tree without `.git` builds without the file.
- New `BuildInfo` component and `AboutUiController` (`GET /admin/api/about` opens, `POST /admin/api/about/close` closes — patches on the dialog host, the page underneath stays). A run from the IDE, with nothing packaged, shows no label and an About that says so.

## Why

Whoever tests a snapshot or a branch build should see at a glance which server answers, and what it changes, without leaving the UI.

## Verified

Built and ran `0.3.1-feature-version-in-header-SNAPSHOT` locally: header label `0.3.1-SNAPSHOT · 21936c9`, About shows version, built time (UTC), commit, branch `feature/version-in-header`, and the `[Unreleased]` section with this PR's own entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)