### PR TITLE
fix: make branch version suffix importable in IntelliJ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,9 @@ mvn -f <module-path>/pom.xml clean install
 # Working on a branch: run this ONCE after creating (or checking out) the
 # branch. It writes the git-ignored .mvn/maven.config, and from then on every
 # build in this checkout installs as 0.x.y-<branch>-SNAPSHOT — parallel
-# branches never overwrite each other in the shared ~/.m2. Safe to re-run.
+# branches never overwrite each other in the shared ~/.m2. Safe to re-run;
+# re-run after pulling a version bump (it copies revision/changelist from
+# the root pom, which IntelliJ needs next to the sha1 suffix).
 ./after-branch-creation.sh
 
 # If you change a core/shared module, rebuild it before dependent modules

--- a/after-branch-creation.sh
+++ b/after-branch-creation.sh
@@ -8,9 +8,21 @@
 # each other in the one shared ~/.m2. The file is git-ignored: the pom is
 # identical on every branch, and nothing has to be undone before a merge.
 #
+# Why revision and changelist are written as well, although the pom defines
+# them: IntelliJ's Maven server interpolates <parent><version> in the raw pom
+# BEFORE the parent is looked up, with only the properties it already has —
+# maven.config and the module's own. With -Dsha1 alone that yields the half-
+# resolved "${revision}-feature-x${changelist}", which matches neither the
+# parent pom at relativePath nor anything in ~/.m2, and IntelliJ reports
+# "Non-resolvable parent POM ... 'parent.relativePath' points at wrong local
+# POM". Either none of the three placeholders is a user property, or all of
+# them are — so main gets no lines at all, and a branch gets all three, with
+# revision/changelist copied from the root pom. Re-run after pulling a version
+# bump, or the copy goes stale. (An empty -Dsha1= would not do for main either:
+# IntelliJ reads "-Dname=" as name=true.)
+#
 # Run it once after creating (or checking out) a branch, from anywhere inside
-# the repository. Safe to re-run. `main` gets an explicitly empty suffix, so a
-# clone that moves back to main builds the plain version again.
+# the repository. Safe to re-run.
 #
 #   ./after-branch-creation.sh              # suffix from the current branch
 #   ./after-branch-creation.sh fix/thing    # suffix for a branch by name
@@ -33,14 +45,35 @@ else
     sha1="-$(printf '%s' "$branch" | tr '/A-Z' '-a-z' | tr -c 'a-z0-9.\n-' '-')"
 fi
 
+# revision and changelist as the root pom currently defines them.
+pom_prop() { sed -n "s|.*<$1>\(.*\)</$1>.*|\1|p" "$root/pom.xml" | head -1; }
+revision=$(pom_prop revision)
+changelist=$(pom_prop changelist)
+if [ -z "$revision" ]; then
+    echo "after-branch-creation: no <revision> in $root/pom.xml" >&2
+    exit 1
+fi
+
 config="$root/.mvn/maven.config"
 mkdir -p "$root/.mvn"
-# Replace only our own line; other options someone put there stay.
-{ [ -f "$config" ] && grep -v '^-Dsha1=' "$config" || true; echo "-Dsha1=$sha1"; } > "$config.tmp"
+# Replace only our own lines; other options someone put there stay.
+{
+    [ -f "$config" ] && grep -v -e '^-Dsha1=' -e '^-Drevision=' -e '^-Dchangelist=' "$config" || true
+    if [ -n "$sha1" ]; then
+        printf -- '-Drevision=%s\n-Dchangelist=%s\n-Dsha1=%s\n' "$revision" "$changelist" "$sha1"
+    fi
+} > "$config.tmp"
 mv "$config.tmp" "$config"
 
 echo "branch:  $branch"
