### PR TITLE
Admin UI: task manager behind a live badge in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
   user whose session a task runs for — and takes the task's sub-tasks with
   it. Endpoints under `/admin/api/tasks`.
 
+### Changed
+
+- **agents:** the admin UI's version label moved from the header to the foot
+  of the sidebar (an info icon in the collapsed rail); a click still opens
+  About. The header's right side is now the task badge and the user.
+
 ## [0.4.0] - 2026-09-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Added
+
+- **agents:** the admin UI has a task manager. A badge in the header shows
+  what the task queue is doing right now — `3 running · 2 waiting`, or
+  `idle` — on every page, kept current over a server-sent event stream the
+  page attaches once and keeps across navigation. A click opens the task
+  queue: the live tasks as a tree (a turn, the tool calls it dispatched, a
+  sub-agent's turn under the `run_agent` call that started it) with status,
+  owner and elapsed time, the tasks that finished last with a failure's
+  reason, and a Cancel per task. Cancel is for one's own tasks only — the
+  user whose session a task runs for — and takes the task's sub-tasks with
+  it. Endpoints under `/admin/api/tasks`.
+
 ## [0.4.0] - 2026-09-03
 
 ### Changed

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/TaskMonitor.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/TaskMonitor.java
@@ -1,0 +1,355 @@
+package ai.mindconnect.adminui.service;
+
+import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
+import ai.mindconnect.agent.domain.AgentDefinition;
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.port.out.AgentDefinitionRepository;
+import ai.mindconnect.agent.port.out.AgentSessionRepository;
+import ai.mindconnect.agent.service.task.AgentTurnWorker;
+import ai.mindconnect.agent.service.task.ToolCallWorker;
+import ai.mindconnect.channel.Channel;
+import ai.mindconnect.channel.ChannelRegistry;
+import ai.mindconnect.channel.Subscription;
+import ai.mindconnect.taskqueue.TaskListener;
+import ai.mindconnect.taskqueue.TaskRecord;
+import ai.mindconnect.taskqueue.TaskStatus;
+import ai.mindconnect.taskqueue.local.LocalTaskQueue;
+import ai.mindconnect.ui.model.UiPatch;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The task manager behind the header's task badge: what the task queue is
+ * doing right now, who it is doing it for, and the one thing an operator may
+ * do about it — cancel a task of their own.
+ *
+ * <p>Three parts, one class because they share the snapshot:
+ * <ul>
+ *   <li><b>Observation.</b> A {@link TaskListener} on the queue. Every
+ *       transition marks the view dirty; a short debounce turns a burst of
+ *       events (a turn dispatching five tool calls) into one snapshot.</li>
+ *   <li><b>Delivery.</b> Snapshots go onto a {@link Channel}, and every
+ *       browser tab that opened the {@code /sse} endpoint is a subscriber
+ *       with its own bounded queue — a slow tab never slows the queue, and
+ *       the listener callback itself only flips a flag. Each subscriber is
+ *       rendered for <em>its</em> user, because whether a Cancel button
+ *       appears depends on who is looking.</li>
+ *   <li><b>Ownership.</b> A task belongs to whoever owns the session it runs
+ *       for ({@code payload.sessionId} → {@link AgentSession#userId()}); a
+ *       sub-agent's session inherits its parent's user, so a whole task tree
+ *       has one owner. Cancel is allowed for that user only.</li>
+ * </ul>
+ */
+@Component
+public class TaskMonitor implements TaskListener {
+
+    private static final Logger log = LoggerFactory.getLogger(TaskMonitor.class);
+
+    /**
+     * Stream channel id AND the DOM id of the header badge. The SPA keeps a
+     * stream attached only while an element with the channel's id is
+     * mounted; the badge is on every admin page, so the stream survives
+     * navigation and is never opened twice.
+     */
+    public static final String CHANNEL_ID = "task-monitor";
+
+    /** Events within this window collapse into one snapshot. */
+    static final long DEBOUNCE_MS = 250;
+    /** SSE comment keeping idle connections alive through proxies. */
+    private static final long HEARTBEAT_SECONDS = 20;
+    /** Finished tasks shown under the live ones — a glance at what just happened. */
+    static final int RECENT_LIMIT = 15;
+    private static final int QUERY_LIMIT = 1000;
+
+    /** One task, resolved into words for a person: what it does and for whom. */
+    public record TaskView(TaskRecord task, String label, String detail, String owner, UUID sessionId) {
+        public String id() { return task.id(); }
+        public TaskStatus status() { return task.status(); }
+        public boolean active() { return !task.status().terminal(); }
+    }
+
+    /** The whole board at one instant. */
+    public record Snapshot(List<TaskView> active, List<TaskView> recent, Instant at) {
+        public int runningCount() { return count(TaskStatus.RUNNING); }
+        public int queuedCount() { return count(TaskStatus.QUEUED); }
+        public int suspendedCount() { return count(TaskStatus.SUSPENDED); }
+        public Counts counts() { return new Counts(runningCount(), queuedCount() + suspendedCount()); }
+        private int count(TaskStatus status) {
+            return (int) active.stream().filter(v -> v.status() == status).count();
+        }
+    }
+
+    /**
+     * Just the numbers on the badge — what every page render asks for.
+     * Cheap on purpose: no session lookups, only the queue's own counters.
+     *
+     * @param waiting queued plus suspended: submitted and not yet done, but
+     *                not on a thread right now either
+     */
+    public record Counts(int running, int waiting) {
+        public boolean busy() { return running + waiting > 0; }
+    }
+
+    /** Why a cancel did or did not happen. */
+    public enum CancelResult { CANCELLED, NOT_OWNER, ALREADY_FINISHED, UNKNOWN }
+
+    private final LocalTaskQueue queue;
+    private final AgentSessionRepository sessions;
+    private final AgentDefinitionRepository definitions;
+    private final ObjectMapper objectMapper;
+
+    private final Channel<Snapshot> channel = new ChannelRegistry().channel(CHANNEL_ID);
+    private final Map<SseEmitter, Subscription> subscriptions = new ConcurrentHashMap<>();
+    private final AtomicBoolean pending = new AtomicBoolean();
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "task-monitor");
+        t.setDaemon(true);
+        return t;
+    });
+
+    public TaskMonitor(LocalTaskQueue queue,
+                       AgentSessionRepository sessions,
+                       AgentDefinitionRepository definitions,
+                       ObjectMapper objectMapper) {
+        this.queue = queue;
+        this.sessions = sessions;
+        this.definitions = definitions;
+        this.objectMapper = objectMapper;
+        queue.addListener(this);
+        scheduler.scheduleWithFixedDelay(this::heartbeat, HEARTBEAT_SECONDS, HEARTBEAT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        for (var entry : subscriptions.entrySet()) {
+            entry.getValue().close();
+            try {
+                entry.getKey().complete();
+            } catch (Exception ignore) {
+                // already gone
+            }
+        }
+        subscriptions.clear();
+        scheduler.shutdownNow();
+    }
+
+    // ── observation ─────────────────────────────────────────────────────────
+
+    @Override public void onSubmitted(TaskRecord task) { touch(); }
+    @Override public void onStarted(TaskRecord task) { touch(); }
+    @Override public void onStateChanged(TaskRecord task) { touch(); }
+    @Override public void onSuspended(TaskRecord task) { touch(); }
+    @Override public void onWoken(TaskRecord task) { touch(); }
+    @Override public void onTerminal(TaskRecord task) { touch(); }
+
+    /**
+     * Marks the board dirty and schedules one publish. Runs on the queue's
+     * transition thread, so it does nothing but flip a flag — the snapshot
+     * (repository lookups included) is taken on the monitor's own thread.
+     */
+    private void touch() {
+        if (scheduler.isShutdown()) return;          // the queue outlives us on shutdown
+        if (pending.compareAndSet(false, true)) {
+            try {
+                scheduler.schedule(this::publish, DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+            } catch (RejectedExecutionException e) {
+                pending.set(false);                  // shut down between the check and the call
+            }
+        }
+    }
+
+    private void publish() {
+        pending.set(false);
+        try {
+            channel.publish(snapshot());
+        } catch (RuntimeException e) {
+            log.warn("Task monitor snapshot failed: {}", e.toString());
+        }
+    }
+
+    // ── the board ───────────────────────────────────────────────────────────
+
+    /** The badge's numbers right now, for the page render. */
+    public Counts counts() {
+        int running = queue.byStatus(TaskStatus.RUNNING, QUERY_LIMIT).size();
+        int waiting = queue.byStatus(TaskStatus.QUEUED, QUERY_LIMIT).size()
+                + queue.byStatus(TaskStatus.SUSPENDED, QUERY_LIMIT).size();
+        return new Counts(running, waiting);
+    }
+
+    /** The board right now — for the dialog; the stream sends the same. */
+    public Snapshot snapshot() {
+        Map<UUID, Optional<AgentSession>> sessionCache = new HashMap<>();
+        Map<UUID, Optional<AgentDefinition>> definitionCache = new HashMap<>();
+
+        List<TaskRecord> active = new ArrayList<>();
+        active.addAll(queue.byStatus(TaskStatus.RUNNING, QUERY_LIMIT));
+        active.addAll(queue.byStatus(TaskStatus.SUSPENDED, QUERY_LIMIT));
+        active.addAll(queue.byStatus(TaskStatus.QUEUED, QUERY_LIMIT));
+        active.sort(Comparator.comparing(TaskRecord::submittedAt, Comparator.nullsLast(Comparator.naturalOrder())));
+
+        List<TaskRecord> finished = new ArrayList<>();
+        finished.addAll(queue.byStatus(TaskStatus.COMPLETED, QUERY_LIMIT));
+        finished.addAll(queue.byStatus(TaskStatus.FAILED, QUERY_LIMIT));
+        finished.addAll(queue.byStatus(TaskStatus.CANCELLED, QUERY_LIMIT));
+        finished.sort(Comparator.comparing(TaskRecord::endedAt, Comparator.nullsLast(Comparator.reverseOrder())));
+        if (finished.size() > RECENT_LIMIT) finished = finished.subList(0, RECENT_LIMIT);
+
+        return new Snapshot(
+                active.stream().map(t -> view(t, sessionCache, definitionCache)).toList(),
+                finished.stream().map(t -> view(t, sessionCache, definitionCache)).toList(),
+                Instant.now());
+    }
+
+    private TaskView view(TaskRecord task,
+                          Map<UUID, Optional<AgentSession>> sessionCache,
+                          Map<UUID, Optional<AgentDefinition>> definitionCache) {
+        UUID sessionId = uuid(task.payload().get(AgentTurnWorker.SESSION_ID));
+        Optional<AgentSession> session = sessionId == null
+                ? Optional.empty()
+                : sessionCache.computeIfAbsent(sessionId, this::findSession);
+        Optional<AgentDefinition> agent = session
+                .map(AgentSession::agentDefinitionId)
+                .flatMap(id -> definitionCache.computeIfAbsent(id, this::findDefinition));
+
+        String agentName = agent.map(AgentDefinition::name).orElse(null);
+        String label;
+        String detail;
+        if (AgentTurnWorker.TYPE.equals(task.type())) {
+            label = agentName == null ? "Agent turn" : agentName;
+            detail = describeTurn(task, session.orElse(null));
+        } else if (ToolCallWorker.TYPE.equals(task.type())) {
+            Object toolName = task.payload().get(ToolCallWorker.TOOL_NAME);
+            label = toolName == null ? "Tool call" : String.valueOf(toolName);
+            detail = agentName == null ? "tool call" : "tool call by " + agentName;
+        } else {
+            label = task.type();
+            detail = null;
+        }
+        String owner = session.map(AgentSession::userId).orElse(null);
+        return new TaskView(task, label, detail, owner, sessionId);
+    }
+
+    private static String describeTurn(TaskRecord task, AgentSession session) {
+        StringBuilder out = new StringBuilder();
+        int depth = ((Number) task.payload().getOrDefault(AgentTurnWorker.DEPTH, 0)).intValue();
+        out.append(depth == 0 ? "turn" : "sub-agent turn (depth " + depth + ")");
+        if (session != null && session.title() != null && !session.title().isBlank()) {
+            out.append(" · ").append(session.title());
+        }
+        Object rounds = task.state().get("rounds");
+        if (rounds != null) out.append(" · round ").append(rounds);
+        return out.toString();
+    }
+
+    private Optional<AgentSession> findSession(UUID id) {
+        try {
+            return sessions.findById(id);
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<AgentDefinition> findDefinition(UUID id) {
+        try {
+            return definitions.findById(id);
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static UUID uuid(Object value) {
+        if (value == null) return null;
+        try {
+            return UUID.fromString(String.valueOf(value));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    // ── cancel ──────────────────────────────────────────────────────────────
+
+    /** Whether {@code userId} may cancel this task: their own, and not finished yet. */
+    public static boolean mayCancel(TaskView view, String userId) {
+        return view.active() && !view.task().cancelRequested()
+                && view.owner() != null && view.owner().equals(userId);
+    }
+
+    /**
+     * Cancels {@code taskId} on behalf of {@code userId}. The queue cascades
+     * to the task's children, so cancelling a turn takes its tool calls and
+     * sub-agents with it.
+     */
+    public CancelResult cancel(String taskId, String userId) {
+        Optional<TaskRecord> record = queue.get(taskId);
+        if (record.isEmpty()) return CancelResult.UNKNOWN;
+        if (record.get().status().terminal()) return CancelResult.ALREADY_FINISHED;
+        TaskView view = view(record.get(), new HashMap<>(), new HashMap<>());
+        if (view.owner() == null || !view.owner().equals(userId)) return CancelResult.NOT_OWNER;
+        return queue.cancel(taskId) ? CancelResult.CANCELLED : CancelResult.ALREADY_FINISHED;
+    }
+
+    // ── delivery ────────────────────────────────────────────────────────────
+
+    /**
+     * Subscribes a browser tab, live only: the page that opened the stream
+     * already shows the current board, so there is nothing to replay. Every
+     * snapshot from here on is rendered for {@code userId} and written as
+     * one {@code patch} frame.
+     */
+    public void attach(SseEmitter emitter, String userId) {
+        Subscription subscription = channel.subscribe(channel.lastSeq(),
+                event -> send(emitter, event.seq(), event.value(), userId));
+        Subscription previous = subscriptions.put(emitter, subscription);
+        if (previous != null) previous.close();
+    }
+
+    public void detach(SseEmitter emitter) {
+        Subscription subscription = subscriptions.remove(emitter);
+        if (subscription != null) subscription.close();
+    }
+
+    private void send(SseEmitter emitter, long seq, Snapshot snapshot, String userId) {
+        try {
+            UiPatch patch = TaskMonitorComponent.livePatch(snapshot, userId);
+            emitter.send(SseEmitter.event()
+                    .id(Long.toString(seq))
+                    .name("patch")
+                    .data(objectMapper.writeValueAsString(patch)));
+        } catch (Exception e) {
+            // The client went away, or the socket is broken. The heartbeat
+            // reaps it; the channel must not see the exception.
+            detach(emitter);
+        }
+    }
+
+    /** Keeps idle connections open and notices the ones that are gone. */
+    private void heartbeat() {
+        for (SseEmitter emitter : subscriptions.keySet()) {
+            try {
+                emitter.send(SseEmitter.event().comment("hb"));
+            } catch (Exception e) {
+                detach(emitter);
+            }
+        }
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
@@ -6,7 +6,11 @@ import ai.mindconnect.ui.model.UiHeader;
 import ai.mindconnect.ui.model.UiLink;
 import ai.mindconnect.ui.model.UiMenu;
 import ai.mindconnect.ui.model.UiMenuItem;
+import ai.mindconnect.ui.model.UiNode;
 import ai.mindconnect.ui.model.UiPage;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Builds the shared admin-ui chrome as a semantic-ui {@link UiAppShell}:
@@ -24,6 +28,8 @@ public final class AdminLayout {
     private final String userName;
     private final boolean authEnabled;
     private final String versionLabel;
+    private final UiNode taskBadge;
+    private final UiPage.ActiveStream taskStream;
 
     /**
      * @param userName    display name of the current user (e.g. {@code "mc_user"})
@@ -33,9 +39,22 @@ public final class AdminLayout {
      *                     when this is not a packaged build
      */
     public AdminLayout(String userName, boolean authEnabled, String versionLabel) {
+        this(userName, authEnabled, versionLabel, null, null);
+    }
+
+    /**
+     * @param taskBadge  the task-queue badge for the header, or null when the
+     *                   host has no task monitor
+     * @param taskStream the live feed behind the badge; put on every page so
+     *                   the SPA attaches once and keeps it across navigation
+     */
+    public AdminLayout(String userName, boolean authEnabled, String versionLabel,
+                       UiNode taskBadge, UiPage.ActiveStream taskStream) {
         this.userName = userName;
         this.authEnabled = authEnabled;
         this.versionLabel = versionLabel;
+        this.taskBadge = taskBadge;
+        this.taskStream = taskStream;
     }
 
     /**
@@ -53,7 +72,20 @@ public final class AdminLayout {
         UiPage out = UiPage.of(page.getNavigate(), shell);
         out.setToasts(page.getToasts());
         out.setDialogs(page.getDialogs());
-        out.setActiveStreams(page.getActiveStreams());
+        out.setActiveStreams(withTaskStream(page.getActiveStreams()));
+        return out;
+    }
+
+    /**
+     * The page's own streams (a chat session's, say) plus the task feed. The
+     * client opens a stream only when it has none under that channel id, so
+     * naming it on every page costs nothing after the first.
+     */
+    private List<UiPage.ActiveStream> withTaskStream(List<UiPage.ActiveStream> streams) {
+        if (taskStream == null) return streams;
+        List<UiPage.ActiveStream> out = streams == null ? new ArrayList<>() : new ArrayList<>(streams);
+        boolean present = out.stream().anyMatch(s -> taskStream.getChannelId().equals(s.getChannelId()));
+        if (!present) out.add(taskStream);
         return out;
     }
 
@@ -70,6 +102,11 @@ public final class AdminLayout {
         // not identity, so it sits beside the user widget rather than in it.
         // A click opens the About dialog with build time, commit, branch and
         // the changelog section of this build.
+        // The task badge sits left of the version: what the server is DOING,
+        // beside what the server IS. A click opens the task manager.
+        if (taskBadge != null) {
+            header.extra(taskBadge);
+        }
         if (versionLabel != null) {
             header.extra(UiAction.link("about-version", versionLabel)
                     .dispatch("GET", "/admin/api/about")

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
@@ -1,13 +1,13 @@
 package ai.mindconnect.adminui.ui;
 
 import ai.mindconnect.ui.model.UiAppShell;
-import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.ui.model.UiHeader;
 import ai.mindconnect.ui.model.UiLink;
 import ai.mindconnect.ui.model.UiMenu;
 import ai.mindconnect.ui.model.UiMenuItem;
 import ai.mindconnect.ui.model.UiNode;
 import ai.mindconnect.ui.model.UiPage;
+import ai.mindconnect.ui.model.UiTrigger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,8 +35,8 @@ public final class AdminLayout {
      * @param userName    display name of the current user (e.g. {@code "mc_user"})
      * @param authEnabled whether Keycloak auth is on; the logout link is shown
      *                    only then (with auth off the user is a fixed dev user)
-     * @param versionLabel the build's short version for the header, or null
-     *                     when this is not a packaged build
+     * @param versionLabel the build's short version for the sidebar's foot, or
+     *                     null when this is not a packaged build
      */
     public AdminLayout(String userName, boolean authEnabled, String versionLabel) {
         this(userName, authEnabled, versionLabel, null, null);
@@ -98,19 +98,12 @@ public final class AdminLayout {
         // logout), so it's a plain link, not a semantic-ui action. Shown only
         // when auth is enabled — with auth off there's a fixed dev user and
         // nothing to log out of.
-        // The build's version, small and muted, right of the brand: status,
-        // not identity, so it sits beside the user widget rather than in it.
-        // A click opens the About dialog with build time, commit, branch and
-        // the changelog section of this build.
-        // The task badge sits left of the version: what the server is DOING,
-        // beside what the server IS. A click opens the task manager.
+        // The task badge is the one live thing in the header: what the server
+        // is DOING right now, beside who is using it. A click opens the task
+        // manager. What the server IS — its version — lives at the foot of
+        // the sidebar (see buildMenu), where it is out of the way.
         if (taskBadge != null) {
             header.extra(taskBadge);
-        }
-        if (versionLabel != null) {
-            header.extra(UiAction.link("about-version", versionLabel)
-                    .dispatch("GET", "/admin/api/about")
-                    .withCssClass("sui-hint"));
         }
         if (authEnabled) {
             header.extra(UiLink.of("logout", "/admin/logout", "Logout"));
@@ -131,6 +124,14 @@ public final class AdminLayout {
         menu.item(navItem("nav-vector-stores", "Vector Stores", "/admin/vector-stores", "database", navigate));
         menu.item(navItem("nav-migrations", "Migrations", "/admin/migrations", "refresh", navigate));
         menu.item(navItem("nav-api", "API", "/admin/api-explorer", "code", navigate));
+        // The build's version as the last entry, pushed to the bottom by the
+        // stylesheet: small and muted, an info icon in the collapsed rail. A
+        // click opens the About dialog with build time, commit, branch and
+        // the changelog section of this build.
+        if (versionLabel != null) {
+            menu.item(UiMenuItem.of("nav-version", versionLabel).icon("info")
+                    .onClick(UiTrigger.api("GET", "/admin/api/about")));
+        }
         return menu;
     }
 

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
@@ -1,10 +1,15 @@
 package ai.mindconnect.adminui.ui;
 
+import ai.mindconnect.adminui.service.TaskMonitor;
+import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
+import ai.mindconnect.ui.model.UiPage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 /**
  * Builds a per-request {@link AdminLayout} from the current security context.
@@ -19,16 +24,26 @@ public class AdminLayoutFactory {
 
     private final boolean authEnabled;
     private final BuildInfo buildInfo;
+    /** Absent when the host runs no task queue; the header then has no badge. */
+    private final TaskMonitor taskMonitor;
 
     public AdminLayoutFactory(@Value("${mindconnect.auth.enabled:false}") boolean authEnabled,
-                              BuildInfo buildInfo) {
+                              BuildInfo buildInfo,
+                              Optional<TaskMonitor> taskMonitor) {
         this.authEnabled = authEnabled;
         this.buildInfo = buildInfo;
+        this.taskMonitor = taskMonitor.orElse(null);
     }
 
     /** Layout for the user currently in the {@link SecurityContextHolder}. */
     public AdminLayout current() {
-        return new AdminLayout(currentUserName(), authEnabled, buildInfo.label());
+        if (taskMonitor == null) {
+            return new AdminLayout(currentUserName(), authEnabled, buildInfo.label());
+        }
+        return new AdminLayout(currentUserName(), authEnabled, buildInfo.label(),
+                TaskMonitorComponent.badge(taskMonitor.counts()),
+                UiPage.ActiveStream.of(TaskMonitor.CHANNEL_ID, TaskMonitorComponent.STREAM_URL,
+                        "Task queue", "/admin/agents"));
     }
 
     private String currentUserName() {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/BuildInfo.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/BuildInfo.java
@@ -13,8 +13,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 /**
- * What this server build is, for the header's version label and the About
- * dialog behind it. Everything comes out of the jar: Spring Boot's
+ * What this server build is, for the version label at the foot of the sidebar
+ * and the About dialog behind it. Everything comes out of the jar: Spring Boot's
  * {@code META-INF/build-info.properties} (version, build time),
  * {@code git.properties} (commit, branch) and the repository's
  * {@code META-INF/CHANGELOG.md} — the admin-ui app packages all three. An IDE
@@ -46,10 +46,10 @@ public class BuildInfo {
     }
 
     /**
-     * The header label — short, because the header is: {@code v0.3.1} for a
-     * release, {@code 0.3.1-SNAPSHOT · dd8d540} for a snapshot. A branch
-     * build's branch is in the dialog; in the header it would take the room
-     * of the whole brand.
+     * The sidebar label — short, because the sidebar is: {@code v0.3.1} for
+     * a release, {@code 0.3.1-SNAPSHOT · dd8d540} for a snapshot. A branch
+     * build's branch is in the dialog; in the label it would not fit the
+     * menu's width.
      */
     public String label() {
         String version = version();

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponent.java
@@ -1,0 +1,233 @@
+package ai.mindconnect.adminui.ui.component;
+
+import ai.mindconnect.adminui.service.TaskMonitor;
+import ai.mindconnect.adminui.service.TaskMonitor.Counts;
+import ai.mindconnect.adminui.service.TaskMonitor.Snapshot;
+import ai.mindconnect.adminui.service.TaskMonitor.TaskView;
+import ai.mindconnect.taskqueue.TaskRecord;
+import ai.mindconnect.taskqueue.TaskStatus;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiNode;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiStack;
+import ai.mindconnect.ui.model.UiText;
+import ai.mindconnect.ui.model.UiTree;
+import ai.mindconnect.ui.model.UiTreeNode;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The task manager's two faces: the badge in the header (how many tasks run
+ * right now, a click opens the dialog) and the dialog body (the live task
+ * tree with per-task Cancel, plus what finished recently).
+ *
+ * <p>Both are rendered from one {@link Snapshot} and both are addressed by
+ * fixed ids, so the same {@link #livePatch} that the SSE stream sends can
+ * update the badge on every page and the dialog whenever it happens to be
+ * open — a REPLACE on the closed dialog's id finds no target and is dropped
+ * by the client, which is exactly right.
+ */
+public final class TaskMonitorComponent {
+
+    /** The badge's DOM id — equal to the stream channel id, see {@link TaskMonitor#CHANNEL_ID}. */
+    public static final String BADGE_ID = TaskMonitor.CHANNEL_ID;
+    public static final String DIALOG_ID = "task-monitor-dialog";
+    public static final String BODY_ID = "task-monitor-body";
+
+    public static final String OPEN_URL = "/admin/api/tasks";
+    public static final String CLOSE_URL = "/admin/api/tasks/close";
+    public static final String STREAM_URL = "/admin/api/tasks/sse";
+
+    private TaskMonitorComponent() { }
+
+    // ── header badge ────────────────────────────────────────────────────────
+
+    /**
+     * The header badge: an activity icon and "3 running" (or "idle"). The
+     * outer stack carries the stream channel id, which is what keeps the
+     * stream attached across navigation, and a class that says whether
+     * anything is going on so the stylesheet can light it up. (The link is
+     * wrapped because an action renders no class of its own.)
+     */
+    public static UiStack badge(Counts counts) {
+        String label = !counts.busy() ? "idle"
+                : counts.waiting() == 0 ? counts.running() + " running"
+                : counts.running() + " running · " + counts.waiting() + " waiting";
+        UiAction link = UiAction.link(BADGE_ID + "-link", label).icon("activity")
+                .dispatch("GET", OPEN_URL);
+        link.setTitle("Task queue — click to open the task manager");
+        UiStack badge = UiStack.of(BADGE_ID).direction(UiStack.Direction.HORIZONTAL).child(link);
+        badge.withCssClass("task-monitor-badge" + (counts.busy() ? " is-busy" : ""));
+        return badge;
+    }
+
+    public static UiStack badge(Snapshot snapshot) {
+        return badge(snapshot.counts());
+    }
+
+    // ── dialog ──────────────────────────────────────────────────────────────
+
+    /** The dialog body for {@code userId}: live tree, recent list, Close. */
+    public static UiStack body(Snapshot snapshot, String userId) {
+        UiStack body = UiStack.of(BODY_ID);
+        body.child(summary(snapshot));
+        body.child(activeTree(snapshot, userId));
+        body.child(recentList(snapshot));
+        body.child(UiAction.secondary("task-monitor-close", "Close").icon("close")
+                .dispatch("POST", CLOSE_URL));
+        return body;
+    }
+
+    /** One stream frame: badge on every page, dialog body when it is open. */
+    public static UiPatch livePatch(Snapshot snapshot, String userId) {
+        return UiPatch.of()
+                .patch(UiPatch.Operation.replace(BADGE_ID, badge(snapshot)))
+                .patch(UiPatch.Operation.replace(BODY_ID, body(snapshot, userId)));
+    }
+
+    private static UiText summary(Snapshot snapshot) {
+        String text = snapshot.active().isEmpty()
+                ? "The task queue is idle."
+                : snapshot.runningCount() + " running, " + snapshot.queuedCount() + " queued, "
+                  + snapshot.suspendedCount() + " suspended (waiting on sub-tasks).";
+        UiText summary = UiText.of("task-monitor-summary", text);
+        summary.withCssClass("sui-hint");
+        return summary;
+    }
+
+    /**
+     * Live tasks as a tree: a turn, under it the tool calls it dispatched,
+     * under a {@code run_agent} call the sub-agent's turn — the shape the
+     * queue's parent links already have. A task whose parent is not live
+     * any more (it finished first) is shown as a root.
+     */
+    private static UiTree activeTree(Snapshot snapshot, String userId) {
+        UiTree tree = UiTree.of("task-monitor-tree", "Running now");
+        tree.withCssClass("task-monitor-tree");
+        if (snapshot.active().isEmpty()) {
+            tree.node(UiTreeNode.of("task-monitor-none", "No task is running.").icon("check"));
+            return tree;
+        }
+        Map<String, UiTreeNode> nodes = new LinkedHashMap<>();
+        for (TaskView view : snapshot.active()) {
+            nodes.put(view.id(), node(view, userId, snapshot.at()));
+        }
+        for (TaskView view : snapshot.active()) {
+            UiTreeNode node = nodes.get(view.id());
+            String parent = view.task().parentTaskId();
+            if (parent != null && nodes.containsKey(parent)) {
+                nodes.get(parent).child(node);
+            } else {
+                tree.node(node);
+            }
+        }
+        return tree;
+    }
+
+    private static UiTreeNode node(TaskView view, String userId, Instant now) {
+        UiTreeNode node = UiTreeNode.of("task-" + view.id(), view.label())
+                .icon(icon(view.task()))
+                .open(true);
+        node.labelNode(row(view, userId, now));
+        node.withCssClass("task-monitor-node task-monitor-node--" + view.status().name().toLowerCase());
+        return node;
+    }
+
+    /** One row: name, what it does, status pill, owner, elapsed time, and Cancel when allowed. */
+    private static UiStack row(TaskView view, String userId, Instant now) {
+        UiStack row = UiStack.of("task-row-" + view.id())
+                .direction(UiStack.Direction.HORIZONTAL).gap(8);
+        row.withCssClass("task-monitor-row");
+        row.child(text("task-name-" + view.id(), view.label(), "task-monitor-name"));
+        if (view.detail() != null) {
+            row.child(text("task-detail-" + view.id(), view.detail(), "task-monitor-detail sui-hint"));
+        }
+        row.child(statusPill(view));
+        row.child(text("task-owner-" + view.id(), view.owner() == null ? "—" : view.owner(), "task-monitor-owner sui-hint"));
+        row.child(text("task-time-" + view.id(), elapsed(view.task(), now), "task-monitor-time sui-hint"));
+        if (TaskMonitor.mayCancel(view, userId)) {
+            row.child(UiAction.danger("task-cancel-" + view.id(), "Cancel").icon("ban")
+                    .appearance(UiAction.Appearance.ICON)
+                    .confirm("Cancel '" + view.label() + "'? Its sub-tasks are cancelled with it.")
+                    .dispatch("POST", cancelUrl(view.id())));
+        }
+        return row;
+    }
+
+    private static UiText statusPill(TaskView view) {
+        TaskRecord task = view.task();
+        String label = task.cancelRequested() && !task.status().terminal()
+                ? "cancelling"
+                : task.status().name().toLowerCase();
+        if (task.attempt() > 1 && !task.status().terminal()) label += " · attempt " + task.attempt();
+        return text("task-status-" + view.id(), label,
+                "task-monitor-status task-monitor-status--" + task.status().name().toLowerCase());
+    }
+
+    /** What finished last — a failure's reason is the thing one opens this for. */
+    private static UiNode recentList(Snapshot snapshot) {
+        UiTree list = UiTree.of("task-monitor-recent", "Finished recently");
+        list.withCssClass("task-monitor-tree task-monitor-recent");
+        if (snapshot.recent().isEmpty()) {
+            list.node(UiTreeNode.of("task-monitor-recent-none", "Nothing has finished yet."));
+            return list;
+        }
+        for (TaskView view : snapshot.recent()) {
+            UiTreeNode node = UiTreeNode.of("task-" + view.id(), view.label()).icon(icon(view.task()));
+            node.labelNode(row(view, null, snapshot.at()));
+            node.withCssClass("task-monitor-node task-monitor-node--" + view.status().name().toLowerCase());
+            if (view.task().failure() != null && view.task().failure().message() != null) {
+                node.content(text("task-failure-" + view.id(), view.task().failure().message(), "task-monitor-failure"));
+                node.open(false);
+            }
+            list.node(node);
+        }
+        return list;
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    public static String cancelUrl(String taskId) {
+        return OPEN_URL + "/" + java.net.URLEncoder.encode(taskId, java.nio.charset.StandardCharsets.UTF_8) + "/cancel";
+    }
+
+    private static UiText text(String id, String value, String cssClass) {
+        UiText text = UiText.of(id, value);
+        text.withCssClass(cssClass);
+        return text;
+    }
+
+    private static String icon(TaskRecord task) {
+        return switch (task.type()) {
+            case "agent.turn" -> "bot";
+            case "agent.tool" -> "wrench";
+            default -> "activity";
+        };
+    }
+
+    /** "12s", "3m 05s", "1h 02m" — since the task started, or since it was submitted while it waits. */
+    static String elapsed(TaskRecord task, Instant now) {
+        Instant from = task.startedAt() != null ? task.startedAt() : task.submittedAt();
+        if (from == null) return "";
+        Instant to = task.endedAt() != null ? task.endedAt() : now;
+        Duration d = Duration.between(from, to);
+        if (d.isNegative()) d = Duration.ZERO;
+        long h = d.toHours(), m = d.toMinutesPart(), s = d.toSecondsPart();
+        String text = h > 0 ? String.format("%dh %02dm", h, m)
+                : m > 0 ? String.format("%dm %02ds", m, s)
+                : s + "s";
+        return task.status() == TaskStatus.QUEUED && task.startedAt() == null ? "waiting " + text : text;
+    }
+
+    /** Ids of every live task, root first — handy for tests and logs. */
+    static List<String> order(Snapshot snapshot) {
+        List<String> ids = new ArrayList<>();
+        for (TaskView v : snapshot.active()) ids.add(v.id());
+        return ids;
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponent.java
@@ -13,6 +13,7 @@ import ai.mindconnect.ui.model.UiStack;
 import ai.mindconnect.ui.model.UiText;
 import ai.mindconnect.ui.model.UiTree;
 import ai.mindconnect.ui.model.UiTreeNode;
+import ai.mindconnect.ui.model.UiTrigger;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -51,17 +52,29 @@ public final class TaskMonitorComponent {
      * The header badge: an activity icon and "3 running" (or "idle"). The
      * outer stack carries the stream channel id, which is what keeps the
      * stream attached across navigation, and a class that says whether
-     * anything is going on so the stylesheet can light it up. (The link is
-     * wrapped because an action renders no class of its own.)
+     * anything is going on so the stylesheet can light it up.
+     *
+     * <p>The count is deliberately a sibling of the button, not its label.
+     * The button keeps focus after the click that opens the dialog, and the
+     * morpher leaves the children of the focused element alone (Idiomorph's
+     * {@code ignoreActiveValue}, meant for a field someone is typing in) —
+     * a count inside the button would freeze at the value it had when the
+     * dialog was opened. A span is never focused, so it always updates. The
+     * whole pill is clickable through the stack's own trigger; the button is
+     * what a keyboard reaches.
      */
     public static UiStack badge(Counts counts) {
         String label = !counts.busy() ? "idle"
                 : counts.waiting() == 0 ? counts.running() + " running"
                 : counts.running() + " running · " + counts.waiting() + " waiting";
-        UiAction link = UiAction.link(BADGE_ID + "-link", label).icon("activity")
+        UiAction open = UiAction.link(BADGE_ID + "-link", "Task queue").icon("activity")
+                .appearance(UiAction.Appearance.ICON)
                 .dispatch("GET", OPEN_URL);
-        link.setTitle("Task queue — click to open the task manager");
-        UiStack badge = UiStack.of(BADGE_ID).direction(UiStack.Direction.HORIZONTAL).child(link);
+        UiStack badge = UiStack.of(BADGE_ID).direction(UiStack.Direction.HORIZONTAL).gap(4)
+                .child(open)
+                .child(text(BADGE_ID + "-count", label, "task-monitor-count"));
+        badge.setOnClick(UiTrigger.api("GET", OPEN_URL));
+        badge.setTitle("Task queue — click to open the task manager");
         badge.withCssClass("task-monitor-badge" + (counts.busy() ? " is-busy" : ""));
         return badge;
     }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AboutUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AboutUiController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * The About dialog behind the header's version label: what build this is
+ * The About dialog behind the version label at the foot of the sidebar: what build this is
  * and what it changes. Opened and closed as patches on the body-level dialog
  * host, the same way the tool-test dialog works — the page underneath is
  * left alone.

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/TaskMonitorUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/TaskMonitorUiController.java
@@ -1,0 +1,92 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.adminui.service.TaskMonitor;
+import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
+import ai.mindconnect.ui.model.UiDialog;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiToast;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * The task manager behind the header's task badge. The dialog opens and
+ * closes as patches on the body-level dialog host, like About; while it is
+ * open the stream every page carries ({@code /sse}) keeps it current, so
+ * there is no refresh button and nothing to poll.
+ */
+@RestController
+@RequestMapping(TaskMonitorComponent.OPEN_URL)
+public class TaskMonitorUiController {
+
+    private final TaskMonitor monitor;
+
+    public TaskMonitorUiController(TaskMonitor monitor) {
+        this.monitor = monitor;
+    }
+
+    /** Opens the dialog with the board as it is right now. */
+    @GetMapping
+    public UiPatch open(@AuthenticationPrincipal OidcUser user) {
+        UiDialog dialog = UiDialog.of("Task queue", null,
+                TaskMonitorComponent.body(monitor.snapshot(), userId(user)));
+        dialog.setId(TaskMonitorComponent.DIALOG_ID);
+        return UiPatch.of()
+                .patch(UiPatch.Operation.remove(TaskMonitorComponent.DIALOG_ID))
+                .patch(UiPatch.Operation.append("sui-dialogs", dialog));
+    }
+
+    @PostMapping("/close")
+    public UiPatch close() {
+        return UiPatch.of().patch(UiPatch.Operation.remove(TaskMonitorComponent.DIALOG_ID));
+    }
+
+    /**
+     * Cancels one task — the caller's own only. The board itself is not
+     * re-sent here: the cancel is a queue transition, and the stream delivers
+     * the resulting snapshot to every tab, this one included.
+     */
+    @PostMapping("/{taskId}/cancel")
+    public UiPatch cancel(@PathVariable String taskId, @AuthenticationPrincipal OidcUser user) {
+        TaskMonitor.CancelResult result = monitor.cancel(taskId, userId(user));
+        UiToast toast = switch (result) {
+            case CANCELLED -> UiToast.success("Cancel requested. A running task stops at its next checkpoint.");
+            case NOT_OWNER -> UiToast.error("Only the user a task belongs to can cancel it.");
+            case ALREADY_FINISHED -> UiToast.info("That task has already finished.");
+            case UNKNOWN -> UiToast.error("No such task — it may have been cleared.");
+        };
+        return UiPatch.of().toast(toast);
+    }
+
+    /**
+     * The live feed the SPA attaches to from every admin page (see
+     * {@code AdminLayout}): one {@code patch} frame per change of the board,
+     * rendered for the user on this connection. Live only — the page that
+     * opened it already shows the current state.
+     */
+    @GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> stream(@AuthenticationPrincipal OidcUser user) {
+        SseEmitter emitter = new SseEmitter(0L);
+        monitor.attach(emitter, userId(user));
+        emitter.onCompletion(() -> monitor.detach(emitter));
+        emitter.onError(t -> monitor.detach(emitter));
+        emitter.onTimeout(() -> monitor.detach(emitter));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Sui-Stream-Channel", TaskMonitor.CHANNEL_ID);
+        headers.add("Sui-Stream-Label", "Task queue");
+        return ResponseEntity.ok().headers(headers).body(emitter);
+    }
+
+    private static String userId(OidcUser user) {
+        return user == null ? "mc_user" : user.getPreferredUsername();
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -659,3 +659,87 @@ body {
     cursor: pointer;
 }
 .group-picker-toggle:hover { border-color: var(--sui-color-border-strong); }
+
+/* ── Task manager: header badge + dialog ──────────────────────────────── */
+
+/* The badge is a header link whose text is the live count ("3 running").
+   Idle it reads as a muted label; busy it gets the accent colour and a dot
+   that pulses, so a glance at any page says whether the queue is working. */
+.task-monitor-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--sui-color-border, #e5e7eb);
+    color: var(--sui-color-text-muted);
+    font-size: var(--sui-text-xs, 12px);
+    white-space: nowrap;
+}
+.task-monitor-badge .sui-link {
+    color: inherit;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.task-monitor-badge.is-busy {
+    color: var(--sui-color-primary, #2563eb);
+    border-color: var(--sui-color-primary, #2563eb);
+}
+.task-monitor-badge.is-busy::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    animation: task-monitor-pulse 1.4s ease-in-out infinite;
+}
+@keyframes task-monitor-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.25; }
+}
+
+/* Dialog: one line per task — name, what it does, status pill, owner,
+   elapsed, Cancel. The pill colours follow the queue's lifecycle. */
+#task-monitor-dialog .sui-dialog { min-width: min(880px, 96vw); }
+.task-monitor-row { align-items: center; flex-wrap: wrap; }
+.task-monitor-row .sui-text { margin: 0; }
+.task-monitor-name { font-weight: 600; }
+.task-monitor-detail { flex: 1 1 auto; }
+.task-monitor-owner::before { content: "@"; }
+.task-monitor-time { font-variant-numeric: tabular-nums; }
+.task-monitor-status {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-size: var(--sui-text-xs, 12px);
+    font-weight: 500;
+    line-height: 1.6;
+    white-space: nowrap;
+    border: 1px solid var(--sui-color-border, #e5e7eb);
+    color: var(--sui-color-text-muted);
+}
+.task-monitor-status--running {
+    background: var(--sui-color-success-bg, #dcfce7);
+    color: var(--sui-color-success, #15803d);
+    border-color: var(--sui-color-success-border, #86efac);
+}
+.task-monitor-status--queued,
+.task-monitor-status--suspended {
+    background: var(--sui-color-warn-bg, #fef3c7);
+    color: var(--sui-color-warn, #92400e);
+    border-color: var(--sui-color-warn-border, #fcd34d);
+}
+.task-monitor-status--failed {
+    background: var(--sui-color-error-bg, #fee2e2);
+    color: var(--sui-color-error, #991b1b);
+    border-color: var(--sui-color-error-border, #fca5a5);
+}
+.task-monitor-failure {
+    font-family: var(--sui-font-mono, ui-monospace, monospace);
+    font-size: var(--sui-text-xs, 12px);
+    white-space: pre-wrap;
+    color: var(--sui-color-error, #991b1b);
+}
+.task-monitor-recent .sui-tree-node { opacity: 0.8; }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -676,13 +676,16 @@ body {
     font-size: var(--sui-text-xs, 12px);
     white-space: nowrap;
 }
-.task-monitor-badge .sui-link {
+.task-monitor-badge { cursor: pointer; }
+/* The icon button is the keyboard target; visually it is just the icon. */
+.task-monitor-badge .sui-icon-btn {
+    border: none;
+    background: none;
+    padding: 0;
     color: inherit;
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
+    line-height: 1;
 }
+.task-monitor-count { font-size: inherit; }
 .task-monitor-badge.is-busy {
     color: var(--sui-color-primary, #2563eb);
     border-color: var(--sui-color-primary, #2563eb);

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -660,6 +660,28 @@ body {
 }
 .group-picker-toggle:hover { border-color: var(--sui-color-border-strong); }
 
+/* ── Sidebar foot: the build's version ─────────────────────────────────── */
+
+/* The version is the menu's last entry, pushed to the very bottom: the list
+   takes the sidebar's spare height and the entry sits on its far end. Small
+   and muted — status, not navigation; the rail shows its info icon with the
+   version as the hover tip, like any other entry. */
+.sui-menu > .sui-menu-list { flex: 1; }
+#nav-version { margin-top: auto; }
+#nav-version .sui-menu-link {
+    font-size: var(--sui-text-xs, 12px);
+    color: var(--sui-color-text-muted);
+    align-items: flex-start;
+}
+/* A snapshot's "0.4.1-SNAPSHOT · e87cc00" is wider than the menu: wrap it
+   onto a second line rather than losing the commit behind an ellipsis. */
+#nav-version .sui-menu-label {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    line-height: 1.4;
+}
+
 /* ── Task manager: header badge + dialog ──────────────────────────────── */
 
 /* The badge is a header link whose text is the live count ("3 running").

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/TaskMonitorTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/TaskMonitorTest.java
@@ -1,0 +1,157 @@
+package ai.mindconnect.adminui.service;
+
+import ai.mindconnect.adminui.service.TaskMonitor.CancelResult;
+import ai.mindconnect.adminui.service.TaskMonitor.Snapshot;
+import ai.mindconnect.adminui.service.TaskMonitor.TaskView;
+import ai.mindconnect.agent.adapter.repo.memory.InMemoryAgentDefinitionRepository;
+import ai.mindconnect.agent.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.domain.AgentDefinition;
+import ai.mindconnect.agent.domain.AgentDefinitionStatus;
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.SessionStatus;
+import ai.mindconnect.agent.service.task.AgentTurnWorker;
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.taskqueue.TaskOutcome;
+import ai.mindconnect.taskqueue.TaskStatus;
+import ai.mindconnect.taskqueue.TaskSubmission;
+import ai.mindconnect.taskqueue.local.LocalTaskQueue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The monitor against a real {@link LocalTaskQueue}: a task that runs for
+ * someone shows up under their name, only they may cancel it, and the
+ * cancel reaches the worker. The stream side is exercised through a
+ * capturing emitter — a transition on the queue ends as one patch frame on
+ * every attached connection.
+ */
+class TaskMonitorTest {
+
+    private static final Namespace NS = new Namespace("local");
+    private static final UUID AGENT_ID = UUID.randomUUID();
+    private static final UUID ALICE_SESSION = UUID.randomUUID();
+
+    private LocalTaskQueue queue;
+    private TaskMonitor monitor;
+    private final CountDownLatch started = new CountDownLatch(1);
+    private final CountDownLatch release = new CountDownLatch(1);
+
+    @BeforeEach
+    void setUp() {
+        queue = new LocalTaskQueue(new ai.mindconnect.taskqueue.memory.InMemoryTaskStore());
+        // A stand-in for the agent turn: blocks until released or cancelled,
+        // so the task is observably RUNNING while the test looks at it.
+        queue.register(AgentTurnWorker.TYPE, ctx -> {
+            started.countDown();
+            try {
+                while (!ctx.cancelRequested() && !release.await(20, TimeUnit.MILLISECONDS)) {
+                    // spin on the cooperative flag
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return TaskOutcome.done("ok");
+        });
+
+        var definitions = new InMemoryAgentDefinitionRepository();
+        definitions.save(new AgentDefinition(AGENT_ID, NS, "Scout", "A test agent",
+                "assistants", "bot", "prompt", null, "cfg", 5, null,
+                AgentDefinitionStatus.ACTIVE, List.of(), List.of(), null, null, null, null));
+        var sessions = new InMemoryAgentSessionRepository();
+        sessions.save(new AgentSession(ALICE_SESSION, AGENT_ID, NS, "alice", UUID.randomUUID(),
+                "Alice asks", SessionStatus.ACTIVE, Instant.now(), null,
+                null, null, null, null, null, null, null));
+
+        monitor = new TaskMonitor(queue, sessions, definitions, new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() {
+        release.countDown();
+        monitor.shutdown();
+        queue.close();
+    }
+
+    private String submitTurn() {
+        return queue.submit(TaskSubmission.of(AgentTurnWorker.TYPE,
+                Map.of(AgentTurnWorker.SESSION_ID, ALICE_SESSION.toString(), AgentTurnWorker.DEPTH, 0)));
+    }
+
+    @Test
+    void aRunningTurnIsListedUnderItsAgentAndOwner() throws Exception {
+        String id = submitTurn();
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+
+        Snapshot snapshot = monitor.snapshot();
+        assertThat(snapshot.active()).extracting(TaskView::id).containsExactly(id);
+        TaskView view = snapshot.active().get(0);
+        assertThat(view.status()).isEqualTo(TaskStatus.RUNNING);
+        assertThat(view.label()).isEqualTo("Scout");
+        assertThat(view.owner()).isEqualTo("alice");
+        assertThat(view.detail()).contains("turn").contains("Alice asks");
+        assertThat(monitor.counts().running()).isEqualTo(1);
+        assertThat(monitor.counts().busy()).isTrue();
+    }
+
+    @Test
+    void onlyTheOwnerCancelsAndTheCancelReachesTheWorker() throws Exception {
+        String id = submitTurn();
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(monitor.cancel(id, "bob")).isEqualTo(CancelResult.NOT_OWNER);
+        assertThat(queue.get(id).orElseThrow().status()).isEqualTo(TaskStatus.RUNNING);
+
+        assertThat(monitor.cancel(id, "alice")).isEqualTo(CancelResult.CANCELLED);
+        assertThat(queue.await(id, Duration.ofSeconds(5)).status()).isEqualTo(TaskStatus.CANCELLED);
+
+        assertThat(monitor.cancel(id, "alice")).isEqualTo(CancelResult.ALREADY_FINISHED);
+        assertThat(monitor.cancel("no-such-task", "alice")).isEqualTo(CancelResult.UNKNOWN);
+        assertThat(monitor.snapshot().recent()).extracting(TaskView::id).containsExactly(id);
+        assertThat(monitor.counts().busy()).isFalse();
+    }
+
+    @Test
+    void aTransitionBecomesOnePatchFrameOnEveryAttachedStream() throws Exception {
+        var frames = new CopyOnWriteArrayList<String>();
+        var arrived = new CountDownLatch(1);
+        SseEmitter emitter = new SseEmitter(0L) {
+            @Override
+            public void send(SseEventBuilder builder) {
+                // The builder's data parts are the JSON; join them into one frame.
+                frames.add(builder.build().stream()
+                        .map(part -> String.valueOf(part.getData()))
+                        .collect(java.util.stream.Collectors.joining()));
+                arrived.countDown();
+            }
+        };
+        monitor.attach(emitter, "alice");
+
+        String id = submitTurn();
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(arrived.await(5, TimeUnit.SECONDS))
+                .as("the submit/start burst is debounced into a frame")
+                .isTrue();
+
+        String frame = frames.get(0);
+        assertThat(frame).contains("\"targetId\":\"" + TaskMonitor.CHANNEL_ID + "\"");
+        assertThat(frame).contains("task-" + id);
+        // rendered for alice: her task carries its Cancel
+        assertThat(frame).contains("/admin/api/tasks/" + id + "/cancel");
+
+        monitor.detach(emitter);
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponentTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponentTest.java
@@ -1,0 +1,123 @@
+package ai.mindconnect.adminui.ui.component;
+
+import ai.mindconnect.adminui.service.TaskMonitor;
+import ai.mindconnect.adminui.service.TaskMonitor.Snapshot;
+import ai.mindconnect.adminui.service.TaskMonitor.TaskView;
+import ai.mindconnect.taskqueue.TaskFailure;
+import ai.mindconnect.taskqueue.TaskRecord;
+import ai.mindconnect.taskqueue.TaskStatus;
+import ai.mindconnect.taskqueue.TaskSubmission;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The task manager is rendered per viewer: the tree is the same for
+ * everyone, the Cancel buttons are not. This pins the ownership rule, the
+ * tree shape (children under their parent) and the badge wording — and that
+ * the ids the live stream patches are the ids the components render with.
+ */
+class TaskMonitorComponentTest {
+
+    private static final Instant NOW = Instant.parse("2026-09-06T10:00:00Z");
+    private static final UUID SESSION = UUID.randomUUID();
+
+    private static TaskRecord queued(String id, String type, String parent) {
+        return TaskRecord.queued(id, TaskSubmission.of(type, Map.of("sessionId", SESSION.toString()))
+                .withParent(parent));
+    }
+
+    private static TaskView view(TaskRecord task, String label, String owner) {
+        return new TaskView(task, label, null, owner, SESSION);
+    }
+
+    private static Snapshot board() {
+        TaskRecord turn = queued("task_turn_1", "agent.turn", null).claimed("node-1");
+        TaskRecord tool = queued("task_tool_1_a", "agent.tool", "task_turn_1").claimed("node-1");
+        TaskRecord other = queued("task_turn_2", "agent.turn", null);
+        TaskRecord failed = queued("task_turn_0", "agent.turn", null).claimed("node-1")
+                .failed(TaskFailure.of("boom", 1));
+        return new Snapshot(
+                List.of(view(turn, "Scout", "alice"), view(tool, "web_search", "alice"), view(other, "Scout", "bob")),
+                List.of(view(failed, "Scout", "alice")),
+                NOW);
+    }
+
+    private static String json(Object node) throws Exception {
+        return new ObjectMapper().writeValueAsString(node);
+    }
+
+    @Test
+    void cancelIsOfferedForOwnLiveTasksOnly() throws Exception {
+        String alice = json(TaskMonitorComponent.body(board(), "alice"));
+        assertThat(alice).contains(TaskMonitorComponent.cancelUrl("task_turn_1"));
+        assertThat(alice).contains(TaskMonitorComponent.cancelUrl("task_tool_1_a"));
+        assertThat(alice).doesNotContain(TaskMonitorComponent.cancelUrl("task_turn_2"));
+        // finished: nothing left to cancel, whoever looks
+        assertThat(alice).doesNotContain(TaskMonitorComponent.cancelUrl("task_turn_0"));
+
+        String bob = json(TaskMonitorComponent.body(board(), "bob"));
+        assertThat(bob).contains(TaskMonitorComponent.cancelUrl("task_turn_2"));
+        assertThat(bob).doesNotContain(TaskMonitorComponent.cancelUrl("task_turn_1"));
+    }
+
+    @Test
+    void aCancelAlreadyRequestedIsNotOfferedAgain() {
+        TaskRecord cancelling = queued("t", "agent.turn", null).claimed("n").withCancelRequested();
+        assertThat(TaskMonitor.mayCancel(view(cancelling, "Scout", "alice"), "alice")).isFalse();
+        assertThat(TaskMonitor.mayCancel(view(queued("t", "agent.turn", null), "Scout", null), "alice"))
+                .as("a task without a resolvable owner belongs to nobody")
+                .isFalse();
+    }
+
+    @Test
+    void toolCallsNestUnderTheirTurn() throws Exception {
+        String body = json(TaskMonitorComponent.body(board(), "alice"));
+        // The tool's node is inside the turn's node, so it appears after it
+        // and before the second root.
+        int turn = body.indexOf("\"id\":\"task-task_turn_1\"");
+        int tool = body.indexOf("\"id\":\"task-task_tool_1_a\"");
+        int other = body.indexOf("\"id\":\"task-task_turn_2\"");
+        assertThat(turn).isLessThan(tool);
+        assertThat(tool).isLessThan(other);
+        assertThat(body).contains("\"id\":\"" + TaskMonitorComponent.BODY_ID + "\"");
+        assertThat(body).contains("boom");
+    }
+
+    @Test
+    void badgeCountsRunningAndWaiting() throws Exception {
+        String busy = json(TaskMonitorComponent.badge(board()));
+        assertThat(busy).contains("\"label\":\"2 running · 1 waiting\"");
+        assertThat(busy).contains("is-busy");
+        assertThat(busy).contains("\"id\":\"" + TaskMonitor.CHANNEL_ID + "\"");
+        assertThat(busy).contains("\"url\":\"" + TaskMonitorComponent.OPEN_URL + "\"");
+        assertThat(busy).contains("\"id\":\"" + TaskMonitor.CHANNEL_ID + "-link\"");
+
+        String idle = json(TaskMonitorComponent.badge(new Snapshot(List.of(), List.of(), NOW)));
+        assertThat(idle).contains("\"label\":\"idle\"");
+        assertThat(idle).doesNotContain("is-busy");
+    }
+
+    @Test
+    void theLivePatchTargetsTheBadgeAndTheDialogBody() throws Exception {
+        String patch = json(TaskMonitorComponent.livePatch(board(), "alice"));
+        assertThat(patch).contains("\"targetId\":\"" + TaskMonitor.CHANNEL_ID + "\"");
+        assertThat(patch).contains("\"targetId\":\"" + TaskMonitorComponent.BODY_ID + "\"");
+    }
+
+    @Test
+    void elapsedReadsLikeAClock() {
+        TaskRecord waiting = queued("t", "agent.turn", null);
+        assertThat(TaskMonitorComponent.elapsed(waiting, waiting.submittedAt().plusSeconds(5))).isEqualTo("waiting 5s");
+        TaskRecord running = waiting.claimed("n");
+        assertThat(TaskMonitorComponent.elapsed(running, running.startedAt().plusSeconds(125))).isEqualTo("2m 05s");
+        assertThat(TaskMonitorComponent.elapsed(running, running.startedAt().plusSeconds(3725))).isEqualTo("1h 02m");
+        assertThat(running.status()).isEqualTo(TaskStatus.RUNNING);
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponentTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponentTest.java
@@ -93,15 +93,30 @@ class TaskMonitorComponentTest {
     @Test
     void badgeCountsRunningAndWaiting() throws Exception {
         String busy = json(TaskMonitorComponent.badge(board()));
-        assertThat(busy).contains("\"label\":\"2 running · 1 waiting\"");
+        assertThat(busy).contains("\"text\":\"2 running · 1 waiting\"");
         assertThat(busy).contains("is-busy");
         assertThat(busy).contains("\"id\":\"" + TaskMonitor.CHANNEL_ID + "\"");
         assertThat(busy).contains("\"url\":\"" + TaskMonitorComponent.OPEN_URL + "\"");
         assertThat(busy).contains("\"id\":\"" + TaskMonitor.CHANNEL_ID + "-link\"");
 
         String idle = json(TaskMonitorComponent.badge(new Snapshot(List.of(), List.of(), NOW)));
-        assertThat(idle).contains("\"label\":\"idle\"");
+        assertThat(idle).contains("\"text\":\"idle\"");
         assertThat(idle).doesNotContain("is-busy");
+    }
+
+    /**
+     * The count must never sit inside the button: the button keeps focus
+     * after the click that opens the dialog, and the morpher skips the
+     * children of the focused element, so a count in there would go stale.
+     */
+    @Test
+    void theCountLivesOutsideTheFocusableButton() {
+        var badge = TaskMonitorComponent.badge(board());
+        var button = (ai.mindconnect.ui.model.UiAction) badge.getChildren().get(0);
+        var count = (ai.mindconnect.ui.model.UiText) badge.getChildren().get(1);
+        assertThat(button.getLabel()).isEqualTo("Task queue");
+        assertThat(count.getText()).isEqualTo("2 running · 1 waiting");
+        assertThat(badge.getOnClick().getUrl()).isEqualTo(TaskMonitorComponent.OPEN_URL);
     }
 
     @Test

--- a/website/docs/agents/admin-ui/index.md
+++ b/website/docs/agents/admin-ui/index.md
@@ -114,6 +114,32 @@ The navigation has seven top-level entries:
 | **[Migrations](./migrations.md)** | Review and apply changes to the bundled seed data (agents, LLM configs, workflows). |
 | **API** | Embedded Swagger UI for the REST API under `/api/**`. |
 
+## The task manager
+
+The header carries a small badge that says what the task queue is doing right
+now — `3 running · 2 waiting`, or `idle`. It is live: the page attaches to a
+server-sent event stream (`/admin/api/tasks/sse`) once, and the stream stays
+attached while you navigate, so the count is current on every page without
+polling.
+
+A click on the badge opens the task queue, the admin UI's Task Manager:
+
+- **Running now** — the live tasks as a tree, the way the queue links them:
+  a chat turn, under it the tool calls it dispatched, and under a `run_agent`
+  call the sub-agent's turn. Every row shows the agent or tool, what it is
+  doing (session title, round), the status (`running`, `queued`, `suspended`
+  while a turn waits on its sub-tasks, `cancelling`), the user it belongs to
+  and how long it has been at it.
+- **Finished recently** — the last tasks that completed, failed or were
+  cancelled; a failed one opens to show the reason.
+- **Cancel** — the ban icon on a row. Cancel is cooperative (a running task
+  stops at its next checkpoint) and cascades: cancelling a turn takes its
+  tool calls and sub-agents with it. It is offered for **your own tasks
+  only** — the tasks whose session belongs to the signed-in user; other
+  users' tasks are visible but not cancellable.
+
+The dialog updates itself over the same stream while it is open.
+
 ## Related
 
 - [Environment variables](../environment-variables.md) — every variable you can


### PR DESCRIPTION
## What does this PR do?

Adds a task manager to the admin UI, the way Windows has one for processes.

- **Header badge.** A pill in the header says what the task queue is doing right now — `3 running · 2 waiting`, or `idle` — on every admin page. It is live: the layout names a server-sent event stream (`/admin/api/tasks/sse`) on every page, the SPA attaches to it once and keeps it across navigation because the badge element carries the stream's channel id. No polling.
- **Task queue dialog.** A click opens the queue: the live tasks as a tree the way the queue links them (a turn, the tool calls it dispatched, a sub-agent's turn under its `run_agent` call) with agent/tool, session title and round, status pill, owner and elapsed time; below it the tasks that finished last, a failed one opening to its reason; and a Cancel per task. The dialog updates itself over the same stream while open.
- **Cancel, own tasks only.** A task belongs to the user whose session it runs for (sub-agent sessions inherit the parent's user). Cancel is offered only to that user; other users' tasks are visible but not cancellable. The queue cascades the cancel through its parent links, so cancelling a turn takes its tool calls and sub-agents with it.
- **`TaskMonitor`** (`mc-agent-admin-ui-rest`) listens on the `LocalTaskQueue`, debounces a burst of transitions into one snapshot, and fans snapshots out over a `Channel` so a slow browser tab never slows the queue. Each connection is rendered for its own user, which is what decides whether a Cancel button appears.
- **Version label** moved from the header to the foot of the sidebar (an info icon in the collapsed rail; a click still opens About), so the header's right side is the task badge and the user.

One fix found on the way, in the second commit: the badge's count must not live inside the clickable button. The button keeps focus after the click that opens the dialog, and the framework's morpher (Idiomorph with `ignoreActiveValue`) leaves the children of the focused element alone — the count froze at the value it had when the dialog opened. The count is now a span next to an icon-only button; the whole pill stays clickable.

Endpoints: `GET /admin/api/tasks` (open), `POST …/close`, `POST …/{id}/cancel`, `GET …/sse`.

## Affected area

agent runtime (admin UI, `agents/server/mc-agent-admin-ui-rest`) · docs

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [x] I added/updated tests where it makes sense.
- [x] I updated docs/README if behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

Tests: `TaskMonitorComponentTest` (ownership rule, tree shape, badge wording, patch targets) and `TaskMonitorTest` against a real `LocalTaskQueue` (a running turn listed under its agent and owner, only the owner cancels and the cancel reaches the worker, a transition becomes one patch frame on an attached stream). Also verified end to end with a headless browser against the running app, with a fake LLM endpoint holding a turn for 20 seconds: badge `1 running` with the dialog open and closed, `idle` when the task ends, Cancel toasts, About from the sidebar entry.

## Related issues

—

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfmCGd5HsvHPXUKwP5ceWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfmCGd5HsvHPXUKwP5ceWp)_