-echo "written: ${config#"$root"/}  ->  -Dsha1=$sha1"
+if [ -n "$sha1" ]; then
+    echo "written: ${config#"$root"/}  ->  -Drevision=$revision -Dchangelist=$changelist -Dsha1=$sha1"
+    if [ -z "$changelist" ]; then
+        echo "warning: <changelist> is empty in the root pom (release commit?); IntelliJ reads an empty -D value as 'true'" >&2
+    fi
+else
+    echo "written: ${config#"$root"/}  ->  no version suffix (main)"
+fi
 if version=$(cd "$root" && mvn -q -ntp help:evaluate -Dexpression=project.version -DforceStdout 2>/dev/null); then
     echo "version: $version"
 fi

--- a/mc-java-parent/pom.xml
+++ b/mc-java-parent/pom.xml
@@ -38,8 +38,9 @@
         <!-- CI-friendly version: Maven permits exactly these three placeholders in
              <version>. revision is the number, changelist is -SNAPSHOT or empty for a
              release, and sha1 - Maven's name, meant for a commit hash - is the one that
-             is free, so it carries the branch suffix: -Dsha1=-feature-x, written by
-             ./after-branch-creation.sh into the git-ignored .mvn/maven.config. -->
+             is free, so it carries the branch suffix: -Dsha1=-feature-x. On a branch,
+             ./after-branch-creation.sh writes all three into the git-ignored
+             .mvn/maven.config (IntelliJ needs all or none - see the script). -->
         <revision>0.4.2</revision>
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,9 @@
         <!-- CI-friendly version: Maven permits exactly these three placeholders in
              <version>. revision is the number, changelist is -SNAPSHOT or empty for a
              release, and sha1 - Maven's name, meant for a commit hash - is the one that
-             is free, so it carries the branch suffix: -Dsha1=-feature-x, written by
-             ./after-branch-creation.sh into the git-ignored .mvn/maven.config. -->
+             is free, so it carries the branch suffix: -Dsha1=-feature-x. On a branch,
+             ./after-branch-creation.sh writes all three into the git-ignored
+             .mvn/maven.config (IntelliJ needs all or none - see the script). -->
         <revision>0.4.2</revision>
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>


### PR DESCRIPTION
## Problem

Branch clones set up with `./after-branch-creation.sh` could not be imported in IntelliJ:

```
Non-resolvable parent POM for ai.mindconnect:mc-webscraper:${revision}-feature-content-parts${changelist}:
... 'parent.relativePath' points at wrong local POM
```

The CLI build was fine. IntelliJ's Maven server (`CustomModelValidator385`) interpolates `<parent><version>` in the raw pom *before* Maven looks the parent up, using only the properties it already has: `.mvn/maven.config` and the module's own. With `-Dsha1` alone that produces the half-resolved `${revision}-feature-x${changelist}`, which matches neither the raw version in the parent pom at `relativePath` nor anything in `~/.m2`. Maven falls back to repository resolution and caches the failure as `.lastUpdated`.

A second finding: IntelliJ's `MavenServerConfigUtil` reads an empty `-Dsha1=` as `sha1=true`, so the main checkout produced `${revision}true${changelist}` the same way.

## Fix

Either none of the three placeholders is a user property, or all of them are.

- `after-branch-creation.sh` now writes `-Drevision` and `-Dchangelist` (copied from the root pom) next to `-Dsha1` on a branch, and removes all three lines on `main`. Reasoning is in the script header.
- Comments in the two root poms and CLAUDE.md updated; CLAUDE.md notes that the script has to be re-run after pulling a version bump, because the copied revision goes stale otherwise.

## Verified

- `mvn help:evaluate -Dexpression=project.version` at root and in `common/mc-webscraper` still gives `0.4.2-<branch>-SNAPSHOT`.
- `./after-branch-creation.sh main` leaves an empty `maven.config` and version `0.4.2-SNAPSHOT`.
- Not yet verified in IntelliJ itself: the fix follows from reading `CustomModelValidator385` / `MavenServerConfigUtil` in intellij-community and Maven 3.9's `DefaultModelBuilder`. To test: delete the stale `${revision}…` directories in `~/.m2/repository/ai/mindconnect/mc-java-parent/`, re-run the script in a branch clone, reload the Maven project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
