### PR TITLE
Images and PDFs reach the model: content parts and LLM capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
   written before this field existed load as declaring nothing. The bundled
   cloud configs (`claude-*`, `openai-default`, `azure-openai-default`,
   `gemini-default`) declare their capabilities, the local ones
-  `TOOL_CALLING`; existing installs keep their stored configs unchanged.
-  `VISION` and `DOCUMENTS` decide what the next entry sends.
+  `TOOL_CALLING`. A config that declares nothing — every config written
+  before the field existed — takes its provider's default: Anthropic and
+  OpenAI read images and PDFs, Gemini also audio, Azure OpenAI images, local
+  servers and routers tool calling only; a declared set, empty included,
+  wins. `VISION` and `DOCUMENTS` decide what the next entry sends.
 - **agents:** images and PDFs reach the model. A message is made of content
   parts — its text plus the images and files sent with it, referenced by
   file-store id (`Message.parts`; the file store and Postgres carry them
@@ -63,6 +66,8 @@ fresh empty one, so nothing has to be moved by hand at release time.
   takes the target `LlmConfig` as a fifth argument, and a host's own
   mapper implementation has to add it. A user message that carries the
   open turn's id continues that turn instead of opening a new one.
+  `DELETE /api/sessions/{id}/files?file=` takes the file's name or its
+  ingested id, and no longer fails without a vector store.
 
 ## [0.4.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,40 @@ fresh empty one, so nothing has to be moved by hand at release time.
   `capabilities`, any of `TOOL_CALLING`, `VISION`, `DOCUMENTS`,
   `AUDIO_INPUT`. The Admin UI's chat-config form has a multiselect for it,
   the detail view shows it, the JSON (file store, Postgres, REST API,
-  bundled `initial-data` configs) carries it as a string array. It is a
-  declaration: callers ask `LlmConfig.supports(...)`, the runtime does not
-  derive its behaviour from it yet. Configs written before this field
-  existed load as declaring nothing. The bundled cloud configs
-  (`claude-*`, `openai-default`, `azure-openai-default`, `gemini-default`)
-  declare their capabilities, the local ones `TOOL_CALLING`; existing
-  installs keep their stored configs unchanged.
+  bundled `initial-data` configs) carries it as a string array. Configs
+  written before this field existed load as declaring nothing. The bundled
+  cloud configs (`claude-*`, `openai-default`, `azure-openai-default`,
+  `gemini-default`) declare their capabilities, the local ones
+  `TOOL_CALLING`; existing installs keep their stored configs unchanged.
+  `VISION` and `DOCUMENTS` decide what the next entry sends.
+- **agents:** images and PDFs reach the model. A message is made of content
+  parts — its text plus the images and files sent with it, referenced by
+  file-store id (`Message.parts`; the file store and Postgres carry them
+  without a migration, older messages read as text). An image or PDF
+  attached to a chat goes with the next user message as a part: a model
+  whose config declares `VISION` / `DOCUMENTS` gets it inline as the
+  provider's content block (OpenAI, Anthropic and Gemini gateways), any
+  other model a placeholder line saying what the file is and why it is not
+  there. Media is sent in the turn it belongs to only; afterwards the new
+  `view_attachment` tool — activated for the session on such an upload —
+  shows the file again as a message of its own. Images are no longer
+  ingested into the session's vector store (they were read as UTF-8 text);
+  the chat bubble shows the picture, the attached-files dialog says how
+  each file reaches the model. `POST /api/sessions/{id}/chat` takes a JSON
+  body `{message, parts:[{kind, fileId}]}` beside the plain-text one,
+  `GET /api/sessions/{id}/files` lists file id, media type, size and chunk
+  count per file, the protocol bridge accepts `Image` parts, and
+  `AgentRuntime.chat(sessionId, parts, …)` takes parts in an embedding.
+
+### Changed
+
+- **agents:** a session's `attachedFiles` are records — id, name, media
+  type, size — instead of bare names; sessions written before read their
+  names as files without an id. `LlmMessage` is made of content blocks
+  (`parts`), `content()` remains the text; `LlmMessageMapper.toMessages`
+  takes the target `LlmConfig` as a fifth argument, and a host's own
+  mapper implementation has to add it. A user message that carries the
+  open turn's id continues that turn instead of opening a new one.
 
 ## [0.4.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,23 @@ fresh empty one, so nothing has to be moved by hand at release time.
   open turn's id continues that turn instead of opening a new one.
   `DELETE /api/sessions/{id}/files?file=` takes the file's name or its
   ingested id, and no longer fails without a vector store.
+- **agents:** the request body an LLM call trace records (`LlmCallEvent.requestJson`,
+  the Admin UI's trace view) no longer carries inline media: an image's or
+  PDF's base64 payload is replaced by a note with its media type and length,
+  so the trace store does not grow by the size of every attachment on every
+  turn. The wire request is unchanged.
+- **agents:** the working-memory token budget counts media. An image is
+  taken as 1,600 tokens, a document as one token per 100 bytes (at least
+  1,000); before, a message's images and PDFs counted as nothing and a
+  window could exceed the model's context.
+- **agents:** a config that declares `DOCUMENTS` on a server without
+  OpenAI's `file` content block (LM Studio, Ollama, Groq, Mistral, …) gets
+  the document as a text note instead of a 400 from the endpoint; images
+  reach every OpenAI-compatible endpoint as before.
+- **agents:** an image sent through the protocol bridge
+  (`ContentPart.Image` on `AgentRuntimeBackend`) is recorded on the session
+  like an upload, so `view_attachment` is activated and the model can ask
+  for the picture again in a later turn.
 
 ## [0.4.1] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Added
+
+- **agents:** an LLM config can declare what its model can take in and do —
+  `capabilities`, any of `TOOL_CALLING`, `VISION`, `DOCUMENTS`,
+  `AUDIO_INPUT`. The Admin UI's chat-config form has a multiselect for it,
+  the detail view shows it, the JSON (file store, Postgres, REST API,
+  bundled `initial-data` configs) carries it as a string array. It is a
+  declaration: callers ask `LlmConfig.supports(...)`, the runtime does not
+  derive its behaviour from it yet. Configs written before this field
+  existed load as declaring nothing. The bundled cloud configs
+  (`claude-*`, `openai-default`, `azure-openai-default`, `gemini-default`)
+  declare their capabilities, the local ones `TOOL_CALLING`; existing
+  installs keep their stored configs unchanged.
+
 ## [0.4.0] - 2026-09-03
 
 ### Changed

--- a/agents/adapter/postgres/mc-llm-gateway-pg/src/test/java/ai/mindconnect/llm/adapter/pg/PgLlmConfigRepositoryTest.java
+++ b/agents/adapter/postgres/mc-llm-gateway-pg/src/test/java/ai/mindconnect/llm/adapter/pg/PgLlmConfigRepositoryTest.java
@@ -37,7 +37,9 @@ class PgLlmConfigRepositoryTest {
         LlmConfig config = new LlmConfig(UUID.randomUUID(), "claude", LlmProvider.ANTHROPIC,
                 "claude-sonnet-5", "https://api.anthropic.com", "sk-secret", 0.3, 8192,
                 Map.of("top_p", 0.9, "stop", List.of("END")), 200_000, false, null, null, null,
-                LlmConfigType.CHAT);
+                LlmConfigType.CHAT,
+                java.util.Set.of(ai.mindconnect.llm.domain.LlmCapability.TOOL_CALLING,
+                        ai.mindconnect.llm.domain.LlmCapability.VISION));
         repo.save(config);
 
         assertThat(repo.findById(config.id())).contains(config);
@@ -49,7 +51,7 @@ class PgLlmConfigRepositoryTest {
         LlmConfig first = LlmConfig.lmStudio("local", "qwen", "http://localhost:1234");
         repo.save(first);
         LlmConfig renamed = LlmConfig.fromJson(first.id(), "local-qwen", first.provider(), "qwen-2",
-                first.baseUrl(), first.apiKey(), 0.1, 1024, Map.of(), null, false, null, null, null, null);
+                first.baseUrl(), first.apiKey(), 0.1, 1024, Map.of(), null, false, null, null, null, null, null);
         repo.save(renamed);
 
         assertThat(repo.findAll()).containsExactly(renamed);

--- a/agents/adapter/postgres/mc-message-repository-pg/src/test/java/ai/mindconnect/message/adapter/pg/PgMessageRepositoryTest.java
+++ b/agents/adapter/postgres/mc-message-repository-pg/src/test/java/ai/mindconnect/message/adapter/pg/PgMessageRepositoryTest.java
@@ -2,6 +2,7 @@ package ai.mindconnect.message.adapter.pg;
 
 import ai.mindconnect.common.PageRequest;
 import ai.mindconnect.jdbc.Sql;
+import ai.mindconnect.message.domain.ContentPart;
 import ai.mindconnect.message.domain.Message;
 import ai.mindconnect.message.domain.MessageType;
 import ai.mindconnect.message.domain.ParticipantType;
@@ -45,6 +46,19 @@ class PgMessageRepositoryTest {
 
         assertThat(repo.findById(conversation, m.id())).contains(m);
         assertThat(repo.findById(UUID.randomUUID(), m.id())).as("scoped to the conversation").isEmpty();
+    }
+
+    @Test
+    void aMessageMadeOfPartsComesBackAsTheSameParts() {
+        Message m = Message.of(conversation, sender, ParticipantType.USER, MessageType.CHAT, List.of(
+                new ContentPart.Text("see attached"),
+                new ContentPart.Image("f-1", "photo.png", "image/png", 240_000L),
+                new ContentPart.File("f-2", "spec.pdf", "application/pdf", 1_048_576L)), 1);
+        repo.save(m);
+
+        assertThat(repo.findById(conversation, m.id())).contains(m);
+        assertThat(repo.findById(conversation, m.id())).get()
+                .extracting(Message::content).isEqualTo("see attached");
     }
 
     @Test

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntime.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntime.java
@@ -110,7 +110,17 @@ public final class AgentRuntime implements AutoCloseable {
 
     /** Sends one message in an existing session and blocks for the answer. */
     public String chat(UUID sessionId, String message, Consumer<StreamEvent> events) {
-        ChatTurnHandle handle = chatService.submitChat(sessionId, message, events);
+        return chat(sessionId, ai.mindconnect.message.domain.ContentPart.text(message), events);
+    }
+
+    /**
+     * Same, for a message made of content parts — text plus the images and
+     * documents sent with it, referenced by the ids {@link #fileStore()}
+     * holds them under. A vision model sees the image with the question.
+     */
+    public String chat(UUID sessionId, java.util.List<ai.mindconnect.message.domain.ContentPart> parts,
+                       Consumer<StreamEvent> events) {
+        ChatTurnHandle handle = chatService.submitChat(sessionId, parts, events);
         try {
             return handle.result().get();
         } catch (InterruptedException e) {

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
@@ -113,8 +113,8 @@ public final class AgentRuntimeBuilder {
     private String defaultLlmConfigName;
     private String encryptionKey;
     private String toolResultSummarizer = "rule";
-    private ai.mindconnect.agent.port.out.LlmMessageMapper llmMessageMapper =
-            new ai.mindconnect.agent.service.MessageToLlmMessageMapper();
+    /** null → the default mapper, reading media parts from the runtime's file store. */
+    private ai.mindconnect.agent.port.out.LlmMessageMapper llmMessageMapper;
     private final Map<String, String> environment = new LinkedHashMap<>();
     private final List<LlmConfig> pendingLlmConfigs = new ArrayList<>();
     private final List<AgentDefinition> pendingAgentDefinitions = new ArrayList<>();
@@ -203,7 +203,11 @@ public final class AgentRuntimeBuilder {
         return this;
     }
 
-    /** How stored messages read to the model; the default renders text, tool calls, results and attachment notices. */
+    /**
+     * How stored messages read to the model; the default renders text, tool
+     * calls, results, attachment notices, and image / document parts as
+     * content blocks when the model reads them.
+     */
     public AgentRuntimeBuilder llmMessageMapper(ai.mindconnect.agent.port.out.LlmMessageMapper mapper) {
         this.llmMessageMapper = mapper;
         return this;
@@ -379,9 +383,20 @@ public final class AgentRuntimeBuilder {
                 definitionRepository, llmChat, namespace, resolveDefaultLlmConfigName(), promptRenderer);
         ToolResultSummarizer summarizer = "llm".equalsIgnoreCase(toolResultSummarizer)
                 ? new LlmToolResultSummarizer(statelessRunner) : new RuleBasedToolResultSummarizer();
+        // The file store — Postgres, or the filesystem one when the file-store
+        // module is present — feeds media parts to the mapper and, further
+        // down, the attach support. Opened once, shared by both.
+        ai.mindconnect.filestore.FileStore fileStore = sql != null && PostgresFileStore.present()
+                ? PostgresFileStore.open(sql)
+                : AttachSupport.defaultFileStoreIfPresent(environment);
+        ai.mindconnect.agent.port.out.LlmMessageMapper messageMapper = llmMessageMapper != null
+                ? llmMessageMapper
+                : new ai.mindconnect.agent.service.MessageToLlmMessageMapper(fileStore != null
+                        ? new ai.mindconnect.agent.adapter.filestore.FileStorePartContentReader(fileStore)
+                        : ai.mindconnect.agent.port.out.PartContentReader.none());
         MemoryStrategyFactory memoryStrategyFactory = new DefaultMemoryStrategyFactory(
                 conversationManager, summaryRepository, summarizer, statelessRunner,
-                tokenCounterRegistry, llmConfigRepository, llmMessageMapper);
+                tokenCounterRegistry, llmConfigRepository, messageMapper);
 
         // 5. Tools: SPI over whatever capability modules are on the classpath.
         DynamicToolActivations activations = new DynamicToolActivations(sessionRepository);
@@ -439,8 +454,6 @@ public final class AgentRuntimeBuilder {
         for (AgentDefinition definition : pendingAgentDefinitions) definitionRepository.save(definition);
         seedWorkflows(workflows);
 
-        ai.mindconnect.filestore.FileStore fileStore =
-                sql != null && PostgresFileStore.present() ? PostgresFileStore.open(sql) : null;
         AttachSupport attachSupport = AttachSupport.createIfPresent(
                 environment, activations, sessionRepository, embeddings, llmConfigRepository, workflows, fileStore);
         return new AgentRuntime(chatService, sessionService, definitionRepository,

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
@@ -405,6 +405,7 @@ public final class AgentRuntimeBuilder {
                 .service(AgentDefinitionRepository.class, definitionRepository)
                 .service(AgentSessionRepository.class, sessionRepository)
                 .service(MessageRepository.class, messageRepository)
+                .service(ai.mindconnect.message.port.in.ConversationManager.class, conversationManager)
                 .service(WorkspaceStore.class, workspaceStore)
                 .service(TodoListService.class, todoListService)
                 .service(ToolRegistryRef.class, registryRef)

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
@@ -138,6 +138,15 @@ final class AttachSupport {
      * reference later ({@code Document(FileId)} content parts).
      */
     String attachStored(UUID sessionId, ai.mindconnect.filestore.StoredFile stored) {
+        var attached = new ai.mindconnect.agent.domain.AttachedFile(
+                stored.id(), stored.name(), stored.contentType(), stored.size());
+        if (attached.isImage()) {
+            // Not text to index: the image goes to the model with the next
+            // message as an image part, or as that part's placeholder.
+            sessions.findById(sessionId).ifPresent(session ->
+                    sessions.save(session.withAttachedFiles(List.of(attached))));
+            return stored.name() + " attached — it goes to the model with the next message.";
+        }
         try {
             String storeName = "session-" + sessionId;
             var template = stores.template("chat-uploads").orElseGet(() -> {
@@ -166,7 +175,7 @@ final class AttachSupport {
 
             activations.activate(sessionId, List.of("vector_search"));
             sessions.findById(sessionId).ifPresent(session ->
-                    sessions.save(session.withAttachedFiles(List.of(stored.name()))));
+                    sessions.save(session.withAttachedFiles(List.of(attached))));
             return message;
         } catch (Exception e) {
             throw new IllegalStateException("attachFile failed: " + e.getMessage(), e);

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
@@ -67,6 +67,29 @@ final class AttachSupport {
         return create(environment, activations, sessions, embeddings, llmConfigs, workflows, hostFileStore);
     }
 
+    /**
+     * The filesystem file store under the data dir when the file-store module
+     * is on the classpath, {@code null} otherwise — the builder feeds it to
+     * the message mapper before any tool support exists.
+     */
+    static ai.mindconnect.filestore.FileStore defaultFileStoreIfPresent(Map<String, String> environment) {
+        try {
+            Class.forName("ai.mindconnect.filestore.filesystem.FilesystemFileStoreBackend");
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+        return openDefaultFileStore(environment);
+    }
+
+    /** Separate method so the backend type is only linked once the guard passed. */
+    private static ai.mindconnect.filestore.FileStore openDefaultFileStore(Map<String, String> environment) {
+        return ai.mindconnect.filestore.FileStoreBackend
+                .byType(environment.getOrDefault("fileStoreBackend", "filesystem"))
+                .orElseThrow()
+                .open(Map.of("dir", environment.getOrDefault("fileStoreDir",
+                        environment.get("dataBaseDir") + "/files")));
+    }
+
     /** Separate method so optional types are only linked once the guard passed. */
     private static AttachSupport create(Map<String, String> environment,
                                         DynamicToolActivations activations,
@@ -75,11 +98,7 @@ final class AttachSupport {
                                         LlmConfigRepository llmConfigs,
                                          ai.mindconnect.workflow.persistence.port.WorkflowDataRepository workflows,
                                         ai.mindconnect.filestore.FileStore hostFileStore) {
-        var fileStore = hostFileStore != null ? hostFileStore : ai.mindconnect.filestore.FileStoreBackend
-                .byType(environment.getOrDefault("fileStoreBackend", "filesystem"))
-                .orElseThrow()
-                .open(Map.of("dir", environment.getOrDefault("fileStoreDir",
-                        environment.get("dataBaseDir") + "/files")));
+        var fileStore = hostFileStore != null ? hostFileStore : openDefaultFileStore(environment);
         var env = new ai.mindconnect.agent.tool.ToolEnvironment() {
             @Override @SuppressWarnings("unchecked")
             public <T> Optional<T> get(Class<T> type) {

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
@@ -142,9 +142,12 @@ final class AttachSupport {
                 stored.id(), stored.name(), stored.contentType(), stored.size());
         if (attached.isImage()) {
             // Not text to index: the image goes to the model with the next
-            // message as an image part, or as that part's placeholder.
+            // message as an image part, or as that part's placeholder. Shown
+            // once; afterwards the model asks for it through view_attachment.
             sessions.findById(sessionId).ifPresent(session ->
                     sessions.save(session.withAttachedFiles(List.of(attached))));
+            activations.activate(sessionId,
+                    List.of(ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.NAME));
             return stored.name() + " attached — it goes to the model with the next message.";
         }
         try {
@@ -173,7 +176,9 @@ final class AttachSupport {
                         stores, store, storeName, stored.name(), text);
             }
 
-            activations.activate(sessionId, List.of("vector_search"));
+            activations.activate(sessionId, attached.isPdf()
+                    ? List.of("vector_search", ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.NAME)
+                    : List.of("vector_search"));
             sessions.findById(sessionId).ifPresent(session ->
                     sessions.save(session.withAttachedFiles(List.of(attached))));
             return message;

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/agent-default.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/agent-default.json
@@ -8,5 +8,8 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 32768
+  "contextWindowTokens": 32768,
+  "capabilities": [
+    "TOOL_CALLING"
+  ]
 }

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/azure-openai-default.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/azure-openai-default.json
@@ -8,5 +8,9 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 128000
+  "contextWindowTokens": 128000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION"
+  ]
 }

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/claude-default.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/claude-default.json
@@ -12,6 +12,11 @@
     "effort": "high"
   },
   "contextWindowTokens": 200000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS"
+  ],
   "rateLimit": {
     "maxConcurrentRequests": 3
   },

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/claude-haiku-default.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/claude-haiku-default.json
@@ -9,6 +9,11 @@
   "maxOutputTokens": 8192,
   "additionalParams": {},
   "contextWindowTokens": 200000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS"
+  ],
   "retry": {
     "enabled": true,
     "maxAttempts": 5,

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/gemini-default.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/gemini-default.json
@@ -8,5 +8,11 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 8192,
   "additionalParams": {},
-  "contextWindowTokens": 1000000
+  "contextWindowTokens": 1000000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS",
+    "AUDIO_INPUT"
+  ]
 }

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/lm-studio-default.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/lm-studio-default.json
@@ -8,5 +8,8 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 32768
+  "contextWindowTokens": 32768,
+  "capabilities": [
+    "TOOL_CALLING"
+  ]
 }

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/openai-default.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/llm-configs/openai-default.json
@@ -8,5 +8,10 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 128000
+  "contextWindowTokens": 128000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS"
+  ]
 }

--- a/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/AutoCompactStrategy.java
+++ b/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/AutoCompactStrategy.java
@@ -97,7 +97,8 @@ public class AutoCompactStrategy implements MemoryStrategy {
         }
         // No budget-driven trimming, no per-message guard — auto-compact assumes the
         // window will not overflow because compact() ran when it crossed the threshold.
-        result.addAll(messageMapper.toMessages(ToolPairSanitizer.sanitize(live), def, session, permissiveBudget(def)));
+        result.addAll(messageMapper.toMessages(ToolPairSanitizer.sanitize(live), def, session, permissiveBudget(def),
+                llmConfigRepository.findResolvedByName(def.llmConfigName()).orElse(null)));
         return result;
     }
 

--- a/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/FullHistoryMemoryStrategy.java
+++ b/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/FullHistoryMemoryStrategy.java
@@ -71,7 +71,8 @@ public class FullHistoryMemoryStrategy implements MemoryStrategy {
             log.warn("FullHistory strategy: {} messages ~{} tokens exceed context window {} — request may fail",
                     all.size(), total, budget.contextWindow());
         }
-        return messageMapper.toMessages(ToolPairSanitizer.sanitize(all), def, session, budget);
+        return messageMapper.toMessages(ToolPairSanitizer.sanitize(all), def, session, budget,
+                llmConfigRepository.findResolvedByName(def.llmConfigName()).orElse(null));
     }
 
     @Override

--- a/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/NoMemoryStrategy.java
+++ b/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/NoMemoryStrategy.java
@@ -57,7 +57,7 @@ public class NoMemoryStrategy implements MemoryStrategy {
     public List<LlmMessage> buildWindow(AgentDefinition def, AgentSession session,
                                         AuthenticationInfo auth, List<Message> history) {
         return messageMapper.toMessages(ToolPairSanitizer.sanitize(episode(history)), def, session,
-                permissiveBudget(def));
+                permissiveBudget(def), llmConfigRepository.findResolvedByName(def.llmConfigName()).orElse(null));
     }
 
     /** No per-message truncation — an episode is short by construction. */

--- a/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/NoMemoryStrategy.java
+++ b/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/NoMemoryStrategy.java
@@ -75,16 +75,10 @@ public class NoMemoryStrategy implements MemoryStrategy {
         return List.of();
     }
 
-    /** Everything from the last user CHAT on — the question and this turn's tool traffic. */
+    /** The current turn — the question and this turn's tool traffic; nothing before any question. */
     private List<Message> episode(List<Message> all) {
-        for (int i = all.size() - 1; i >= 0; i--) {
-            Message message = all.get(i);
-            if (message.type() == ai.mindconnect.message.domain.MessageType.CHAT
-                    && message.senderType() == ai.mindconnect.message.domain.ParticipantType.USER) {
-                return all.subList(i, all.size());
-            }
-        }
-        return List.of();
+        List<Message> turn = ai.mindconnect.message.domain.ConversationHistory.currentTurnMessages(all);
+        return turn == all ? List.of() : turn;
     }
 
     @Override

--- a/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/SummarizingWindowStrategy.java
+++ b/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/SummarizingWindowStrategy.java
@@ -112,7 +112,8 @@ public class SummarizingWindowStrategy implements MemoryStrategy {
                 result.add(LlmMessage.user(summaryUserMsg));
             }
         }
-        result.addAll(messageMapper.toMessages(ToolPairSanitizer.sanitize(windowed), def, session, budget));
+        result.addAll(messageMapper.toMessages(ToolPairSanitizer.sanitize(windowed), def, session, budget,
+                llmConfigRepository.findResolvedByName(def.llmConfigName()).orElse(null)));
         return result;
     }
 

--- a/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/ToolPairSanitizer.java
+++ b/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/ToolPairSanitizer.java
@@ -199,6 +199,7 @@ public final class ToolPairSanitizer {
                 Instant.now(),
                 false, null, null, null, null,
                 parentToolCall.turnId(),
-                parentToolCall.run());        // inherit turnId from parent for traceability
+                parentToolCall.run(),
+                null);        // inherit turnId from parent for traceability
     }
 }

--- a/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/WindowedMemoryStrategy.java
+++ b/agents/core/mc-agent-memory-strategies/src/main/java/ai/mindconnect/agent/memory/strategy/WindowedMemoryStrategy.java
@@ -63,7 +63,8 @@ public class WindowedMemoryStrategy implements MemoryStrategy {
         // MessageMapper needs a budget for per-message truncation; use a permissive default
         // (per-message limit equal to the whole window) — strategy doesn't impose a per-msg cap.
         ContextTokenBudget budget = permissiveBudget(def);
-        return messageMapper.toMessages(ToolPairSanitizer.sanitize(tail), def, session, budget);
+        return messageMapper.toMessages(ToolPairSanitizer.sanitize(tail), def, session, budget,
+                llmConfigRepository.findResolvedByName(def.llmConfigName()).orElse(null));
     }
 
     @Override

--- a/agents/core/mc-agent-memory-strategies/src/test/java/ai/mindconnect/agent/memory/strategy/CompressEligibilityTest.java
+++ b/agents/core/mc-agent-memory-strategies/src/test/java/ai/mindconnect/agent/memory/strategy/CompressEligibilityTest.java
@@ -241,6 +241,12 @@ class CompressEligibilityTest {
                 Integer run, Map<String, Object> metadata) {
             throw new UnsupportedOperationException();
         }
+        @Override public Message addMessageToConversation(UUID conversationId, UUID senderId,
+                ParticipantType senderType, MessageType type,
+                java.util.List<ai.mindconnect.message.domain.ContentPart> parts, UUID turnId,
+                Integer run, Map<String, Object> metadata) {
+            throw new UnsupportedOperationException();
+        }
         @Override public void updateTokenCount(UUID conversationId, UUID messageId, int tokenCount) {
             throw new UnsupportedOperationException();
         }

--- a/agents/core/mc-agent-memory-strategies/src/test/java/ai/mindconnect/agent/memory/strategy/ToolPairSanitizerThinkingTest.java
+++ b/agents/core/mc-agent-memory-strategies/src/test/java/ai/mindconnect/agent/memory/strategy/ToolPairSanitizerThinkingTest.java
@@ -43,7 +43,7 @@ class ToolPairSanitizerThinkingTest {
 
     private Message msg(int seq, MessageType type, ParticipantType sender, String content) {
         return new Message(UUID.randomUUID(), CONV, AGENT, sender, null, type, content,
-                Map.of(), seq, Instant.now(), false, null, null, null, null, null, null);
+                Map.of(), seq, Instant.now(), false, null, null, null, null, null, null, null);
     }
 
     @Test

--- a/agents/core/mc-agent-protocol-mc-runtime/README.md
+++ b/agents/core/mc-agent-protocol-mc-runtime/README.md
@@ -24,9 +24,18 @@ The same caller code as the OpenAI example works here — upload via
 design: OpenAI stuffs the document into context; the runtime ingests it into
 the session's vector store (chunk + embed via the attach pipeline) and the
 agent retrieves with `vector_search` — visible as a normal tool-call item
-pair. Wiring is two small ports (`FileStore` + `FileAttacher`), supplied by
-the builder: `withFiles(runtime.fileStore(), runtime::attachStored)`.
+pair. A PDF additionally goes with the message as a document part when the
+agent's LLM config declares the `DOCUMENTS` capability. Wiring is two small
+ports (`FileStore` + `FileAttacher`), supplied by the builder:
+`withFiles(runtime.fileStore(), runtime::attachStored)`.
 Live example: `RuntimeFileQaExampleTest`.
+
+An `Image` part (`FileId` or `Inline`) is never ingested: it is recorded on
+the session and goes with the message as an image part, which a config with
+the `VISION` capability receives as the provider's image block and any other
+config as a placeholder line. The image is sent in its own turn only; in
+later turns the model asks for it again through the `view_attachment` tool,
+activated for the session on attach.
 
 ## Web search & code execution (parity examples)
 
@@ -60,7 +69,8 @@ web search, a running container binary for code execution).
 ## v1 limitations (each one is a concept-doc pointer)
 
 - `clientTools` rejected — the runtime has no per-request tools yet (K7).
-- `Document` sources: `FileId` and `Inline` work; `Url` not yet.
+- `Document` and `Image` sources: `FileId` and `Inline` work; `Url` not yet.
+  `Audio` parts are rejected.
 - No `INCOMPLETE`/approvals — needs the item-native turn state (K5/K7).
 - Sub-agent turns are not addressable child responses; `AgentCall.childResponseId`
   carries the sub-session id, child streams are folded into the parent (K8).

--- a/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
@@ -208,13 +208,15 @@ public final class AgentRuntimeBackend {
         }
 
         /**
-         * One user message in, its text out — after side effects: every
-         * {@code Document} part is resolved (FileId) or stored (Inline) and
-         * ingested into the session via the {@link FileAttacher}. The runtime
-         * answers document questions by retrieval (vector_search), not by
-         * context-stuffing — the backend detail behind the same protocol item.
+         * One user message in, the conversation's content parts out — after
+         * side effects. A {@code Document} part is resolved (FileId) or stored
+         * (Inline) and attached to the session via the {@link FileAttacher}:
+         * ingested for retrieval, and — a PDF — sent with the message as a
+         * document part by the chat facade, which announces every fresh
+         * attachment. An {@code Image} part is resolved or stored and goes
+         * with the message directly, as the image part a vision model reads.
          */
-        private String prepareInput(ResponseRequest request) {
+        private List<ai.mindconnect.message.domain.ContentPart> prepareInput(ResponseRequest request) {
             if (request.input().size() != 1
                     || !(request.input().get(0) instanceof ConversationItem.Message message)) {
                 throw new RuntimeBackendException("The runtime backend currently accepts exactly "
@@ -222,6 +224,7 @@ public final class AgentRuntimeBackend {
             }
             UUID sessionId = UUID.fromString(request.sessionId());
             StringBuilder text = new StringBuilder();
+            List<ai.mindconnect.message.domain.ContentPart> media = new java.util.ArrayList<>();
             for (ContentPart part : message.content()) {
                 switch (part) {
                     case ContentPart.Text t -> {
@@ -229,28 +232,36 @@ public final class AgentRuntimeBackend {
                         text.append(t.text());
                     }
                     case ContentPart.Document d -> attachDocument(sessionId, d);
+                    case ContentPart.Image i -> media.add(ProtocolParts.image(resolve(i.source(), "image")));
                     default -> throw new RuntimeBackendException("Content part not supported by "
                             + "the runtime backend yet: " + part.getClass().getSimpleName());
                 }
             }
-            if (text.isEmpty()) {
+            if (text.isEmpty() && media.isEmpty()) {
                 throw new RuntimeBackendException(
-                        "The runtime backend needs a text part in the user message");
+                        "The runtime backend needs a text or image part in the user message");
             }
-            return text.toString();
+            List<ai.mindconnect.message.domain.ContentPart> parts = new java.util.ArrayList<>();
+            parts.add(new ai.mindconnect.message.domain.ContentPart.Text(text.toString()));
+            parts.addAll(media);
+            return List.copyOf(parts);
         }
 
         private void attachDocument(UUID sessionId, ContentPart.Document doc) {
+            fileAttacher.attach(sessionId, resolve(doc.source(), doc.name()));
+        }
+
+        /** The stored file behind a media source: looked up (FileId) or stored now (Inline). */
+        private ai.mindconnect.filestore.StoredFile resolve(ContentPart.MediaSource source, String name) {
             requireFiles();
-            ai.mindconnect.filestore.StoredFile stored = switch (doc.source()) {
+            return switch (source) {
                 case ContentPart.MediaSource.FileId f -> fileStore.find(f.fileId())
                         .orElseThrow(() -> new RuntimeBackendException(
                                 "Unknown file id " + f.fileId() + " — upload via files() first"));
-                case ContentPart.MediaSource.Inline in -> storeInline(doc.name(), in);
+                case ContentPart.MediaSource.Inline in -> storeInline(name, in);
                 case ContentPart.MediaSource.Url u -> throw new RuntimeBackendException(
-                        "Url document sources are not supported by the runtime backend yet");
+                        "Url media sources are not supported by the runtime backend yet");
             };
-            fileAttacher.attach(sessionId, stored);
         }
 
         private ai.mindconnect.filestore.StoredFile storeInline(String name,
@@ -332,9 +343,9 @@ public final class AgentRuntimeBackend {
             String content = m.compressed() && m.compressedContent() != null
                     ? m.compressedContent() : m.content();
             ConversationItem item = switch (m.type()) {
-                case CHAT -> m.senderType() == ParticipantType.USER
-                        ? ConversationItem.Message.user(content)
-                        : ConversationItem.Message.assistant(content);
+                case CHAT -> ProtocolParts.message(m.senderType() == ParticipantType.USER
+                        ? ai.mindconnect.agent.protocol.item.Role.USER
+                        : ai.mindconnect.agent.protocol.item.Role.ASSISTANT, m);
                 case TOOL_CALL -> new ConversationItem.FunctionCall(
                         m.id().toString(), "tool_calls", Map.of("_raw", content));
                 case TOOL_RESULT -> new ConversationItem.FunctionCallOutput(m.id().toString(), content, false);

--- a/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
@@ -213,8 +213,11 @@ public final class AgentRuntimeBackend {
          * (Inline) and attached to the session via the {@link FileAttacher}:
          * ingested for retrieval, and — a PDF — sent with the message as a
          * document part by the chat facade, which announces every fresh
-         * attachment. An {@code Image} part is resolved or stored and goes
-         * with the message directly, as the image part a vision model reads.
+         * attachment. An {@code Image} part is resolved or stored, attached
+         * the same way — the session records it and {@code view_attachment}
+         * is activated, so the model can ask for it again in a later turn —
+         * and goes with the message directly, as the image part a vision
+         * model reads; the facade does not add it a second time.
          */
         private List<ai.mindconnect.message.domain.ContentPart> prepareInput(ResponseRequest request) {
             if (request.input().size() != 1
@@ -232,7 +235,7 @@ public final class AgentRuntimeBackend {
                         text.append(t.text());
                     }
                     case ContentPart.Document d -> attachDocument(sessionId, d);
-                    case ContentPart.Image i -> media.add(ProtocolParts.image(resolve(i.source(), "image")));
+                    case ContentPart.Image i -> media.add(ProtocolParts.image(attachImage(sessionId, i)));
                     default -> throw new RuntimeBackendException("Content part not supported by "
                             + "the runtime backend yet: " + part.getClass().getSimpleName());
                 }
@@ -249,6 +252,25 @@ public final class AgentRuntimeBackend {
 
         private void attachDocument(UUID sessionId, ContentPart.Document doc) {
             fileAttacher.attach(sessionId, resolve(doc.source(), doc.name()));
+        }
+
+        /** The stored image, attached to the session (recorded, viewer activated — never ingested). */
+        private ai.mindconnect.filestore.StoredFile attachImage(UUID sessionId, ContentPart.Image image) {
+            var stored = resolve(image.source(), inlineImageName(image.source()));
+            fileAttacher.attach(sessionId, stored);
+            return stored;
+        }
+
+        /**
+         * A name for an inline image — the session records attachments by
+         * name, so two pictures in one conversation must not share one.
+         */
+        private static String inlineImageName(ContentPart.MediaSource source) {
+            String extension = source instanceof ContentPart.MediaSource.Inline in
+                    && in.mediaType() != null && in.mediaType().startsWith("image/")
+                    ? "." + in.mediaType().substring("image/".length()).replace("jpeg", "jpg")
+                    : "";
+            return "image-" + UUID.randomUUID().toString().substring(0, 8) + extension;
         }
 
         /** The stored file behind a media source: looked up (FileId) or stored now (Inline). */

--- a/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/FileAttacher.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/FileAttacher.java
@@ -3,11 +3,13 @@ package ai.mindconnect.agent.protocol.runtime;
 import java.util.UUID;
 
 /**
- * Ingests an already-stored file into a session's context — in the Mindconnect
- * runtime typically: chunk + embed into the session's vector store and
- * activate the {@code vector_search} tool. Supplied by the composition root
- * (e.g. {@code AgentRuntime::attachStored} from the builder); the backend
- * itself neither knows nor cares how "attaching" works.
+ * Attaches an already-stored file to a session — in the Mindconnect runtime:
+ * record it on the session, and for a document chunk + embed it into the
+ * session's vector store and activate {@code vector_search}; an image is
+ * recorded only, with {@code view_attachment} activated so the model can ask
+ * for it again. Supplied by the composition root (e.g.
+ * {@code AgentRuntime::attachStored} from the builder); the backend itself
+ * neither knows nor cares how "attaching" works.
  *
  * <p>This is the backend-detail seam of concept 9's file story: OpenAI stuffs
  * the referenced document into context, the runtime ingests it for retrieval —
@@ -15,6 +17,6 @@ import java.util.UUID;
  */
 public interface FileAttacher {
 
-    /** Ingests {@code file} for {@code sessionId}; returns a human-readable status. */
+    /** Attaches {@code file} to {@code sessionId}; returns a human-readable status. */
     String attach(UUID sessionId, ai.mindconnect.filestore.StoredFile file);
 }

--- a/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/ProtocolParts.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/ProtocolParts.java
@@ -1,0 +1,51 @@
+package ai.mindconnect.agent.protocol.runtime;
+
+import ai.mindconnect.agent.protocol.item.ContentPart;
+import ai.mindconnect.agent.protocol.item.ConversationItem;
+import ai.mindconnect.agent.protocol.item.Role;
+import ai.mindconnect.message.domain.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Between the protocol's content parts and the conversation record's: a
+ * stored image or document becomes a domain part that references it by
+ * file id; a stored message reads back as a protocol message whose media
+ * parts point at the same ids. Text is text on both sides.
+ */
+final class ProtocolParts {
+
+    private ProtocolParts() {
+    }
+
+    /** The domain part for a stored image. */
+    static ai.mindconnect.message.domain.ContentPart image(ai.mindconnect.filestore.StoredFile stored) {
+        return new ai.mindconnect.message.domain.ContentPart.Image(
+                stored.id(), stored.name(), stored.contentType(), stored.size());
+    }
+
+    /**
+     * A stored message as a protocol message: the text as one text part,
+     * each media part as an image or document with a {@code FileId} source.
+     * The compressed stub, when there is one, stands in for the text.
+     */
+    static ConversationItem.Message message(Role role, Message m) {
+        String text = m.compressed() && m.compressedContent() != null ? m.compressedContent() : m.content();
+        List<ContentPart> parts = new ArrayList<>();
+        parts.add(new ContentPart.Text(text == null ? "" : text));
+        if (m.parts() != null) {
+            for (ai.mindconnect.message.domain.ContentPart part : m.parts()) {
+                switch (part) {
+                    case ai.mindconnect.message.domain.ContentPart.Text t -> { /* in the text already */ }
+                    case ai.mindconnect.message.domain.ContentPart.Image i ->
+                            parts.add(ContentPart.Image.of(new ContentPart.MediaSource.FileId(i.fileId())));
+                    case ai.mindconnect.message.domain.ContentPart.File f ->
+                            parts.add(new ContentPart.Document(
+                                    new ContentPart.MediaSource.FileId(f.fileId()), f.name()));
+                }
+            }
+        }
+        return new ConversationItem.Message(role, List.copyOf(parts));
+    }
+}

--- a/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/ProtocolPartsTest.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/ProtocolPartsTest.java
@@ -1,0 +1,53 @@
+package ai.mindconnect.agent.protocol.runtime;
+
+import ai.mindconnect.agent.protocol.item.ContentPart;
+import ai.mindconnect.agent.protocol.item.ConversationItem;
+import ai.mindconnect.agent.protocol.item.Role;
+import ai.mindconnect.filestore.StoredFile;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProtocolPartsTest {
+
+    @Test
+    void aStoredImageBecomesAnImagePartReferencingItsId() {
+        StoredFile stored = new StoredFile("f-1", "photo.png", "image/png", 240, Instant.now());
+
+        assertThat(ProtocolParts.image(stored))
+                .isEqualTo(new ai.mindconnect.message.domain.ContentPart.Image("f-1", "photo.png", "image/png", 240));
+    }
+
+    @Test
+    void aStoredMessageReadsBackWithItsMediaAsFileIdSources() {
+        Message m = Message.of(UUID.randomUUID(), UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT, List.of(
+                new ai.mindconnect.message.domain.ContentPart.Text("what is this?"),
+                new ai.mindconnect.message.domain.ContentPart.Image("f-1", "photo.png", "image/png", 240),
+                new ai.mindconnect.message.domain.ContentPart.File("f-2", "spec.pdf", "application/pdf", 1024)), 1);
+
+        ConversationItem.Message item = ProtocolParts.message(Role.USER, m);
+
+        assertThat(item.role()).isEqualTo(Role.USER);
+        assertThat(item.content()).containsExactly(
+                new ContentPart.Text("what is this?"),
+                ContentPart.Image.of(new ContentPart.MediaSource.FileId("f-1")),
+                new ContentPart.Document(new ContentPart.MediaSource.FileId("f-2"), "spec.pdf"));
+    }
+
+    @Test
+    void aTextMessageIsOneTextPart_theCompressedStubWhenThereIsOne() {
+        Message m = Message.of(UUID.randomUUID(), UUID.randomUUID(), ParticipantType.AGENT, MessageType.CHAT, "long", 1);
+
+        assertThat(ProtocolParts.message(Role.ASSISTANT, m).content())
+                .containsExactly(new ContentPart.Text("long"));
+        assertThat(ProtocolParts.message(Role.ASSISTANT, m.withCompressed("[stub]", 1)).content())
+                .containsExactly(new ContentPart.Text("[stub]"));
+    }
+}

--- a/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeFileQaExampleTest.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeFileQaExampleTest.java
@@ -101,6 +101,6 @@ class RuntimeFileQaExampleTest {
     private static LlmConfig local(String name, String model, String apiKey, LlmConfigType type) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.LM_STUDIO, model,
                 TestModels.baseUrl(), apiKey, 0.2, 2048, Map.of(), 128_000,
-                false, null, null, null, type);
+                false, null, null, null, type, null);
     }
 }

--- a/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeToolsExampleTest.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/RuntimeToolsExampleTest.java
@@ -201,6 +201,6 @@ class RuntimeToolsExampleTest {
     private static LlmConfig local(String name, String model, String apiKey, LlmConfigType type) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.LM_STUDIO, model,
                 TestModels.baseUrl(), apiKey, 0.2, 2048, Map.of(), 128_000,
-                false, null, null, null, type);
+                false, null, null, null, type, null);
     }
 }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AgentSession.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AgentSession.java
@@ -50,11 +50,14 @@ public record AgentSession(
          */
         java.util.List<String> activatedTools,
         /**
-         * Names of files attached to this conversation (chat uploads). The
-         * system-prompt renderer announces them to the LLM together with the
-         * hint to use vector_search; maintained by the session file service.
+         * The files attached to this conversation (chat uploads) — see
+         * {@link AttachedFile}. The system-prompt renderer announces them to
+         * the LLM, the chat facade sends images and PDFs with the next user
+         * message as content parts; maintained by the session file service.
+         * Sessions written before the record existed hold bare names, read
+         * as files without an id.
          */
-        java.util.List<String> attachedFiles,
+        java.util.List<AttachedFile> attachedFiles,
         /**
          * Tool NAMES the user approved for the rest of this session ("allow
          * for this session" on an approval card). Deliberately session
@@ -109,7 +112,7 @@ public record AgentSession(
                         UUID conversationId, String title, SessionStatus status,
                         Instant startedAt, Instant completedAt, UUID parentSessionId,
                         UUID parentTurnId, String parentToolCallId,
-                        java.util.List<String> activatedTools, java.util.List<String> attachedFiles) {
+                        java.util.List<String> activatedTools, java.util.List<AttachedFile> attachedFiles) {
         this(id, agentDefinitionId, namespace, userId, conversationId, title, status,
                 startedAt, completedAt, parentSessionId, parentTurnId, parentToolCallId,
                 activatedTools, attachedFiles, java.util.Set.of(), java.util.List.of());
@@ -133,21 +136,36 @@ public record AgentSession(
                 parentToolCallId, java.util.List.copyOf(merged), attachedFiles, approvedTools, sessionAgents);
     }
 
-    /** This session plus attached file names (deduplicated, order kept). */
-    public AgentSession withAttachedFiles(java.util.Collection<String> names) {
-        java.util.LinkedHashSet<String> merged = new java.util.LinkedHashSet<>(attachedFiles);
-        merged.addAll(names);
+    /**
+     * This session plus attached files. One entry per name, order kept: a
+     * file attached again under the same name replaces the earlier entry —
+     * the newer upload is the one the next message sends.
+     */
+    public AgentSession withAttachedFiles(java.util.Collection<AttachedFile> files) {
+        java.util.LinkedHashMap<String, AttachedFile> merged = new java.util.LinkedHashMap<>();
+        for (AttachedFile f : attachedFiles) merged.put(f.name(), f);
+        for (AttachedFile f : files) merged.put(f.name(), f);
         return new AgentSession(id, agentDefinitionId, namespace, userId, conversationId,
                 title, status, startedAt, completedAt, parentSessionId, parentTurnId,
-                parentToolCallId, activatedTools, java.util.List.copyOf(merged), approvedTools, sessionAgents);
+                parentToolCallId, activatedTools, java.util.List.copyOf(merged.values()), approvedTools, sessionAgents);
     }
 
-    /** This session without the given attached file name. */
+    /** This session without the attached file of the given name. */
     public AgentSession withoutAttachedFile(String name) {
         return new AgentSession(id, agentDefinitionId, namespace, userId, conversationId,
                 title, status, startedAt, completedAt, parentSessionId, parentTurnId,
                 parentToolCallId, activatedTools,
-                attachedFiles.stream().filter(f -> !f.equals(name)).toList(), approvedTools, sessionAgents);
+                attachedFiles.stream().filter(f -> !f.name().equals(name)).toList(), approvedTools, sessionAgents);
+    }
+
+    /** The attached files' names, in attach order — what the notices and the prompt speak of. */
+    public java.util.List<String> attachedFileNames() {
+        return attachedFiles.stream().map(AttachedFile::name).toList();
+    }
+
+    /** The attached file of that name, if any. */
+    public java.util.Optional<AttachedFile> attachedFile(String name) {
+        return attachedFiles.stream().filter(f -> f.name().equals(name)).findFirst();
     }
 
     /** Jackson deserialisation — unknown legacy fields (compressionWatermark, lastCompressedAt) are silently ignored. */
@@ -166,7 +184,7 @@ public record AgentSession(
             @JsonProperty("parentTurnId")      UUID parentTurnId,
             @JsonProperty("parentToolCallId")  String parentToolCallId,
             @JsonProperty("activatedTools")    java.util.List<String> activatedTools,
-            @JsonProperty("attachedFiles")     java.util.List<String> attachedFiles,
+            @JsonProperty("attachedFiles")     java.util.List<AttachedFile> attachedFiles,
             @JsonProperty("approvedTools")     java.util.Set<String> approvedTools,
             @JsonProperty("sessionAgents")     java.util.List<ai.mindconnect.agent.domain.session.SessionAgent> sessionAgents) {
         return new AgentSession(id, agentDefinitionId, namespace, userId, conversationId,

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AttachedFile.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AttachedFile.java
@@ -1,0 +1,70 @@
+package ai.mindconnect.agent.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Locale;
+
+/**
+ * A file attached to a chat session: the id the file store holds it under,
+ * and what the upload said about it. The name is what the model and the user
+ * see; the id is what a message part references; the media type decides how
+ * the file reaches the model — an image goes with the next message as an
+ * image part, a PDF as a document part, everything else through the vector
+ * store and {@code vector_search}.
+ *
+ * <p>Sessions written before this record existed stored bare names; such an
+ * entry reads as a file with no id, and is announced but never sent inline.
+ */
+public record AttachedFile(
+        String id,
+        String name,
+        String mediaType,
+        long sizeBytes
+) {
+    @JsonCreator
+    public AttachedFile(@JsonProperty("id") String id,
+                        @JsonProperty("name") String name,
+                        @JsonProperty("mediaType") String mediaType,
+                        @JsonProperty("sizeBytes") long sizeBytes) {
+        this.id = id;
+        this.name = name;
+        this.mediaType = mediaType;
+        this.sizeBytes = sizeBytes;
+    }
+
+    /** A legacy entry — a session that stored only the file's name. */
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static AttachedFile named(String name) {
+        return new AttachedFile(null, name, null, 0);
+    }
+
+    /** Is this an image — by media type, or by extension when the upload recorded none? */
+    @JsonIgnore
+    public boolean isImage() {
+        if (mediaType != null) return mediaType.toLowerCase(Locale.ROOT).startsWith("image/");
+        String ext = extension();
+        return ext.equals("png") || ext.equals("jpg") || ext.equals("jpeg")
+                || ext.equals("gif") || ext.equals("webp");
+    }
+
+    /** Is this a PDF — the one document kind the vision-capable providers read inline? */
+    @JsonIgnore
+    public boolean isPdf() {
+        if (mediaType != null) return mediaType.equalsIgnoreCase("application/pdf");
+        return extension().equals("pdf");
+    }
+
+    /** Can this file travel as a message part at all — it has an id, and a kind a model may read. */
+    @JsonIgnore
+    public boolean sendableAsPart() {
+        return id != null && (isImage() || isPdf());
+    }
+
+    private String extension() {
+        String n = name == null ? "" : name.toLowerCase(Locale.ROOT);
+        int dot = n.lastIndexOf('.');
+        return dot < 0 ? "" : n.substring(dot + 1);
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AttachedFile.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AttachedFile.java
@@ -40,10 +40,14 @@ public record AttachedFile(
         return new AttachedFile(null, name, null, 0);
     }
 
-    /** Is this an image — by media type, or by extension when the upload recorded none? */
+    /**
+     * Is this an image — by media type, or by extension when the upload
+     * recorded none or only the generic {@code application/octet-stream}
+     * (what curl and some drag-and-drop sources send for anything)?
+     */
     @JsonIgnore
     public boolean isImage() {
-        if (mediaType != null) return mediaType.toLowerCase(Locale.ROOT).startsWith("image/");
+        if (hasSpecificMediaType()) return mediaType.toLowerCase(Locale.ROOT).startsWith("image/");
         String ext = extension();
         return ext.equals("png") || ext.equals("jpg") || ext.equals("jpeg")
                 || ext.equals("gif") || ext.equals("webp");
@@ -52,8 +56,31 @@ public record AttachedFile(
     /** Is this a PDF — the one document kind the vision-capable providers read inline? */
     @JsonIgnore
     public boolean isPdf() {
-        if (mediaType != null) return mediaType.equalsIgnoreCase("application/pdf");
+        if (hasSpecificMediaType()) return mediaType.equalsIgnoreCase("application/pdf");
         return extension().equals("pdf");
+    }
+
+    /**
+     * The media type to send the file with: the recorded one when it says
+     * something, else the one the extension implies ({@code null} when
+     * neither does). What a message part and the gateway carry.
+     */
+    @JsonIgnore
+    public String effectiveMediaType() {
+        if (hasSpecificMediaType()) return mediaType;
+        return switch (extension()) {
+            case "png" -> "image/png";
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "gif" -> "image/gif";
+            case "webp" -> "image/webp";
+            case "pdf" -> "application/pdf";
+            default -> mediaType;
+        };
+    }
+
+    private boolean hasSpecificMediaType() {
+        return mediaType != null && !mediaType.isBlank()
+                && !mediaType.equalsIgnoreCase("application/octet-stream");
     }
 
     /** Can this file travel as a message part at all — it has an id, and a kind a model may read. */

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/port/out/LlmMessageMapper.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/port/out/LlmMessageMapper.java
@@ -3,6 +3,7 @@ package ai.mindconnect.agent.port.out;
 import ai.mindconnect.agent.domain.AgentDefinition;
 import ai.mindconnect.agent.domain.AgentSession;
 import ai.mindconnect.agent.service.ContextTokenBudget;
+import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.llm.domain.LlmMessage;
 import ai.mindconnect.message.domain.Message;
 
@@ -28,15 +29,20 @@ public interface LlmMessageMapper {
      * Maps a list of stored messages to LLM-ready messages, within the
      * per-message token limit of {@code budget}. The session is the live
      * state a record may have to be read against — what is attached to the
-     * chat <em>now</em>, not what was when the message was written.
+     * chat <em>now</em>, not what was when the message was written. The
+     * target is the model the messages go to: what it declares it can read
+     * ({@link LlmConfig#capabilities()}) decides whether an image or document
+     * part travels as content or as a placeholder line. {@code null} when the
+     * agent's config is unknown — then nothing travels as media.
      */
     List<LlmMessage> toMessages(List<Message> messages, AgentDefinition def, AgentSession session,
-                                ContextTokenBudget budget);
+                                ContextTokenBudget budget, LlmConfig target);
 
     /**
      * The text the model reads for one stored message — what {@link #toMessages}
-     * would put in its content. For the working-memory view, so the admin
-     * sees the same text and the same token count as the model.
+     * would put in its content, with a media part standing in as a one-line
+     * descriptor. For the working-memory view, so the admin sees the same
+     * text and the same token count as the model.
      */
     default String modelText(Message message, AgentDefinition def, AgentSession session) {
         return message.content();

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/port/out/PartContentReader.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/port/out/PartContentReader.java
@@ -1,0 +1,27 @@
+package ai.mindconnect.agent.port.out;
+
+import java.util.Optional;
+
+/**
+ * Reads the bytes behind a media content part — the file a
+ * {@link ai.mindconnect.message.domain.ContentPart.Media} references by id.
+ * The conversation record carries the reference; the message mapper turns it
+ * into the base64 the gateway sends, and this is where it gets the bytes.
+ *
+ * <p>An out-port because the runtime core does not know where files live.
+ * The host adapts its file store; a host without one uses {@link #none()},
+ * and every media part renders as its placeholder.
+ */
+public interface PartContentReader {
+
+    /** The file's bytes and media type, or empty when the id is unknown or the file is gone. */
+    Optional<Content> read(String fileId);
+
+    /** What a read hands back. {@code mediaType} may be null when the store did not record one. */
+    record Content(byte[] bytes, String mediaType) {}
+
+    /** A reader that finds nothing — for hosts without a file store. */
+    static PartContentReader none() {
+        return fileId -> Optional.empty();
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/port/out/TokenCounter.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/port/out/TokenCounter.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.port.out;
 
+import ai.mindconnect.llm.domain.LlmContent;
 import ai.mindconnect.llm.domain.LlmMessage;
 
 import java.util.List;
@@ -10,15 +11,50 @@ import java.util.List;
  */
 public interface TokenCounter {
 
+    /**
+     * What an image costs, whatever its pixels: the order of magnitude of a
+     * full-detail picture at OpenAI and Anthropic (a 1-megapixel image is
+     * about 1,500 tokens at either). Media has no text to count, so the
+     * budget takes a flat estimate rather than nothing.
+     */
+    int IMAGE_TOKENS = 1_600;
+
+    /** A document's estimate: one token per this many bytes of the file, never fewer than {@link #DOCUMENT_MIN_TOKENS}. */
+    int DOCUMENT_BYTES_PER_TOKEN = 100;
+
+    /** The least a document is taken to cost — one text-heavy PDF page. */
+    int DOCUMENT_MIN_TOKENS = 1_000;
+
     /** Count tokens in a plain string. */
     int countText(String text);
 
-    /** Count tokens across a list of messages (content + role overhead). */
+    /**
+     * The estimate for one content block: text is counted, an image is {@link #IMAGE_TOKENS}; a
+     * document is sized by its bytes — a PDF page of text runs to a few
+     * thousand tokens, and the base64 length is what is known here.
+     */
+    default int countPart(LlmContent part) {
+        return switch (part) {
+            case LlmContent.Text t -> countText(t.text());
+            case LlmContent.Image i -> IMAGE_TOKENS;
+            case LlmContent.Document d -> Math.max(DOCUMENT_MIN_TOKENS,
+                    decodedLength(d.base64()) / DOCUMENT_BYTES_PER_TOKEN);
+        };
+    }
+
+    /** The byte count a base64 string decodes to, without decoding it. */
+    private static int decodedLength(String base64) {
+        if (base64 == null || base64.isEmpty()) return 0;
+        int padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+        return (int) Math.max(0, (long) base64.length() * 3 / 4 - padding);
+    }
+
+    /** Count tokens across a list of messages (content blocks + role overhead). */
     default int countMessages(List<LlmMessage> messages) {
         int total = 0;
         for (LlmMessage m : messages) {
             total += 4; // per-message overhead (role, separators)
-            if (m.content() != null) total += countText(m.content());
+            for (LlmContent part : m.parts()) total += countPart(part);
             if (m.toolCalls() != null) {
                 for (var tc : m.toolCalls()) {
                     total += countText(tc.name());

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentChatService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentChatService.java
@@ -2,8 +2,10 @@ package ai.mindconnect.agent.service;
 
 import ai.mindconnect.agent.domain.AgentDefinition;
 import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.message.domain.ContentPart;
 import ai.mindconnect.message.domain.Message;
 import ai.mindconnect.agent.service.prompt.AttachmentNotice;
+import ai.mindconnect.agent.service.prompt.AttachmentParts;
 import ai.mindconnect.agent.domain.StreamEvent;
 import ai.mindconnect.agent.memory.domain.WorkingMemory;
 import ai.mindconnect.agent.memory.port.in.MemoryStrategy;
@@ -121,8 +123,20 @@ public class AgentChatService {
      */
     public ChatTurnHandle submitChat(UUID sessionId, String userMessage,
                                      Consumer<StreamEvent> eventHandler) {
+        return submitChat(sessionId, ContentPart.text(userMessage), eventHandler);
+    }
+
+    /**
+     * Same, for a message made of content parts — text plus the images and
+     * documents the caller sends with it. Files attached to the session
+     * since the last turn ride along as parts of their own (images, PDFs)
+     * or as a notice (everything else); see {@link AttachmentParts}.
+     */
+    public ChatTurnHandle submitChat(UUID sessionId, List<ContentPart> parts,
+                                     Consumer<StreamEvent> eventHandler) {
         AgentSession session = sessionService.findSession(sessionId);
         AgentDefinition def = effectiveDefinition(session);
+        String userMessage = ContentPart.textOf(parts);
 
         boolean isFirstMessage = conversationManager
                 .loadHistory(session.conversationId(), new PageRequest(0, 1)).isEmpty();
@@ -136,7 +150,8 @@ public class AgentChatService {
         // 1. The question becomes conversation truth — BEFORE the task exists.
         //    A file attached since the last turn is recorded on this message
         //    (metadata); the model reads the notice with the question, the
-        //    text stays what the user typed.
+        //    text stays what the user typed. An image or PDF among them also
+        //    becomes a part of the message, so a model that reads it sees it.
         TokenCounter tokenCounter = memoryStrategyFactory.create(def).resolveTokenCounter(def);
         //    An attachment that was removed since is announced the same way,
         //    so the model stops looking for it. Both are read off the record;
@@ -146,7 +161,8 @@ public class AgentChatService {
         List<String> attached = AttachmentNotice.unannounced(session, history);
         List<String> detached = AttachmentNotice.unannouncedRemovals(session, history);
         AgentTurnWorker.appendUserMessage(conversationManager, session.conversationId(),
-                userMessage, turnId, tokenCounter, AttachmentNotice.metadata(attached, detached));
+                AttachmentParts.withAttachments(parts, session, attached), turnId, tokenCounter,
+                AttachmentNotice.metadata(attached, detached));
 
         // 2.+3. Listen on the turn's channel, make the turn a task — the queue
         //        is the only registry of running work, nothing is tracked here.

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/MessageToLlmMessageMapper.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/MessageToLlmMessageMapper.java
@@ -61,6 +61,9 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
     /** Largest file sent inline; above it the placeholder says so. */
     static final long MAX_INLINE_BYTES = 20L * 1024 * 1024;
 
+    /** The tool that shows an earlier attachment again — named in the placeholder when the agent has it. */
+    static final String VIEWER_TOOL = "view_attachment";
+
     private final PartContentReader partContentReader;
 
     /** A mapper without a file store: every media part renders as its placeholder. */
@@ -95,7 +98,8 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
                     } else if (media(m).isEmpty()) {
                         result.add(LlmMessage.user(text));
                     } else {
-                        result.add(LlmMessage.user(userParts(m, text, target, inCurrentTurn(m, lastUser))));
+                        result.add(LlmMessage.user(userParts(m, text, target, inCurrentTurn(m, lastUser),
+                                viewerAvailable(def, session))));
                     }
                 }
                 case TOOL_CALL -> mapToolCall(m, result);
@@ -133,6 +137,12 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
         return AttachmentNotice.forModel(m, session);
     }
 
+    /** Can this agent, in this session, call the viewer tool — assigned, or activated by an upload? */
+    private static boolean viewerAvailable(AgentDefinition def, AgentSession session) {
+        if (session != null && session.activatedTools().contains(VIEWER_TOOL)) return true;
+        return def.tools() != null && def.tools().stream().anyMatch(t -> VIEWER_TOOL.equals(t.name()));
+    }
+
     private static List<ContentPart.Media> media(Message m) {
         if (m.parts() == null) return List.of();
         return m.parts().stream()
@@ -167,7 +177,8 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
      * otherwise. Text and placeholders are separate blocks; a gateway joins
      * them when the message ends up text-only after all.
      */
-    private List<LlmContent> userParts(Message m, String text, LlmConfig target, boolean currentTurn) {
+    private List<LlmContent> userParts(Message m, String text, LlmConfig target, boolean currentTurn,
+                                       boolean viewerAvailable) {
         List<LlmContent> parts = new ArrayList<>();
         parts.add(new LlmContent.Text(text));
         for (ContentPart.Media part : media(m)) {
@@ -178,7 +189,10 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
                         ? "this model does not read images, so it is not included"
                         : "this model does not read documents; read its content with vector_search"));
             } else if (!currentTurn) {
-                parts.add(placeholder(part, "sent in an earlier turn, not resent"));
+                parts.add(placeholder(part, viewerAvailable
+                        ? "sent in an earlier turn, not resent; call " + VIEWER_TOOL + "(\""
+                                + part.name() + "\") to see it again"
+                        : "sent in an earlier turn, not resent"));
             } else if (part.sizeBytes() > MAX_INLINE_BYTES) {
                 parts.add(placeholder(part, "too large to send inline (limit "
                         + humanSize(MAX_INLINE_BYTES) + ")"));

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/MessageToLlmMessageMapper.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/MessageToLlmMessageMapper.java
@@ -3,21 +3,30 @@ package ai.mindconnect.agent.service;
 import ai.mindconnect.agent.tool.Tool;
 import ai.mindconnect.agent.domain.AgentDefinition;
 import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.port.out.PartContentReader;
 import ai.mindconnect.agent.service.prompt.AttachmentNotice;
 import ai.mindconnect.agent.service.ContextTokenBudget;
+import ai.mindconnect.llm.domain.LlmCapability;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmContent;
 import ai.mindconnect.llm.domain.LlmMessage;
 import ai.mindconnect.llm.domain.ThinkingBlock;
 import ai.mindconnect.llm.domain.ToolCall;
+import ai.mindconnect.message.domain.ContentPart;
 import ai.mindconnect.message.domain.Message;
 import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Translates stored {@link Message} domain records into {@link LlmMessage} objects
@@ -27,11 +36,20 @@ import java.util.Map;
  * <ul>
  *   <li>Structural mapping: CHAT → user/assistant, TOOL_CALL → assistantWithToolCalls,
  *       TOOL_RESULT → tool (using compressed stub if available)</li>
- *   <li>Per-message token guard: truncates any message whose effective content exceeds
+ *   <li>Media: an image or document part of a user message travels as a
+ *       content block when the target model declares it reads that kind
+ *       ({@link LlmConfig#capabilities()}) and the message belongs to the
+ *       current turn; otherwise a placeholder line stands in for it — see
+ *       {@link #placeholder}. Bytes come from the {@link PartContentReader}.</li>
+ *   <li>Per-message token guard: truncates any message whose effective text exceeds
  *       {@link ContextTokenBudget#maxMessageTokens()}</li>
  * </ul>
  * <p>
- * No repository access, no summarization, no window logic — pure translation.
+ * Media is sent in the current turn only. A request repeats the whole
+ * history, and an image repeated in every request costs its tokens every
+ * time; once the turn that brought it is over, its placeholder names it and
+ * the model can ask for it again. No repository access, no summarization,
+ * no window logic — pure translation.
  */
 public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.LlmMessageMapper {
 
@@ -40,22 +58,45 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
     private static final String TRUNCATION_MARKER =
             "\n[... truncated — content exceeded per-message token limit]";
 
+    /** Largest file sent inline; above it the placeholder says so. */
+    static final long MAX_INLINE_BYTES = 20L * 1024 * 1024;
+
+    private final PartContentReader partContentReader;
+
+    /** A mapper without a file store: every media part renders as its placeholder. */
+    public MessageToLlmMessageMapper() {
+        this(PartContentReader.none());
+    }
+
+    public MessageToLlmMessageMapper(PartContentReader partContentReader) {
+        this.partContentReader = Objects.requireNonNull(partContentReader, "partContentReader");
+    }
+
     /**
      * Maps a list of stored messages to LLM-ready messages, enforcing the per-message
-     * token limit from the supplied budget.
+     * token limit from the supplied budget and rendering media by what {@code target}
+     * declares it reads.
      */
     @Override
     public List<LlmMessage> toMessages(List<Message> messages,
                                        AgentDefinition def,
                                        AgentSession session,
-                                       ContextTokenBudget budget) {
+                                       ContextTokenBudget budget,
+                                       LlmConfig target) {
+        Message lastUser = lastUserChat(messages);
         List<LlmMessage> result = new ArrayList<>();
         for (Message m : messages) {
             switch (m.type()) {
                 case CHAT -> {
                     boolean assistant = m.senderId().equals(def.id());
-                    String content = guard(modelText(m, def, session), budget, m.sequenceNum(), "CHAT");
-                    result.add(assistant ? LlmMessage.assistant(content) : LlmMessage.user(content));
+                    String text = guard(textForModel(m, def, session), budget, m.sequenceNum(), "CHAT");
+                    if (assistant) {
+                        result.add(LlmMessage.assistant(text));
+                    } else if (media(m).isEmpty()) {
+                        result.add(LlmMessage.user(text));
+                    } else {
+                        result.add(LlmMessage.user(userParts(m, text, target, inCurrentTurn(m, lastUser))));
+                    }
                 }
                 case TOOL_CALL -> mapToolCall(m, result);
                 case TOOL_RESULT -> mapToolResult(m, result, budget);
@@ -69,15 +110,125 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
      * A user message that announced attachments (metadata) gets the notice
      * ahead of its text — the stored text stays what the user typed. Only
      * files still attached are named: a removed one is gone from the store,
-     * so it must be gone from the notice too. Assistant text is as stored.
+     * so it must be gone from the notice too. A media part stands in as its
+     * one-line descriptor. Assistant text is as stored.
      */
     @Override
     public String modelText(Message m, AgentDefinition def, AgentSession session) {
+        String text = textForModel(m, def, session);
+        List<ContentPart.Media> media = media(m);
+        if (media.isEmpty()) return text;
+        StringBuilder out = new StringBuilder(text);
+        for (ContentPart.Media part : media) {
+            out.append('\n').append('[').append(describe(part)).append(']');
+        }
+        return out.toString();
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    /** The text of the message as the model reads it — notices ahead of a user's text. */
+    private static String textForModel(Message m, AgentDefinition def, AgentSession session) {
         if (m.type() != MessageType.CHAT || m.senderId().equals(def.id())) return m.content();
         return AttachmentNotice.forModel(m, session);
     }
 
-    // ── private helpers ───────────────────────────────────────────────────────
+    private static List<ContentPart.Media> media(Message m) {
+        if (m.parts() == null) return List.of();
+        return m.parts().stream()
+                .filter(ContentPart.Media.class::isInstance)
+                .map(ContentPart.Media.class::cast)
+                .toList();
+    }
+
+    private static Message lastUserChat(List<Message> messages) {
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            Message m = messages.get(i);
+            if (m.type() == MessageType.CHAT && m.senderType() == ParticipantType.USER) return m;
+        }
+        return null;
+    }
+
+    /**
+     * The current turn is the one the last user message opened: that message
+     * itself, and every message sharing its turn id (a message the runtime
+     * inserted on the user's behalf within the turn, say). A legacy message
+     * without a turn id is current only when it is the last user message.
+     */
+    private static boolean inCurrentTurn(Message m, Message lastUser) {
+        if (lastUser == null) return false;
+        if (m.id().equals(lastUser.id())) return true;
+        return m.turnId() != null && m.turnId().equals(lastUser.turnId());
+    }
+
+    /**
+     * The user's text first, then each media part — inline when the model
+     * reads it and it belongs to the current turn, a placeholder line
+     * otherwise. Text and placeholders are separate blocks; a gateway joins
+     * them when the message ends up text-only after all.
+     */
+    private List<LlmContent> userParts(Message m, String text, LlmConfig target, boolean currentTurn) {
+        List<LlmContent> parts = new ArrayList<>();
+        parts.add(new LlmContent.Text(text));
+        for (ContentPart.Media part : media(m)) {
+            LlmCapability needed = part instanceof ContentPart.Image
+                    ? LlmCapability.VISION : LlmCapability.DOCUMENTS;
+            if (target == null || !target.supports(needed)) {
+                parts.add(placeholder(part, part instanceof ContentPart.Image
+                        ? "this model does not read images, so it is not included"
+                        : "this model does not read documents; read its content with vector_search"));
+            } else if (!currentTurn) {
+                parts.add(placeholder(part, "sent in an earlier turn, not resent"));
+            } else if (part.sizeBytes() > MAX_INLINE_BYTES) {
+                parts.add(placeholder(part, "too large to send inline (limit "
+                        + humanSize(MAX_INLINE_BYTES) + ")"));
+            } else {
+                LlmContent inline = inline(part);
+                parts.add(inline != null ? inline : placeholder(part, "no longer available"));
+            }
+        }
+        return parts;
+    }
+
+    /** The media as a content block, or null when the store no longer has it. */
+    private LlmContent inline(ContentPart.Media part) {
+        PartContentReader.Content content = partContentReader.read(part.fileId()).orElse(null);
+        if (content == null || content.bytes() == null) {
+            log.warn("Media part {} ({}) is not readable — sending a placeholder", part.fileId(), part.name());
+            return null;
+        }
+        String base64 = Base64.getEncoder().encodeToString(content.bytes());
+        String mediaType = part.mediaType() != null ? part.mediaType() : content.mediaType();
+        return part instanceof ContentPart.Image
+                ? new LlmContent.Image(base64, mediaType)
+                : new LlmContent.Document(base64, mediaType, part.name());
+    }
+
+    /**
+     * What stands in for a media part the model does not get: what it is
+     * and why it is not here, marked as a system note so the model does not
+     * take it for something the user typed.
+     */
+    static LlmContent.Text placeholder(ContentPart.Media part, String reason) {
+        return new LlmContent.Text("[System note — " + describe(part) + " — " + reason + ".]");
+    }
+
+    /** "image attached: photo.png (image/png, 240 KB)" — the same line the working-memory view shows. */
+    static String describe(ContentPart.Media part) {
+        String kind = part instanceof ContentPart.Image ? "image" : "document";
+        StringBuilder out = new StringBuilder(kind).append(" attached: ").append(part.name());
+        List<String> details = new ArrayList<>();
+        if (part.mediaType() != null) details.add(part.mediaType());
+        if (part.sizeBytes() > 0) details.add(humanSize(part.sizeBytes()));
+        if (!details.isEmpty()) out.append(" (").append(String.join(", ", details)).append(')');
+        return out.toString();
+    }
+
+    static String humanSize(long bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes + 512) / 1024 + " KB";
+        return String.format(java.util.Locale.ROOT, "%.1f MB", bytes / (1024.0 * 1024.0));
+    }
 
     private void mapToolCall(Message m, List<LlmMessage> result) {
         try {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentNotice.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentNotice.java
@@ -57,7 +57,7 @@ public final class AttachmentNotice {
         if (session == null || session.attachedFiles().isEmpty()) return List.of();
         Set<String> announced = announced(history);
         List<String> fresh = new ArrayList<>();
-        for (String file : session.attachedFiles()) {
+        for (String file : session.attachedFileNames()) {
             if (!announced.contains(file)) fresh.add(file);
         }
         return fresh;
@@ -65,7 +65,7 @@ public final class AttachmentNotice {
 
     /** Files the model has been told about that are no longer attached — removed since the last turn. */
     public static List<String> unannouncedRemovals(AgentSession session, List<Message> history) {
-        Set<String> live = session == null ? Set.of() : new LinkedHashSet<>(session.attachedFiles());
+        Set<String> live = session == null ? Set.of() : new LinkedHashSet<>(session.attachedFileNames());
         List<String> gone = new ArrayList<>();
         for (String file : announced(history)) {
             if (!live.contains(file)) gone.add(file);
@@ -96,9 +96,12 @@ public final class AttachmentNotice {
      * what was attached, what kind of file it is, and the one instruction
      * that matters: the content is reached through {@code vector_search},
      * never through a path. Marked as a system note so the model does not
-     * take it for something the user said.
+     * take it for something the user said. Images are not named here: an
+     * image is not indexed, it travels with the message as an image part
+     * (or as that part's placeholder), which speaks for itself.
      */
-    public static String notice(List<String> files) {
+    public static String notice(List<String> attached) {
+        List<String> files = attached.stream().filter(f -> !"image".equals(kind(f))).toList();
         if (files.isEmpty()) return "";
         StringBuilder out = new StringBuilder("[System note — attached to this chat: ");
         for (int i = 0; i < files.size(); i++) {
@@ -125,12 +128,13 @@ public final class AttachmentNotice {
      * alone otherwise.
      */
     public static String forModel(Message message, AgentSession session) {
-        Set<String> live = session == null ? Set.of() : new LinkedHashSet<>(session.attachedFiles());
+        Set<String> live = session == null ? Set.of() : new LinkedHashSet<>(session.attachedFileNames());
         List<String> attached = announcedBy(message).stream().filter(live::contains).toList();
         List<String> removed = detachedBy(message).stream().filter(f -> !live.contains(f)).toList();
         StringBuilder out = new StringBuilder();
         if (!removed.isEmpty()) out.append(removalNotice(removed)).append("\n\n");
-        if (!attached.isEmpty()) out.append(notice(attached)).append("\n\n");
+        String attachNotice = notice(attached);
+        if (!attachNotice.isEmpty()) out.append(attachNotice).append("\n\n");
         return out.append(message.content()).toString();
     }
 

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentNotice.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentNotice.java
@@ -96,12 +96,12 @@ public final class AttachmentNotice {
      * what was attached, what kind of file it is, and the one instruction
      * that matters: the content is reached through {@code vector_search},
      * never through a path. Marked as a system note so the model does not
-     * take it for something the user said. Images are not named here: an
-     * image is not indexed, it travels with the message as an image part
-     * (or as that part's placeholder), which speaks for itself.
+     * take it for something the user said. Callers leave images out (see
+     * {@link #forModel}): an image is not indexed, it travels with the
+     * message as an image part (or as that part's placeholder), which speaks
+     * for itself.
      */
-    public static String notice(List<String> attached) {
-        List<String> files = attached.stream().filter(f -> !"image".equals(kind(f))).toList();
+    public static String notice(List<String> files) {
         if (files.isEmpty()) return "";
         StringBuilder out = new StringBuilder("[System note — attached to this chat: ");
         for (int i = 0; i < files.size(); i++) {
@@ -129,13 +129,31 @@ public final class AttachmentNotice {
      */
     public static String forModel(Message message, AgentSession session) {
         Set<String> live = session == null ? Set.of() : new LinkedHashSet<>(session.attachedFileNames());
-        List<String> attached = announcedBy(message).stream().filter(live::contains).toList();
+        // Images are announced in the metadata (the chat's chip shows them)
+        // but not in the notice — they are not indexed, the part speaks.
+        List<String> attached = announcedBy(message).stream()
+                .filter(live::contains)
+                .filter(name -> !isImage(session, name))
+                .toList();
         List<String> removed = detachedBy(message).stream().filter(f -> !live.contains(f)).toList();
         StringBuilder out = new StringBuilder();
         if (!removed.isEmpty()) out.append(removalNotice(removed)).append("\n\n");
         String attachNotice = notice(attached);
         if (!attachNotice.isEmpty()) out.append(attachNotice).append("\n\n");
         return out.append(message.content()).toString();
+    }
+
+    /**
+     * Is the attached file of that name an image — by the session's record,
+     * the one classification the attach flow and the prompt use; by the
+     * extension only for a name the session does not hold.
+     */
+    static boolean isImage(AgentSession session, String name) {
+        if (session != null) {
+            var file = session.attachedFile(name);
+            if (file.isPresent()) return file.get().isImage();
+        }
+        return "image".equals(kind(name));
     }
 
     /** A human word for the file type, from the extension — enough for the model to stop treating "x.pdf" as a path. */

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentParts.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentParts.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.agent.service.prompt;
+
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.AttachedFile;
+import ai.mindconnect.message.domain.ContentPart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Which attached files ride along with a user message as content parts.
+ * A file attached since the last turn is announced with the next message
+ * ({@link AttachmentNotice}); the ones a model may read inline — images and
+ * PDFs — go with that message as parts too, so a vision model sees the
+ * picture the user just dropped in. Everything else is reached through
+ * {@code vector_search}, as before.
+ */
+public final class AttachmentParts {
+
+    private AttachmentParts() {
+    }
+
+    /**
+     * The user's parts plus one media part per freshly attached image or
+     * PDF, in attach order. {@code fresh} names the files this message
+     * announces (see {@link AttachmentNotice#unannounced}); a name the
+     * session no longer holds, or a legacy entry without an id, adds nothing.
+     */
+    public static List<ContentPart> withAttachments(List<ContentPart> parts, AgentSession session,
+                                                    List<String> fresh) {
+        if (session == null || fresh.isEmpty()) return parts;
+        List<ContentPart> out = new ArrayList<>(parts);
+        for (String name : fresh) {
+            session.attachedFile(name)
+                    .filter(AttachedFile::sendableAsPart)
+                    .map(AttachmentParts::part)
+                    .ifPresent(out::add);
+        }
+        return List.copyOf(out);
+    }
+
+    /** The content part for an attached file the model may read inline. */
+    public static ContentPart part(AttachedFile file) {
+        return file.isImage()
+                ? new ContentPart.Image(file.id(), file.name(), file.mediaType(), file.sizeBytes())
+                : new ContentPart.File(file.id(), file.name(), file.mediaType(), file.sizeBytes());
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentParts.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentParts.java
@@ -5,7 +5,9 @@ import ai.mindconnect.agent.domain.AttachedFile;
 import ai.mindconnect.message.domain.ContentPart;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Which attached files ride along with a user message as content parts.
@@ -25,14 +27,22 @@ public final class AttachmentParts {
      * PDF, in attach order. {@code fresh} names the files this message
      * announces (see {@link AttachmentNotice#unannounced}); a name the
      * session no longer holds, or a legacy entry without an id, adds nothing.
+     * A file the caller already sends as a part of its own — the REST body
+     * and the protocol bridge reference attachments by file id — is not
+     * added a second time.
      */
     public static List<ContentPart> withAttachments(List<ContentPart> parts, AgentSession session,
                                                     List<String> fresh) {
         if (session == null || fresh.isEmpty()) return parts;
+        Set<String> sent = new HashSet<>();
+        for (ContentPart part : parts) {
+            if (part instanceof ContentPart.Media media && media.fileId() != null) sent.add(media.fileId());
+        }
         List<ContentPart> out = new ArrayList<>(parts);
         for (String name : fresh) {
             session.attachedFile(name)
                     .filter(AttachedFile::sendableAsPart)
+                    .filter(file -> !sent.contains(file.id()))
                     .map(AttachmentParts::part)
                     .ifPresent(out::add);
         }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentParts.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/AttachmentParts.java
@@ -42,7 +42,7 @@ public final class AttachmentParts {
     /** The content part for an attached file the model may read inline. */
     public static ContentPart part(AttachedFile file) {
         return file.isImage()
-                ? new ContentPart.Image(file.id(), file.name(), file.mediaType(), file.sizeBytes())
-                : new ContentPart.File(file.id(), file.name(), file.mediaType(), file.sizeBytes());
+                ? new ContentPart.Image(file.id(), file.name(), file.effectiveMediaType(), file.sizeBytes())
+                : new ContentPart.File(file.id(), file.name(), file.effectiveMediaType(), file.sizeBytes());
     }
 }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/SystemPromptRenderer.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/prompt/SystemPromptRenderer.java
@@ -33,12 +33,19 @@ public final class SystemPromptRenderer {
      * a removed file disappears from the prompt with it.
      */
     static String attachedFilesSection(AgentSession session) {
-        if (session == null || session.attachedFiles().isEmpty()) {
+        if (session == null) return "";
+        // Images are not indexed — they travel with the message as image
+        // parts (or their placeholders) and have no business in this list.
+        java.util.List<String> searchable = session.attachedFiles().stream()
+                .filter(f -> !f.isImage())
+                .map(ai.mindconnect.agent.domain.AttachedFile::name)
+                .toList();
+        if (searchable.isEmpty()) {
             return "";
         }
         StringBuilder out = new StringBuilder("\n\n## Attached files\n"
                 + "The user attached these files to this conversation:\n");
-        for (String file : session.attachedFiles()) {
+        for (String file : searchable) {
             out.append("- ").append(file).append(" (").append(AttachmentNotice.kind(file)).append(")\n");
         }
         return out.append("Their content is indexed for semantic search. To answer anything about them, "

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/round/ToolCalls.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/round/ToolCalls.java
@@ -67,17 +67,13 @@ public record ToolCalls(List<Call> calls) {
     }
 
     /**
-     * The current episode: everything from the last user CHAT message on
-     * (inclusive). No user message yet — the whole list is the episode.
+     * The current episode: the current turn's messages, from the user CHAT
+     * that opened it on (inclusive) — a user message the runtime inserted
+     * within the turn does not start a new one. No user message yet — the
+     * whole list is the episode.
      */
     public static List<Message> episode(List<Message> history) {
-        for (int i = history.size() - 1; i >= 0; i--) {
-            Message message = history.get(i);
-            if (message.type() == MessageType.CHAT && message.senderType() == ParticipantType.USER) {
-                return history.subList(i, history.size());
-            }
-        }
-        return history;
+        return ai.mindconnect.message.domain.ConversationHistory.currentTurnMessages(history);
     }
 
     public static ToolCalls of(List<Message> episode) {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/AgentTurnWorker.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/AgentTurnWorker.java
@@ -168,6 +168,24 @@ public final class AgentTurnWorker implements TaskWorker {
         return persisted;
     }
 
+    /**
+     * Same, for a message made of content parts — the text plus the images
+     * and documents sent with it. The token count is the text's; what a
+     * media part costs is the provider's business.
+     */
+    public static Message appendUserMessage(ConversationManager conversationManager,
+                                            UUID conversationId,
+                                            java.util.List<ai.mindconnect.message.domain.ContentPart> parts,
+                                            UUID turnId, TokenCounter tokenCounter,
+                                            Map<String, Object> metadata) {
+        Message persisted = conversationManager.addMessageToConversation(
+                conversationId, UUID.randomUUID() /* user sender — see follow-up task */,
+                ParticipantType.USER, MessageType.CHAT, parts, turnId, 0, metadata);
+        conversationManager.updateTokenCount(conversationId, persisted.id(),
+                tokenCounter.countText(persisted.content()));
+        return persisted;
+    }
+
     // ── the turn ────────────────────────────────────────────────────────────
 
     @Override

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/tools/attachment/ViewAttachmentTool.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/tools/attachment/ViewAttachmentTool.java
@@ -1,0 +1,121 @@
+package ai.mindconnect.agent.tools.attachment;
+
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.AttachedFile;
+import ai.mindconnect.agent.port.out.AgentSessionRepository;
+import ai.mindconnect.agent.service.prompt.AttachmentParts;
+import ai.mindconnect.agent.tool.Tool;
+import ai.mindconnect.message.domain.ContentPart;
+import ai.mindconnect.message.domain.ConversationHistory;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import ai.mindconnect.message.port.in.ConversationManager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Shows the model an attached image or PDF again. A file the model reads
+ * inline goes with the message it was attached to, once — a request repeats
+ * the whole history, and media repeated in every request costs its tokens
+ * every time. From the next turn on a placeholder names it, and this tool
+ * brings it back: not as the tool's result (a tool result carries text on
+ * every provider) but as a message of its own in the conversation, on the
+ * user's side and in the current turn, carrying the image or document part.
+ * The mapper renders that message like any other user message with media,
+ * so the model sees the picture in the very next request.
+ */
+public final class ViewAttachmentTool implements Tool {
+
+    public static final String NAME = "view_attachment";
+
+    /** Metadata key on the inserted message: which tool put it there. */
+    public static final String INSERTED_BY = "insertedBy";
+
+    /** Metadata key on the inserted message: the attachment's name. */
+    public static final String ATTACHMENT = "attachment";
+
+    private final AgentSessionRepository sessions;
+    private final ConversationManager conversations;
+    private final UUID sessionId;
+
+    public ViewAttachmentTool(AgentSessionRepository sessions, ConversationManager conversations,
+                              UUID sessionId) {
+        this.sessions = sessions;
+        this.conversations = conversations;
+        this.sessionId = sessionId;
+    }
+
+    /** Was this message inserted by this tool — an attachment shown again, not something the user typed? */
+    public static boolean insertedBy(Message message) {
+        return message.metadata() != null && NAME.equals(message.metadata().get(INSERTED_BY));
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public String description() {
+        return """
+                Show an image or PDF attached to this chat again.
+
+                An attached image or PDF is shown to you with the message it came with, once.
+                In later turns a note names it instead. Call this tool with the file's name
+                when you need to look at it again — it is shown to you right after this
+                tool's result, as a message of its own. Files that are not images or PDFs
+                are read with vector_search, not with this tool.
+                """;
+    }
+
+    @Override
+    public Map<String, Object> parametersSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "name", Map.of(
+                                "type", "string",
+                                "description", "The attached file's name, as shown in the chat's attachments")),
+                "required", List.of("name"));
+    }
+
+    @Override
+    public String execute(Map<String, Object> arguments) {
+        Object raw = arguments.get("name");
+        String name = raw == null ? "" : raw.toString().trim();
+        if (name.isEmpty()) return "Error: 'name' is required — the attached file's name.";
+
+        AgentSession session = sessions.findById(sessionId).orElse(null);
+        if (session == null) return "Error: session " + sessionId + " not found.";
+
+        AttachedFile file = session.attachedFile(name).orElse(null);
+        if (file == null) {
+            List<String> names = session.attachedFileNames();
+            return names.isEmpty()
+                    ? "No file named '" + name + "' — nothing is attached to this chat."
+                    : "No file named '" + name + "'. Attached to this chat: " + String.join(", ", names) + ".";
+        }
+        if (!file.sendableAsPart()) {
+            return "'" + name + "' is not an image or PDF" + (file.id() == null ? " that can be shown again" : "")
+                    + " — read its content with vector_search.";
+        }
+
+        // The message goes into the turn that is running — same turn id, same
+        // run — so the turn's bookkeeping keeps it and the mapper sends the
+        // media inline. Recorded before this result is, which the sanitizer
+        // sorts out: results follow their calls, the message follows both.
+        ConversationHistory history = conversations.loadCompleteHistory(session.conversationId());
+        UUID turnId = history.currentTurnId().orElse(null);
+        String kind = file.isImage() ? "image" : "document";
+        List<ContentPart> parts = List.of(
+                new ContentPart.Text("[" + name + " — " + kind + " shown again at the assistant's request]"),
+                AttachmentParts.part(file));
+        conversations.addMessageToConversation(session.conversationId(), UUID.randomUUID(),
+                ParticipantType.USER, MessageType.CHAT, parts, turnId, history.currentRun(),
+                Map.of(INSERTED_BY, NAME, ATTACHMENT, name));
+        return "Showing '" + name + "' — the " + kind + " follows this result as a message of its own.";
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/tools/attachment/ViewAttachmentToolFactory.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/tools/attachment/ViewAttachmentToolFactory.java
@@ -1,0 +1,41 @@
+package ai.mindconnect.agent.tools.attachment;
+
+import ai.mindconnect.agent.port.out.AgentSessionRepository;
+import ai.mindconnect.agent.tool.AgentTool;
+import ai.mindconnect.agent.tool.Tool;
+import ai.mindconnect.agent.tool.ToolCallScope;
+import ai.mindconnect.agent.tool.ToolEnvironment;
+import ai.mindconnect.agent.tool.ToolFactory;
+import ai.mindconnect.message.port.in.ConversationManager;
+
+/**
+ * Built into the runtime: needs only the session store and the
+ * conversation manager, which every host has. Activated for a session when
+ * an image or PDF is attached, so the agent has it exactly when a
+ * placeholder may name it; assignable to an agent like any other tool.
+ */
+public final class ViewAttachmentToolFactory implements ToolFactory {
+
+    private AgentSessionRepository sessions;
+    private ConversationManager conversations;
+
+    @Override public String name() { return ViewAttachmentTool.NAME; }
+
+    @Override public String group() { return "attachments"; }
+
+    @Override
+    public void bind(ToolEnvironment env) {
+        this.sessions = env.get(AgentSessionRepository.class).orElse(null);
+        this.conversations = env.get(ConversationManager.class).orElse(null);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return sessions != null && conversations != null;
+    }
+
+    @Override
+    public Tool create(AgentTool agentTool, ToolCallScope scope) {
+        return new ViewAttachmentTool(sessions, conversations, scope.sessionId());
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/main/resources/META-INF/services/ai.mindconnect.agent.tool.ToolFactory
+++ b/agents/core/mc-agent-runtime-core/src/main/resources/META-INF/services/ai.mindconnect.agent.tool.ToolFactory
@@ -1,3 +1,4 @@
 ai.mindconnect.agent.tools.toolsearch.ToolSearchToolFactory
 ai.mindconnect.agent.tools.todo.TodoWriteToolFactory
 ai.mindconnect.agent.tools.todo.TodoReadToolFactory
+ai.mindconnect.agent.tools.attachment.ViewAttachmentToolFactory

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AttachedFileTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AttachedFileTest.java
@@ -28,6 +28,20 @@ class AttachedFileTest {
     }
 
     @Test
+    void aGenericContentTypeFallsBackToTheExtension() {
+        // curl and some drag-and-drop sources send application/octet-stream for anything
+        AttachedFile png = new AttachedFile("f", "photo.png", "application/octet-stream", 1);
+        assertThat(png.isImage()).isTrue();
+        assertThat(png.effectiveMediaType()).isEqualTo("image/png");
+        AttachedFile pdf = new AttachedFile("f", "spec.pdf", "", 1);
+        assertThat(pdf.isPdf()).isTrue();
+        assertThat(pdf.effectiveMediaType()).isEqualTo("application/pdf");
+        assertThat(AttachedFile.named("scan.jpeg").effectiveMediaType()).isEqualTo("image/jpeg");
+        assertThat(new AttachedFile("f", "notes.md", null, 1).effectiveMediaType()).isNull();
+        assertThat(new AttachedFile("f", "photo.bin", "image/webp", 1).effectiveMediaType()).isEqualTo("image/webp");
+    }
+
+    @Test
     void onlyAFileWithAnIdAndAReadableKindIsSendableAsAPart() {
         assertThat(new AttachedFile("f", "photo.png", "image/png", 1).sendableAsPart()).isTrue();
         assertThat(new AttachedFile("f", "spec.pdf", "application/pdf", 1).sendableAsPart()).isTrue();

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AttachedFileTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AttachedFileTest.java
@@ -1,0 +1,78 @@
+package ai.mindconnect.agent.domain;
+
+import ai.mindconnect.common.Namespace;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** The attached-file record, and how a session written with bare names reads today. */
+class AttachedFileTest {
+
+    private final ObjectMapper json = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    void kindsFollowTheMediaTypeAndFallBackToTheExtension() {
+        assertThat(new AttachedFile("f", "photo.png", "image/png", 1).isImage()).isTrue();
+        assertThat(new AttachedFile("f", "photo.bin", "image/webp", 1).isImage()).isTrue();
+        assertThat(AttachedFile.named("photo.JPG").isImage()).isTrue();
+        assertThat(AttachedFile.named("spec.pdf").isPdf()).isTrue();
+        assertThat(new AttachedFile("f", "spec", "application/pdf", 1).isPdf()).isTrue();
+        assertThat(new AttachedFile("f", "notes.md", "text/markdown", 1).isImage()).isFalse();
+        assertThat(new AttachedFile("f", "notes.md", "text/markdown", 1).isPdf()).isFalse();
+    }
+
+    @Test
+    void onlyAFileWithAnIdAndAReadableKindIsSendableAsAPart() {
+        assertThat(new AttachedFile("f", "photo.png", "image/png", 1).sendableAsPart()).isTrue();
+        assertThat(new AttachedFile("f", "spec.pdf", "application/pdf", 1).sendableAsPart()).isTrue();
+        assertThat(new AttachedFile("f", "notes.md", "text/markdown", 1).sendableAsPart()).isFalse();
+        assertThat(AttachedFile.named("photo.png").sendableAsPart()).as("legacy entry, no id").isFalse();
+    }
+
+    @Test
+    void aSessionWrittenWithBareNamesStillLoads() throws Exception {
+        // A session as written before the record existed: names only.
+        String current = json.writeValueAsString(new AgentSession(UUID.randomUUID(), UUID.randomUUID(),
+                new Namespace("local"), "u", UUID.randomUUID(), "t", SessionStatus.ACTIVE, Instant.now(),
+                null, null, null, null));
+        assertThat(current).contains("\"attachedFiles\":[]");
+        String legacy = current.replace("\"attachedFiles\":[]", "\"attachedFiles\":[\"notes.md\",\"photo.png\"]");
+
+        AgentSession session = json.readValue(legacy, AgentSession.class);
+
+        assertThat(session.attachedFileNames()).containsExactly("notes.md", "photo.png");
+        assertThat(session.attachedFiles()).allMatch(f -> f.id() == null);
+        assertThat(session.attachedFile("photo.png")).get().extracting(AttachedFile::isImage).isEqualTo(true);
+    }
+
+    @Test
+    void aSessionRoundTripsItsAttachedFiles() throws Exception {
+        AgentSession session = new AgentSession(UUID.randomUUID(), UUID.randomUUID(), new Namespace("local"),
+                "u", UUID.randomUUID(), "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null)
+                .withAttachedFiles(List.of(new AttachedFile("f-1", "photo.png", "image/png", 240_000)));
+
+        String written = json.writeValueAsString(session);
+        AgentSession read = json.readValue(written, AgentSession.class);
+
+        assertThat(written).contains("\"attachedFiles\":[{\"id\":\"f-1\",\"name\":\"photo.png\"");
+        assertThat(read.attachedFiles()).containsExactly(new AttachedFile("f-1", "photo.png", "image/png", 240_000));
+    }
+
+    @Test
+    void attachingTheSameNameAgainReplacesTheEntryInPlace() {
+        AgentSession session = new AgentSession(UUID.randomUUID(), UUID.randomUUID(), new Namespace("local"),
+                "u", UUID.randomUUID(), "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null)
+                .withAttachedFiles(List.of(AttachedFile.named("a.md"), new AttachedFile("f-1", "photo.png", "image/png", 1)))
+                .withAttachedFiles(List.of(new AttachedFile("f-2", "photo.png", "image/png", 2)));
+
+        assertThat(session.attachedFileNames()).containsExactly("a.md", "photo.png");
+        assertThat(session.attachedFile("photo.png")).get().extracting(AttachedFile::id).isEqualTo("f-2");
+        assertThat(session.withoutAttachedFile("a.md").attachedFileNames()).containsExactly("photo.png");
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/port/out/TokenCounterMediaTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/port/out/TokenCounterMediaTest.java
@@ -1,0 +1,47 @@
+package ai.mindconnect.agent.port.out;
+
+import ai.mindconnect.llm.domain.LlmContent;
+import ai.mindconnect.llm.domain.LlmMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Media has no text to count, so the budget takes an estimate: a flat one
+ * per image, a byte-sized one per document. Text-only messages count as
+ * they always did.
+ */
+class TokenCounterMediaTest {
+
+    /** One token per character — makes the sums readable. */
+    private final TokenCounter counter = text -> text == null ? 0 : text.length();
+
+    @Test
+    void textOnlyMessagesCountAsBefore() {
+        int tokens = counter.countMessages(List.of(LlmMessage.user("hello")));
+        assertThat(tokens).isEqualTo(4 + 5);
+    }
+
+    @Test
+    void anImageCostsTheFlatEstimate() {
+        LlmMessage user = LlmMessage.user(List.of(
+                new LlmContent.Text("what is this?"),
+                new LlmContent.Image("QUJD", "image/png")));
+
+        assertThat(counter.countMessages(List.of(user)))
+                .isEqualTo(4 + "what is this?".length() + TokenCounter.IMAGE_TOKENS);
+    }
+
+    @Test
+    void aDocumentIsSizedByItsBytes_neverBelowTheMinimum() {
+        // 400,000 base64 chars decode to 300,000 bytes -> 3,000 tokens
+        String big = "QUJD".repeat(100_000);
+        assertThat(counter.countPart(new LlmContent.Document(big, "application/pdf", "big.pdf")))
+                .isEqualTo(300_000 / TokenCounter.DOCUMENT_BYTES_PER_TOKEN);
+
+        assertThat(counter.countPart(new LlmContent.Document("UERG", "application/pdf", "tiny.pdf")))
+                .isEqualTo(TokenCounter.DOCUMENT_MIN_TOKENS);
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/MessageToLlmMessageMapperTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/MessageToLlmMessageMapperTest.java
@@ -1,0 +1,221 @@
+package ai.mindconnect.agent.service;
+
+import ai.mindconnect.agent.domain.AgentDefinition;
+import ai.mindconnect.agent.domain.AgentDefinitionStatus;
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.SessionStatus;
+import ai.mindconnect.agent.port.out.PartContentReader;
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.llm.domain.LlmCapability;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmContent;
+import ai.mindconnect.llm.domain.LlmMessage;
+import ai.mindconnect.llm.domain.MessageRole;
+import ai.mindconnect.message.domain.ContentPart;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * How a user message with media reads to the model: as content blocks when
+ * the target reads that kind and the message is in the current turn, as a
+ * placeholder line otherwise. Text-only messages are untouched.
+ */
+class MessageToLlmMessageMapperTest {
+
+    private static final UUID AGENT = UUID.randomUUID();
+    private static final UUID CONVERSATION = UUID.randomUUID();
+
+    private final Map<String, PartContentReader.Content> files = new HashMap<>();
+    private final PartContentReader reader = id -> Optional.ofNullable(files.get(id));
+    private final MessageToLlmMessageMapper mapper = new MessageToLlmMessageMapper(reader);
+
+    private final AgentDefinition def = new AgentDefinition(AGENT, new Namespace("test"), "a", "d",
+            null, null, "prompt", null, "cfg", 5, null, AgentDefinitionStatus.ACTIVE,
+            List.of(), List.of(), null, null, null, null);
+    private final AgentSession session = new AgentSession(UUID.randomUUID(), CONVERSATION, Namespace.DEFAULT,
+            "user", AGENT, "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null,
+            List.of(), List.of());
+    private final ContextTokenBudget budget = new ContextTokenBudget(text -> text.length() / 4, 8192, 8192, 8192);
+
+    private static final ContentPart.Image PHOTO = new ContentPart.Image("f-1", "photo.png", "image/png", 3);
+    private static final ContentPart.File SPEC = new ContentPart.File("f-2", "spec.pdf", "application/pdf", 3);
+
+    private static LlmConfig target(LlmCapability... capabilities) {
+        return LlmConfig.claude("cfg", "claude-sonnet-4-6", "k").withCapabilities(Set.of(capabilities));
+    }
+
+    private static Message user(int seq, UUID turnId, List<ContentPart> parts) {
+        return Message.of(CONVERSATION, UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT, parts, seq)
+                .withTurnId(turnId);
+    }
+
+    private static Message agent(int seq, UUID turnId, String text) {
+        return Message.of(CONVERSATION, AGENT, ParticipantType.AGENT, MessageType.CHAT, text, seq)
+                .withTurnId(turnId);
+    }
+
+    private void stored(String id, String bytes, String mediaType) {
+        files.put(id, new PartContentReader.Content(bytes.getBytes(StandardCharsets.UTF_8), mediaType));
+    }
+
+    private static String base64(String s) {
+        return Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void textOnlyMessagesAreOneTextBlockEachWhateverTheTarget() {
+        UUID turn = UUID.randomUUID();
+        List<Message> history = List.of(
+                user(1, turn, ContentPart.text("hi")),
+                agent(2, turn, "hello"));
+
+        List<LlmMessage> out = mapper.toMessages(history, def, session, budget, null);
+
+        assertThat(out).extracting(LlmMessage::role).containsExactly(MessageRole.USER, MessageRole.ASSISTANT);
+        assertThat(out.get(0).parts()).containsExactly(new LlmContent.Text("hi"));
+        assertThat(out.get(1).content()).isEqualTo("hello");
+    }
+
+    @Test
+    void anImageInTheCurrentTurnGoesInlineToAVisionModel() {
+        stored("f-1", "PNG", "image/png");
+        UUID turn = UUID.randomUUID();
+        Message m = user(1, turn, List.of(new ContentPart.Text("what is this?"), PHOTO));
+
+        List<LlmMessage> out = mapper.toMessages(List.of(m), def, session, budget, target(LlmCapability.VISION));
+
+        assertThat(out).hasSize(1);
+        assertThat(out.get(0).parts()).containsExactly(
+                new LlmContent.Text("what is this?"),
+                new LlmContent.Image(base64("PNG"), "image/png"));
+        assertThat(out.get(0).hasMedia()).isTrue();
+    }
+
+    @Test
+    void aDocumentGoesInlineOnlyToADocumentReadingModel() {
+        stored("f-2", "PDF", "application/pdf");
+        Message m = user(1, UUID.randomUUID(), List.of(new ContentPart.Text("summarise"), SPEC));
+
+        List<LlmMessage> docs = mapper.toMessages(List.of(m), def, session, budget, target(LlmCapability.DOCUMENTS));
+        List<LlmMessage> vision = mapper.toMessages(List.of(m), def, session, budget, target(LlmCapability.VISION));
+
+        assertThat(docs.get(0).parts()).containsExactly(
+                new LlmContent.Text("summarise"),
+                new LlmContent.Document(base64("PDF"), "application/pdf", "spec.pdf"));
+        assertThat(vision.get(0).hasMedia()).isFalse();
+        assertThat(vision.get(0).content())
+                .startsWith("summarise\n[System note — document attached: spec.pdf (application/pdf, 3 B) — ")
+                .contains("vector_search");
+    }
+
+    @Test
+    void aModelThatDoesNotReadImagesGetsThePlaceholder() {
+        stored("f-1", "PNG", "image/png");
+        Message m = user(1, UUID.randomUUID(), List.of(new ContentPart.Text("look"), PHOTO));
+
+        List<LlmMessage> noCaps = mapper.toMessages(List.of(m), def, session, budget, target());
+        List<LlmMessage> noTarget = mapper.toMessages(List.of(m), def, session, budget, null);
+
+        for (List<LlmMessage> out : List.of(noCaps, noTarget)) {
+            assertThat(out.get(0).hasMedia()).isFalse();
+            assertThat(out.get(0).content()).isEqualTo(
+                    "look\n[System note — image attached: photo.png (image/png, 3 B) — "
+                            + "this model does not read images, so it is not included.]");
+        }
+    }
+
+    @Test
+    void anImageFromAnEarlierTurnIsNotResent() {
+        stored("f-1", "PNG", "image/png");
+        UUID first = UUID.randomUUID(), second = UUID.randomUUID();
+        List<Message> history = List.of(
+                user(1, first, List.of(new ContentPart.Text("what is this?"), PHOTO)),
+                agent(2, first, "a cat"),
+                user(3, second, ContentPart.text("and its colour?")));
+
+        List<LlmMessage> out = mapper.toMessages(history, def, session, budget, target(LlmCapability.VISION));
+
+        assertThat(out.get(0).hasMedia()).isFalse();
+        assertThat(out.get(0).content()).contains("sent in an earlier turn, not resent");
+        assertThat(out.get(2).content()).isEqualTo("and its colour?");
+    }
+
+    @Test
+    void aMessageInsertedWithinTheCurrentTurnStillGoesInline() {
+        stored("f-1", "PNG", "image/png");
+        UUID turn = UUID.randomUUID();
+        // The runtime appended the image on the user's behalf, in the same
+        // turn as the user's question: it is current, it goes inline.
+        List<Message> history = List.of(
+                user(1, turn, ContentPart.text("show me the photo again")),
+                user(2, turn, List.of(new ContentPart.Text("(photo.png)"), PHOTO)));
+
+        List<LlmMessage> out = mapper.toMessages(history, def, session, budget, target(LlmCapability.VISION));
+
+        assertThat(out.get(1).hasMedia()).isTrue();
+    }
+
+    @Test
+    void aFileTheStoreNoLongerHasBecomesAPlaceholderNotAnError() {
+        Message m = user(1, UUID.randomUUID(), List.of(new ContentPart.Text("look"), PHOTO));
+
+        List<LlmMessage> out = mapper.toMessages(List.of(m), def, session, budget, target(LlmCapability.VISION));
+
+        assertThat(out.get(0).hasMedia()).isFalse();
+        assertThat(out.get(0).content()).contains("no longer available");
+    }
+
+    @Test
+    void aFileAboveTheInlineLimitBecomesAPlaceholder() {
+        stored("f-1", "PNG", "image/png");
+        ContentPart.Image huge = new ContentPart.Image("f-1", "huge.png", "image/png",
+                MessageToLlmMessageMapper.MAX_INLINE_BYTES + 1);
+        Message m = user(1, UUID.randomUUID(), List.of(new ContentPart.Text("look"), huge));
+
+        List<LlmMessage> out = mapper.toMessages(List.of(m), def, session, budget, target(LlmCapability.VISION));
+
+        assertThat(out.get(0).hasMedia()).isFalse();
+        assertThat(out.get(0).content()).contains("too large to send inline (limit 20.0 MB)");
+    }
+
+    @Test
+    void modelTextNamesTheMediaOnOneLineEach() {
+        Message m = user(1, UUID.randomUUID(), List.of(new ContentPart.Text("look"), PHOTO, SPEC));
+
+        assertThat(mapper.modelText(m, def, session)).isEqualTo(
+                "look\n[image attached: photo.png (image/png, 3 B)]\n[document attached: spec.pdf (application/pdf, 3 B)]");
+        assertThat(mapper.modelText(user(2, null, ContentPart.text("plain")), def, session)).isEqualTo("plain");
+    }
+
+    @Test
+    void theStoredTextIsWhatTheUserTypedAndTheNoticeStillLeadsIt() {
+        Message m = user(1, UUID.randomUUID(), List.of(new ContentPart.Text("what does it say?"), PHOTO))
+                .withMetadata(Map.of(ai.mindconnect.agent.service.prompt.AttachmentNotice.ATTACHMENTS,
+                        List.of("notes.md")));
+        AgentSession withNotes = new AgentSession(session.id(), CONVERSATION, Namespace.DEFAULT,
+                "user", AGENT, "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null,
+                List.of(), List.of("notes.md"));
+
+        List<LlmMessage> out = mapper.toMessages(List.of(m), def, withNotes, budget, target());
+
+        assertThat(m.content()).isEqualTo("what does it say?");
+        assertThat(out.get(0).content())
+                .startsWith("[System note — attached to this chat: notes.md (Markdown)")
+                .contains("what does it say?")
+                .contains("image attached: photo.png");
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/MessageToLlmMessageMapperTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/MessageToLlmMessageMapperTest.java
@@ -155,6 +155,21 @@ class MessageToLlmMessageMapperTest {
     }
 
     @Test
+    void thePlaceholderNamesTheViewerToolWhenTheSessionHasIt() {
+        stored("f-1", "PNG", "image/png");
+        UUID first = UUID.randomUUID(), second = UUID.randomUUID();
+        List<Message> history = List.of(
+                user(1, first, List.of(new ContentPart.Text("what is this?"), PHOTO)),
+                agent(2, first, "a cat"),
+                user(3, second, ContentPart.text("and its colour?")));
+        AgentSession withViewer = session.withActivatedTools(List.of("view_attachment"));
+
+        List<LlmMessage> out = mapper.toMessages(history, def, withViewer, budget, target(LlmCapability.VISION));
+
+        assertThat(out.get(0).content()).contains("call view_attachment(\"photo.png\") to see it again");
+    }
+
+    @Test
     void aMessageInsertedWithinTheCurrentTurnStillGoesInline() {
         stored("f-1", "PNG", "image/png");
         UUID turn = UUID.randomUUID();

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/MessageToLlmMessageMapperTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/MessageToLlmMessageMapperTest.java
@@ -208,7 +208,7 @@ class MessageToLlmMessageMapperTest {
                         List.of("notes.md")));
         AgentSession withNotes = new AgentSession(session.id(), CONVERSATION, Namespace.DEFAULT,
                 "user", AGENT, "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null,
-                List.of(), List.of("notes.md"));
+                List.of(), List.of(ai.mindconnect.agent.domain.AttachedFile.named("notes.md")));
 
         List<LlmMessage> out = mapper.toMessages(List.of(m), def, withNotes, budget, target());
 

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentNoticeTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentNoticeTest.java
@@ -20,7 +20,8 @@ class AttachmentNoticeTest {
     private static AgentSession session(String... attached) {
         return new AgentSession(UUID.randomUUID(), UUID.randomUUID(), Namespace.DEFAULT, "david",
                 UUID.randomUUID(), "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null,
-                List.of(), List.of(attached));
+                List.of(), java.util.Arrays.stream(attached)
+                        .map(ai.mindconnect.agent.domain.AttachedFile::named).toList());
     }
 
     private static Message user(String text, Map<String, Object> metadata) {
@@ -71,6 +72,20 @@ class AttachmentNoticeTest {
         // attached again after the removal: fresh, because the record is read in order
         assertThat(AttachmentNotice.unannounced(session("a.pdf"), withRemoval)).containsExactly("a.pdf");
         assertThat(AttachmentNotice.unannouncedRemovals(session("a.pdf"), withRemoval)).isEmpty();
+    }
+
+    @Test
+    void imagesAreAnnouncedInTheMetadataButNotInTheNotice() {
+        // The image travels as a part (or its placeholder) — the notice about
+        // vector_search would only mislead. The metadata still records it, so
+        // the bookkeeping and the chat's chip see it.
+        assertThat(AttachmentNotice.notice(List.of("photo.png"))).isEmpty();
+        assertThat(AttachmentNotice.notice(List.of("photo.png", "notes.md")))
+                .contains("notes.md (Markdown)").doesNotContain("photo.png");
+
+        Message announcing = user("what is this?", attached("photo.png"));
+        assertThat(AttachmentNotice.announcedBy(announcing)).containsExactly("photo.png");
+        assertThat(AttachmentNotice.forModel(announcing, session("photo.png"))).isEqualTo("what is this?");
     }
 
     @Test

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentNoticeTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentNoticeTest.java
@@ -79,13 +79,22 @@ class AttachmentNoticeTest {
         // The image travels as a part (or its placeholder) — the notice about
         // vector_search would only mislead. The metadata still records it, so
         // the bookkeeping and the chat's chip see it.
-        assertThat(AttachmentNotice.notice(List.of("photo.png"))).isEmpty();
-        assertThat(AttachmentNotice.notice(List.of("photo.png", "notes.md")))
-                .contains("notes.md (Markdown)").doesNotContain("photo.png");
-
         Message announcing = user("what is this?", attached("photo.png"));
         assertThat(AttachmentNotice.announcedBy(announcing)).containsExactly("photo.png");
         assertThat(AttachmentNotice.forModel(announcing, session("photo.png"))).isEqualTo("what is this?");
+
+        Message both = user("read both", attached("photo.png", "notes.md"));
+        assertThat(AttachmentNotice.forModel(both, session("photo.png", "notes.md")))
+                .contains("notes.md (Markdown)").doesNotContain("photo.png");
+
+        // The session's record decides, not the extension: an image uploaded
+        // under a name without one is still an image, a generic content type
+        // does not make a .png a document.
+        AgentSession odd = new AgentSession(UUID.randomUUID(), UUID.randomUUID(), Namespace.DEFAULT, "david",
+                UUID.randomUUID(), "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null,
+                List.of(), List.of(new ai.mindconnect.agent.domain.AttachedFile("f-1", "scan", "image/jpeg", 1),
+                        new ai.mindconnect.agent.domain.AttachedFile("f-2", "photo.png", "application/octet-stream", 1)));
+        assertThat(AttachmentNotice.forModel(user("?", attached("scan", "photo.png")), odd)).isEqualTo("?");
     }
 
     @Test

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentPartsTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentPartsTest.java
@@ -1,0 +1,63 @@
+package ai.mindconnect.agent.service.prompt;
+
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.AttachedFile;
+import ai.mindconnect.agent.domain.SessionStatus;
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.message.domain.ContentPart;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AttachmentPartsTest {
+
+    private static AgentSession session(AttachedFile... files) {
+        return new AgentSession(UUID.randomUUID(), UUID.randomUUID(), Namespace.DEFAULT, "u",
+                UUID.randomUUID(), "t", SessionStatus.ACTIVE, Instant.now(), null, null, null, null,
+                List.of(), List.of(files));
+    }
+
+    private static final AttachedFile PHOTO = new AttachedFile("f-1", "photo.png", "image/png", 240);
+    private static final AttachedFile SPEC = new AttachedFile("f-2", "spec.pdf", "application/pdf", 1024);
+    private static final AttachedFile NOTES = new AttachedFile("f-3", "notes.md", "text/markdown", 12);
+
+    @Test
+    void freshImagesAndPdfsRideAlongAsParts_otherFilesDoNot() {
+        List<ContentPart> parts = AttachmentParts.withAttachments(ContentPart.text("look"),
+                session(PHOTO, SPEC, NOTES), List.of("photo.png", "spec.pdf", "notes.md"));
+
+        assertThat(parts).containsExactly(
+                new ContentPart.Text("look"),
+                new ContentPart.Image("f-1", "photo.png", "image/png", 240),
+                new ContentPart.File("f-2", "spec.pdf", "application/pdf", 1024));
+    }
+
+    @Test
+    void onlyTheFilesAnnouncedByThisMessageAreSent() {
+        List<ContentPart> parts = AttachmentParts.withAttachments(ContentPart.text("look"),
+                session(PHOTO, SPEC), List.of("spec.pdf"));
+
+        assertThat(parts).containsExactly(
+                new ContentPart.Text("look"),
+                new ContentPart.File("f-2", "spec.pdf", "application/pdf", 1024));
+    }
+
+    @Test
+    void nothingFreshOrNoSessionLeavesThePartsAlone() {
+        List<ContentPart> text = ContentPart.text("look");
+        assertThat(AttachmentParts.withAttachments(text, session(PHOTO), List.of())).isSameAs(text);
+        assertThat(AttachmentParts.withAttachments(text, null, List.of("photo.png"))).isSameAs(text);
+    }
+
+    @Test
+    void aLegacyEntryWithoutAnIdAndAnUnknownNameAddNothing() {
+        List<ContentPart> parts = AttachmentParts.withAttachments(ContentPart.text("look"),
+                session(AttachedFile.named("old.png")), List.of("old.png", "gone.png"));
+
+        assertThat(parts).containsExactly(new ContentPart.Text("look"));
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentPartsTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/prompt/AttachmentPartsTest.java
@@ -47,6 +47,20 @@ class AttachmentPartsTest {
     }
 
     @Test
+    void aFileTheCallerAlreadySendsIsNotAddedAgain() {
+        // The REST body and the protocol bridge reference the upload by id.
+        List<ContentPart> parts = AttachmentParts.withAttachments(
+                List.of(new ContentPart.Text("look"),
+                        new ContentPart.Image("f-1", "photo.png", "image/png", 240)),
+                session(PHOTO, SPEC), List.of("photo.png", "spec.pdf"));
+
+        assertThat(parts).containsExactly(
+                new ContentPart.Text("look"),
+                new ContentPart.Image("f-1", "photo.png", "image/png", 240),
+                new ContentPart.File("f-2", "spec.pdf", "application/pdf", 1024));
+    }
+
+    @Test
     void nothingFreshOrNoSessionLeavesThePartsAlone() {
         List<ContentPart> text = ContentPart.text("look");
         assertThat(AttachmentParts.withAttachments(text, session(PHOTO), List.of())).isSameAs(text);

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/turn/ResponseReviewerChainTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/turn/ResponseReviewerChainTest.java
@@ -222,6 +222,12 @@ class ResponseReviewerChainTest {
                 Integer run, Map<String, Object> metadata) {
             throw new UnsupportedOperationException();
         }
+        @Override public Message addMessageToConversation(UUID id, UUID senderId,
+                ParticipantType senderType, MessageType type,
+                java.util.List<ai.mindconnect.message.domain.ContentPart> parts, UUID turnId,
+                Integer run, Map<String, Object> metadata) {
+            throw new UnsupportedOperationException();
+        }
         @Override public void compressMessage(UUID id, UUID messageId, String stub, Integer tokens) { }
         @Override public void updateTokenCount(UUID id, UUID messageId, int tokenCount) { }
         @Override public void updateDurationMs(UUID id, UUID messageId, long durationMs) { }

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/tools/attachment/ViewAttachmentToolTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/tools/attachment/ViewAttachmentToolTest.java
@@ -1,0 +1,160 @@
+package ai.mindconnect.agent.tools.attachment;
+
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.AttachedFile;
+import ai.mindconnect.agent.domain.SessionStatus;
+import ai.mindconnect.agent.port.out.AgentSessionRepository;
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.domain.ContentPart;
+import ai.mindconnect.message.domain.Conversation;
+import ai.mindconnect.message.domain.ConversationHistory;
+import ai.mindconnect.message.domain.ConversationType;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.Participant;
+import ai.mindconnect.message.domain.ParticipantType;
+import ai.mindconnect.message.port.in.ConversationManager;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ViewAttachmentToolTest {
+
+    private static final UUID CONVERSATION = UUID.randomUUID();
+    private static final UUID SESSION = UUID.randomUUID();
+    private static final UUID AGENT = UUID.randomUUID();
+    private static final UUID TURN = UUID.randomUUID();
+
+    private static final AttachedFile PHOTO = new AttachedFile("f-1", "photo.png", "image/png", 240);
+    private static final AttachedFile NOTES = new AttachedFile("f-3", "notes.md", "text/markdown", 12);
+
+    /** The conversation so far: the user's question and the assistant's tool call, in one turn. */
+    private final List<Message> messages = new ArrayList<>(List.of(
+            Message.of(CONVERSATION, UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT, "show me", 1)
+                    .withTurnId(TURN),
+            Message.of(CONVERSATION, AGENT, ParticipantType.AGENT, MessageType.TOOL_CALL, "{}", 2)
+                    .withTurnId(TURN).withRun(1)));
+
+    private final Conversations conversations = new Conversations();
+    private final Sessions sessions = new Sessions();
+    private final ViewAttachmentTool tool = new ViewAttachmentTool(sessions, conversations, SESSION);
+
+    private void session(AttachedFile... files) {
+        sessions.session = new AgentSession(SESSION, AGENT, Namespace.DEFAULT, "u", CONVERSATION, "t",
+                SessionStatus.ACTIVE, Instant.now(), null, null, null, null, List.of(), List.of(files));
+    }
+
+    @Test
+    void showsTheImageAsAUserMessageOfTheCurrentTurn() {
+        session(PHOTO, NOTES);
+
+        String result = tool.execute(Map.of("name", "photo.png"));
+
+        assertThat(result).contains("Showing 'photo.png'");
+        Message inserted = conversations.appended.get(0);
+        assertThat(inserted.senderType()).isEqualTo(ParticipantType.USER);
+        assertThat(inserted.type()).isEqualTo(MessageType.CHAT);
+        assertThat(inserted.turnId()).isEqualTo(TURN);
+        assertThat(inserted.run()).isEqualTo(1);
+        assertThat(inserted.parts()).containsExactly(
+                new ContentPart.Text("[photo.png — image shown again at the assistant's request]"),
+                new ContentPart.Image("f-1", "photo.png", "image/png", 240));
+        assertThat(inserted.metadata()).containsEntry(ViewAttachmentTool.INSERTED_BY, ViewAttachmentTool.NAME)
+                .containsEntry(ViewAttachmentTool.ATTACHMENT, "photo.png");
+        assertThat(ViewAttachmentTool.insertedBy(inserted)).isTrue();
+        assertThat(ViewAttachmentTool.insertedBy(messages.get(0))).isFalse();
+    }
+
+    @Test
+    void theInsertedMessageStaysInTheTurnItWasInsertedInto() {
+        session(PHOTO);
+        tool.execute(Map.of("name", "photo.png"));
+
+        ConversationHistory history = ConversationHistory.of(CONVERSATION, messages);
+
+        assertThat(history.turns()).hasSize(1);
+        assertThat(history.currentTurn().orElseThrow().messages()).hasSize(3);
+    }
+
+    @Test
+    void namesTheAttachmentsWhenTheNameIsUnknown() {
+        session(PHOTO, NOTES);
+
+        assertThat(tool.execute(Map.of("name", "other.png")))
+                .isEqualTo("No file named 'other.png'. Attached to this chat: photo.png, notes.md.");
+        assertThat(conversations.appended).isEmpty();
+    }
+
+    @Test
+    void pointsAtVectorSearchForAFileItCannotShow() {
+        session(NOTES, AttachedFile.named("old.png"));
+
+        assertThat(tool.execute(Map.of("name", "notes.md"))).contains("not an image or PDF", "vector_search");
+        assertThat(tool.execute(Map.of("name", "old.png"))).contains("not an image or PDF that can be shown again");
+        assertThat(tool.execute(Map.of())).startsWith("Error:");
+        assertThat(conversations.appended).isEmpty();
+    }
+
+    // ── doubles ────────────────────────────────────────────────────────────
+
+    private final class Conversations implements ConversationManager {
+        final List<Message> appended = new ArrayList<>();
+
+        @Override public Conversation createConversation(Namespace ns, String topic, ConversationType type,
+                                                         List<Participant> participants) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public Optional<Conversation> findById(UUID id) { throw new UnsupportedOperationException(); }
+        @Override public List<Conversation> listByNamespace(Namespace ns, PageRequest page) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public List<Message> loadHistory(UUID id, PageRequest page) { return List.copyOf(messages); }
+        @Override public ConversationHistory loadCompleteHistory(UUID id) {
+            return ConversationHistory.of(id, messages);
+        }
+        @Override public Message addMessageToConversation(UUID id, UUID senderId, ParticipantType senderType,
+                                                          MessageType type, String content, UUID turnId) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public Message addMessageToConversation(UUID id, UUID senderId, ParticipantType senderType,
+                                                          MessageType type, String content, UUID turnId,
+                                                          Integer run, Map<String, Object> metadata) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public Message addMessageToConversation(UUID id, UUID senderId, ParticipantType senderType,
+                                                          MessageType type, List<ContentPart> parts, UUID turnId,
+                                                          Integer run, Map<String, Object> metadata) {
+            Message m = Message.of(id, senderId, senderType, type, parts, messages.size() + 1)
+                    .withTurnId(turnId).withMetadata(metadata);
+            if (run != null) m = m.withRun(run);
+            messages.add(m);
+            appended.add(m);
+            return m;
+        }
+        @Override public void compressMessage(UUID id, UUID messageId, String stub, Integer tokens) { }
+        @Override public void updateTokenCount(UUID id, UUID messageId, int tokenCount) { }
+        @Override public void updateDurationMs(UUID id, UUID messageId, long durationMs) { }
+        @Override public int deleteMessages(UUID id, int fromSeq, int toSeq) { return 0; }
+    }
+
+    private static final class Sessions implements AgentSessionRepository {
+        AgentSession session;
+
+        @Override public AgentSession save(AgentSession s) { session = s; return s; }
+        @Override public Optional<AgentSession> findById(UUID id) {
+            return Optional.ofNullable(session).filter(s -> s.id().equals(id));
+        }
+        @Override public List<AgentSession> findByAgentDefinitionId(UUID a, Namespace ns, String u) { return List.of(); }
+        @Override public List<AgentSession> findByUser(Namespace ns, String u) { return List.of(); }
+        @Override public List<AgentSession> findByParentSessionId(UUID p) { return List.of(); }
+        @Override public void deleteById(UUID id) { }
+    }
+}

--- a/agents/core/mc-agent-runtime/pom.xml
+++ b/agents/core/mc-agent-runtime/pom.xml
@@ -48,6 +48,12 @@
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-message-repository-core</artifactId>
         </dependency>
+        <!-- The file-store port: this module adapts it to the runtime's
+             PartContentReader, so media parts get their bytes. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-file-store-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/config/DefaultAgentRuntimeConfig.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/config/DefaultAgentRuntimeConfig.java
@@ -162,6 +162,20 @@ public class DefaultAgentRuntimeConfig {
      * bean when it defines one, the runtime's default otherwise. Define a
      * bean of that type to replace the default; nothing else to configure.
      */
+    /**
+     * Where a media part gets its bytes: the host's file store when there is
+     * one, nothing otherwise — then every image and document part renders
+     * as its placeholder line.
+     */
+    @Bean
+    ai.mindconnect.agent.port.out.PartContentReader partContentReader(
+            org.springframework.beans.factory.ObjectProvider<ai.mindconnect.filestore.FileStore> fileStore) {
+        ai.mindconnect.filestore.FileStore store = fileStore.getIfAvailable();
+        return store != null
+                ? new ai.mindconnect.agent.adapter.filestore.FileStorePartContentReader(store)
+                : ai.mindconnect.agent.port.out.PartContentReader.none();
+    }
+
     @Bean
     MemoryStrategyFactory memoryStrategyFactory(ConversationManager conversationManager,
                                                 ConversationSummaryRepository conversationSummaryRepository,
@@ -169,11 +183,13 @@ public class DefaultAgentRuntimeConfig {
                                                 AgentTaskRunner runTaskUseCase,
                                                 TokenCounters tokenCounterRegistry,
                                                 LlmConfigRepository llmConfigRepository,
+                                                ai.mindconnect.agent.port.out.PartContentReader partContentReader,
                                                 org.springframework.beans.factory.ObjectProvider<ai.mindconnect.agent.port.out.LlmMessageMapper> messageMapper) {
         return new DefaultMemoryStrategyFactory(conversationManager,
                 conversationSummaryRepository, toolResultSummarizer, runTaskUseCase,
                 tokenCounterRegistry, llmConfigRepository,
-                messageMapper.getIfAvailable(ai.mindconnect.agent.service.MessageToLlmMessageMapper::new));
+                messageMapper.getIfAvailable(() ->
+                        new ai.mindconnect.agent.service.MessageToLlmMessageMapper(partContentReader)));
     }
 
     /** Session-scoped tool activations written by tool_search, read per round. */

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/filestore/FileStorePartContentReader.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/filestore/FileStorePartContentReader.java
@@ -1,0 +1,42 @@
+package ai.mindconnect.agent.adapter.filestore;
+
+import ai.mindconnect.agent.port.out.PartContentReader;
+import ai.mindconnect.filestore.FileStore;
+import ai.mindconnect.filestore.StoredFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@link PartContentReader} over the host's {@link FileStore}: a media part's
+ * file id is a file-store id, its bytes are the stored content, its media
+ * type what the upload recorded. A missing or unreadable file reads as
+ * empty — the mapper renders a placeholder, the turn goes on.
+ */
+public final class FileStorePartContentReader implements PartContentReader {
+
+    private static final Logger log = LoggerFactory.getLogger(FileStorePartContentReader.class);
+
+    private final FileStore fileStore;
+
+    public FileStorePartContentReader(FileStore fileStore) {
+        this.fileStore = Objects.requireNonNull(fileStore, "fileStore");
+    }
+
+    @Override
+    public Optional<Content> read(String fileId) {
+        if (fileId == null) return Optional.empty();
+        StoredFile file = fileStore.find(fileId).orElse(null);
+        if (file == null) return Optional.empty();
+        try (InputStream in = fileStore.content(fileId)) {
+            return Optional.of(new Content(in.readAllBytes(), file.contentType()));
+        } catch (IOException e) {
+            log.warn("Could not read file {} ({}): {}", fileId, file.name(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/adapter/filestore/FileStorePartContentReaderTest.java
+++ b/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/adapter/filestore/FileStorePartContentReaderTest.java
@@ -1,0 +1,77 @@
+package ai.mindconnect.agent.adapter.filestore;
+
+import ai.mindconnect.agent.port.out.PartContentReader;
+import ai.mindconnect.filestore.FileStore;
+import ai.mindconnect.filestore.StoredFile;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileStorePartContentReaderTest {
+
+    /** The smallest FileStore that can hold a file: a map. */
+    static final class MapFileStore implements FileStore {
+        final Map<String, StoredFile> files = new HashMap<>();
+        final Map<String, byte[]> bytes = new HashMap<>();
+        boolean failReads;
+
+        @Override
+        public StoredFile save(String name, String contentType, InputStream content) throws IOException {
+            byte[] data = content.readAllBytes();
+            StoredFile file = new StoredFile(UUID.randomUUID().toString(), name, contentType, data.length, Instant.now());
+            files.put(file.id(), file);
+            bytes.put(file.id(), data);
+            return file;
+        }
+
+        @Override public Optional<StoredFile> find(String id) { return Optional.ofNullable(files.get(id)); }
+
+        @Override
+        public InputStream content(String id) throws IOException {
+            if (failReads) throw new IOException("disk on fire");
+            return new ByteArrayInputStream(bytes.get(id));
+        }
+
+        @Override public List<StoredFile> list() { return List.copyOf(files.values()); }
+        @Override public void delete(String id) { files.remove(id); bytes.remove(id); }
+    }
+
+    private final MapFileStore store = new MapFileStore();
+    private final PartContentReader reader = new FileStorePartContentReader(store);
+
+    @Test
+    void readsBytesAndMediaTypeOfAStoredFile() throws Exception {
+        StoredFile file = store.save("photo.png", "image/png",
+                new ByteArrayInputStream("PNG-BYTES".getBytes(StandardCharsets.UTF_8)));
+
+        PartContentReader.Content content = reader.read(file.id()).orElseThrow();
+
+        assertThat(new String(content.bytes(), StandardCharsets.UTF_8)).isEqualTo("PNG-BYTES");
+        assertThat(content.mediaType()).isEqualTo("image/png");
+    }
+
+    @Test
+    void anUnknownOrNullIdReadsAsEmpty() {
+        assertThat(reader.read("nope")).isEmpty();
+        assertThat(reader.read(null)).isEmpty();
+    }
+
+    @Test
+    void anUnreadableFileReadsAsEmptyInsteadOfThrowing() throws Exception {
+        StoredFile file = store.save("photo.png", "image/png", new ByteArrayInputStream(new byte[] {1}));
+        store.failReads = true;
+
+        assertThat(reader.read(file.id())).isEmpty();
+    }
+}

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmCallEvent.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmCallEvent.java
@@ -37,7 +37,12 @@ public record LlmCallEvent(
         int completionTokens,
         /** Provider-reported finish reason ({@code stop}, {@code tool_calls}, …) or {@code null}. */
         String finishReason,
-        /** Verbatim request body the adapter sent. Provider-specific JSON. */
+        /**
+         * The request body the adapter sent, provider-specific JSON — with
+         * one edit: an inline media payload (an image or PDF as base64) is
+         * replaced by a note naming its media type and length, so a trace
+         * does not grow by the size of every attachment.
+         */
         String requestJson,
         /**
          * Verbatim SSE event blocks the provider streamed back, in arrival

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmCapability.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmCapability.java
@@ -1,12 +1,14 @@
 package ai.mindconnect.llm.domain;
 
 /**
- * What a chat model can take in and do, as declared on its {@link LlmConfig}.
- * The set is <em>informative</em>: the admin states it, the UI shows it, and a
- * caller that wants to know whether a model reads images asks the config
- * instead of guessing from the model id. Nothing in the runtime derives its
- * control flow from it yet — a config that leaves the set empty still runs
- * exactly as before.
+ * What a chat model can take in and do, as declared on its {@link LlmConfig}
+ * or, when the config declares nothing, taken from its provider's default
+ * ({@link LlmProvider#defaultCapabilities()}). {@link #VISION} and
+ * {@link #DOCUMENTS} steer the runtime: the message mapper sends an image or
+ * PDF to the model as content when the config has the capability, and as a
+ * placeholder line when it does not. {@link #TOOL_CALLING} and
+ * {@link #AUDIO_INPUT} are declarative for now — shown, readable through
+ * {@link LlmConfig#supports}, not yet acted on.
  *
  * <p>Only meaningful for {@link LlmConfigType#CHAT} configs; embedding models
  * have no input modalities to declare.

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmCapability.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmCapability.java
@@ -1,0 +1,41 @@
+package ai.mindconnect.llm.domain;
+
+/**
+ * What a chat model can take in and do, as declared on its {@link LlmConfig}.
+ * The set is <em>informative</em>: the admin states it, the UI shows it, and a
+ * caller that wants to know whether a model reads images asks the config
+ * instead of guessing from the model id. Nothing in the runtime derives its
+ * control flow from it yet — a config that leaves the set empty still runs
+ * exactly as before.
+ *
+ * <p>Only meaningful for {@link LlmConfigType#CHAT} configs; embedding models
+ * have no input modalities to declare.
+ */
+public enum LlmCapability {
+    /** The model can call tools (function calling). */
+    TOOL_CALLING("Tool calling", "The model can call tools (function calling)"),
+    /** The model reads images sent as message content. */
+    VISION("Vision", "The model reads images (PNG, JPEG, WebP, GIF) sent with a message"),
+    /** The model reads documents (PDF) sent as message content. */
+    DOCUMENTS("Documents", "The model reads documents such as PDF sent with a message"),
+    /** The model takes audio as message content. */
+    AUDIO_INPUT("Audio input", "The model takes audio (speech) as message content");
+
+    private final String label;
+    private final String description;
+
+    LlmCapability(String label, String description) {
+        this.label = label;
+        this.description = description;
+    }
+
+    /** Short display name for UIs. */
+    public String label() {
+        return label;
+    }
+
+    /** One line explaining the capability, for hints and detail views. */
+    public String description() {
+        return description;
+    }
+}

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
@@ -4,6 +4,8 @@ import ai.mindconnect.common.util.EnvVarResolver;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -52,11 +54,33 @@ public record LlmConfig(
          * vectors and have no sampling settings — temperature, output tokens,
          * thinking etc. don't apply.
          */
-        LlmConfigType type
+        LlmConfigType type,
+        /**
+         * What the model can take in and do — see {@link LlmCapability}.
+         * Declared by the admin, shown by the UI, asked by callers that want
+         * to know whether a model reads images; the runtime does not derive
+         * its control flow from it. Never {@code null}: an unset or legacy
+         * config reads as the empty set.
+         */
+        Set<LlmCapability> capabilities
 ) {
-    /** Normalises {@code null} (legacy configs, terse callers) to CHAT. */
+    /**
+     * Normalises {@code null} (legacy configs, terse callers): the type to
+     * CHAT, the capabilities to the empty set. The set is stored as an
+     * unmodifiable copy in declaration order, so JSON and UI show a stable
+     * sequence.
+     */
     public LlmConfig {
         if (type == null) type = LlmConfigType.CHAT;
+        capabilities = capabilities == null || capabilities.isEmpty()
+                ? Set.of()
+                : Collections.unmodifiableSet(EnumSet.copyOf(capabilities));
+    }
+
+    /** Convenience: does this config declare the given capability? */
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    public boolean supports(LlmCapability capability) {
+        return capabilities.contains(capability);
     }
 
     /** Convenience: is this an embedding model? */
@@ -82,11 +106,12 @@ public record LlmConfig(
             @JsonProperty("delegatesTo")          String delegatesTo,
             @JsonProperty("retry")                RetryConfig retry,
             @JsonProperty("rateLimit")            RateLimitConfig rateLimit,
-            @JsonProperty("type")                 LlmConfigType type) {
+            @JsonProperty("type")                 LlmConfigType type,
+            @JsonProperty("capabilities")         Set<LlmCapability> capabilities) {
         return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
                 defaultTemperature, maxOutputTokens,
                 additionalParams != null ? additionalParams : Map.of(),
-                contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type);
+                contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
     }
 
 
@@ -97,27 +122,27 @@ public record LlmConfig(
      */
     public static LlmConfig alias(String name, String delegatesTo) {
         return new LlmConfig(UUID.randomUUID(), name, null, null, null, null,
-                0.0, 0, Map.of(), null, true, delegatesTo, null, null, null);
+                0.0, 0, Map.of(), null, true, delegatesTo, null, null, null, null);
     }
 
     public static LlmConfig lmStudio(String name, String model, String baseUrl) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.LM_STUDIO,
-                model, baseUrl, "lm-studio", 0.7, 2048, Map.of(), 131_072, false, null, null, null, null);
+                model, baseUrl, "lm-studio", 0.7, 2048, Map.of(), 131_072, false, null, null, null, null, null);
     }
 
     public static LlmConfig claude(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.ANTHROPIC,
-                model, "https://api.anthropic.com", apiKey, 0.7, 8192, Map.of(), 200_000, false, null, null, null, null);
+                model, "https://api.anthropic.com", apiKey, 0.7, 8192, Map.of(), 200_000, false, null, null, null, null, null);
     }
 
     public static LlmConfig ollama(String name, String model, String baseUrl) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.OLLAMA,
-                model, baseUrl, "ollama", 0.7, 4096, Map.of(), null, false, null, null, null, null);
+                model, baseUrl, "ollama", 0.7, 4096, Map.of(), null, false, null, null, null, null, null);
     }
 
     public static LlmConfig mistral(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.MISTRAL,
-                model, "https://api.mistral.ai", apiKey, 0.7, 4096, Map.of(), 128_000, false, null, null, null, null);
+                model, "https://api.mistral.ai", apiKey, 0.7, 4096, Map.of(), 128_000, false, null, null, null, null, null);
     }
 
     /**
@@ -126,37 +151,37 @@ public record LlmConfig(
      */
     public static LlmConfig azureOpenAi(String name, String deployment, String baseUrl, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.AZURE_OPENAI,
-                deployment, baseUrl, apiKey, 0.7, 4096, Map.of(), 128_000, false, null, null, null, null);
+                deployment, baseUrl, apiKey, 0.7, 4096, Map.of(), 128_000, false, null, null, null, null, null);
     }
 
     public static LlmConfig deepSeek(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.DEEPSEEK,
-                model, "https://api.deepseek.com", apiKey, 0.7, 4096, Map.of(), 64_000, false, null, null, null, null);
+                model, "https://api.deepseek.com", apiKey, 0.7, 4096, Map.of(), 64_000, false, null, null, null, null, null);
     }
 
     public static LlmConfig together(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.TOGETHER,
-                model, "https://api.together.xyz", apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null);
+                model, "https://api.together.xyz", apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null, null);
     }
 
     public static LlmConfig openRouter(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.OPENROUTER,
-                model, "https://openrouter.ai/api", apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null);
+                model, "https://openrouter.ai/api", apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null, null);
     }
 
     public static LlmConfig perplexity(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.PERPLEXITY,
-                model, "https://api.perplexity.ai", apiKey, 0.7, 4096, Map.of(), 128_000, false, null, null, null, null);
+                model, "https://api.perplexity.ai", apiKey, 0.7, 4096, Map.of(), 128_000, false, null, null, null, null, null);
     }
 
     public static LlmConfig fireworks(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.FIREWORKS,
-                model, "https://api.fireworks.ai/inference", apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null);
+                model, "https://api.fireworks.ai/inference", apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null, null);
     }
 
     public static LlmConfig googleGemini(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.GOOGLE_GEMINI,
-                model, "https://generativelanguage.googleapis.com", apiKey, 0.7, 8192, Map.of(), 1_000_000, false, null, null, null, null);
+                model, "https://generativelanguage.googleapis.com", apiKey, 0.7, 8192, Map.of(), 1_000_000, false, null, null, null, null, null);
     }
 
     /** Guards against runaway / circular alias chains. */
@@ -200,12 +225,18 @@ public record LlmConfig(
 
     public LlmConfig withContextWindowTokens(Integer contextWindowTokens) {
         return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
-                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type);
+                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
     }
 
     public LlmConfig withApiKey(String apiKey) {
         return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
-                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type);
+                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
+    }
+
+    /** Returns a copy declaring exactly the given capabilities ({@code null} clears them). */
+    public LlmConfig withCapabilities(Set<LlmCapability> capabilities) {
+        return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
+                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
     }
 
     /**
@@ -231,7 +262,8 @@ public record LlmConfig(
                 delegatesTo,
                 retry,
                 rateLimit,
-                type);
+                type,
+                capabilities);
     }
 
     /**

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
@@ -56,31 +56,52 @@ public record LlmConfig(
          */
         LlmConfigType type,
         /**
-         * What the model can take in and do — see {@link LlmCapability}.
-         * Declared by the admin, shown by the UI, asked by callers that want
-         * to know whether a model reads images; the runtime does not derive
-         * its control flow from it. Never {@code null}: an unset or legacy
-         * config reads as the empty set.
+         * What the model can take in and do — see {@link LlmCapability}. The
+         * runtime reads it: {@code VISION} and {@code DOCUMENTS} decide whether
+         * an image or PDF sent with a message reaches the model as content or
+         * as a placeholder line. {@code null} means <em>not declared</em> — a
+         * config written before the field existed, or one that leaves the
+         * decision to the provider — and then {@link LlmProvider#defaultCapabilities()}
+         * applies; see {@link #effectiveCapabilities()}. A declared set, the
+         * empty set included, always wins over that default.
          */
         Set<LlmCapability> capabilities
 ) {
     /**
-     * Normalises {@code null} (legacy configs, terse callers): the type to
-     * CHAT, the capabilities to the empty set. The set is stored as an
-     * unmodifiable copy in declaration order, so JSON and UI show a stable
-     * sequence.
+     * Normalises the type ({@code null} reads as CHAT) and keeps a declared
+     * capability set as an unmodifiable copy in declaration order, so JSON
+     * and UI show a stable sequence. {@code null} stays {@code null}: not
+     * declared is a state of its own.
      */
     public LlmConfig {
         if (type == null) type = LlmConfigType.CHAT;
-        capabilities = capabilities == null || capabilities.isEmpty()
-                ? Set.of()
-                : Collections.unmodifiableSet(EnumSet.copyOf(capabilities));
+        if (capabilities != null) {
+            capabilities = capabilities.isEmpty() ? Set.of()
+                    : Collections.unmodifiableSet(EnumSet.copyOf(capabilities));
+        }
     }
 
-    /** Convenience: does this config declare the given capability? */
+    /** Has this config declared its capabilities itself, rather than leaving them to the provider? */
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    public boolean declaresCapabilities() {
+        return capabilities != null;
+    }
+
+    /**
+     * The capabilities that hold for this config: the declared set when there
+     * is one, else the provider's default, else (no provider — an alias)
+     * nothing. What the runtime asks through {@link #supports}.
+     */
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    public Set<LlmCapability> effectiveCapabilities() {
+        if (capabilities != null) return capabilities;
+        return provider != null ? provider.defaultCapabilities() : Set.of();
+    }
+
+    /** Does this config — declared or by its provider's default — have the given capability? */
     @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean supports(LlmCapability capability) {
-        return capabilities.contains(capability);
+        return effectiveCapabilities().contains(capability);
     }
 
     /** Convenience: is this an embedding model? */
@@ -233,7 +254,7 @@ public record LlmConfig(
                 defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
     }
 
-    /** Returns a copy declaring exactly the given capabilities ({@code null} clears them). */
+    /** Returns a copy declaring exactly the given capabilities ({@code null}: not declared, the provider's default applies). */
     public LlmConfig withCapabilities(Set<LlmCapability> capabilities) {
         return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
                 defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmContent.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmContent.java
@@ -1,0 +1,28 @@
+package ai.mindconnect.llm.domain;
+
+/**
+ * One block of an {@link LlmMessage}'s content, as a gateway renders it into
+ * the provider's content array. Media travels inline as base64 — the gateway
+ * is the last stop before the wire, so this is where bytes belong; the
+ * conversation records upstream carry references only.
+ *
+ * <p>Text-only messages are one {@link Text}; the gateways render those as a
+ * plain string, exactly as before content blocks existed, so a provider that
+ * never learned arrays (a local server behind an OpenAI-compatible endpoint)
+ * sees the same request it always did.
+ */
+public sealed interface LlmContent {
+
+    /** A run of text. */
+    record Text(String text) implements LlmContent {
+        public Text {
+            if (text == null) text = "";
+        }
+    }
+
+    /** An image, base64-encoded, with its media type ({@code image/png}, …). */
+    record Image(String base64, String mediaType) implements LlmContent {}
+
+    /** A document, base64-encoded, with its media type and the name the provider shows. */
+    record Document(String base64, String mediaType, String name) implements LlmContent {}
+}

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmMessage.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmMessage.java
@@ -1,35 +1,67 @@
 package ai.mindconnect.llm.domain;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
+ * One message of an LLM request. Its content is a list of {@link LlmContent}
+ * blocks — for almost every message exactly one {@link LlmContent.Text}, for
+ * a user message carrying images or documents a text block plus the media.
+ * {@link #content()} is the text of those blocks, which is what every reader
+ * that does not render media wants.
+ *
+ * @param parts          the content blocks; empty for an assistant turn that
+ *                       only calls tools
  * @param thinkingBlocks reasoning blocks (with signatures) that preceded the
  *        tool calls in an assistant turn. Anthropic-specific; null for every
  *        other provider. Must be replayed before {@code toolCalls} in history
  *        (see {@link ThinkingBlock}).
  */
-public record LlmMessage(MessageRole role, String content, String toolCallId,
+public record LlmMessage(MessageRole role, List<LlmContent> parts, String toolCallId,
                          List<ToolCall> toolCalls, List<ThinkingBlock> thinkingBlocks) {
 
-    /** Compatibility constructor for messages without thinking blocks. */
-    public LlmMessage(MessageRole role, String content, String toolCallId, List<ToolCall> toolCalls) {
-        this(role, content, toolCallId, toolCalls, null);
+    /** {@code parts} is never null, and never modifiable. */
+    public LlmMessage {
+        parts = parts == null ? List.of() : List.copyOf(parts);
+    }
+
+    /**
+     * The text of the message — its text blocks joined in order — or
+     * {@code null} when there is no text block at all (an assistant turn that
+     * only calls tools). Media blocks contribute nothing.
+     */
+    public String content() {
+        List<String> texts = parts.stream()
+                .filter(LlmContent.Text.class::isInstance)
+                .map(p -> ((LlmContent.Text) p).text())
+                .toList();
+        return texts.isEmpty() ? null : String.join("\n", texts);
+    }
+
+    /** Does any block carry media — an image or a document? */
+    public boolean hasMedia() {
+        return parts.stream().anyMatch(p -> !(p instanceof LlmContent.Text));
     }
 
     public static LlmMessage system(String content) {
-        return new LlmMessage(MessageRole.SYSTEM, content, null, null);
+        return new LlmMessage(MessageRole.SYSTEM, textBlocks(content), null, null, null);
     }
 
     public static LlmMessage user(String content) {
-        return new LlmMessage(MessageRole.USER, content, null, null);
+        return new LlmMessage(MessageRole.USER, textBlocks(content), null, null, null);
+    }
+
+    /** A user message made of content blocks — text plus the images and documents sent with it. */
+    public static LlmMessage user(List<LlmContent> parts) {
+        return new LlmMessage(MessageRole.USER, parts, null, null, null);
     }
 
     public static LlmMessage assistant(String content) {
-        return new LlmMessage(MessageRole.ASSISTANT, content, null, null);
+        return new LlmMessage(MessageRole.ASSISTANT, textBlocks(content), null, null, null);
     }
 
     public static LlmMessage assistantWithToolCalls(List<ToolCall> toolCalls) {
-        return new LlmMessage(MessageRole.ASSISTANT, null, null, toolCalls);
+        return new LlmMessage(MessageRole.ASSISTANT, null, null, toolCalls, null);
     }
 
     /** Assistant turn carrying thinking blocks that preceded the tool calls. */
@@ -39,6 +71,21 @@ public record LlmMessage(MessageRole role, String content, String toolCallId,
     }
 
     public static LlmMessage tool(String toolCallId, String content) {
-        return new LlmMessage(MessageRole.TOOL, content, toolCallId, null);
+        return new LlmMessage(MessageRole.TOOL, textBlocks(content), toolCallId, null, null);
+    }
+
+    /** A plain string as its one text block; {@code null} text is no block at all. */
+    private static List<LlmContent> textBlocks(String content) {
+        return content == null ? List.of() : List.of(new LlmContent.Text(content));
+    }
+
+    @Override
+    public String toString() {
+        return "LlmMessage[role=" + role + ", content=" + content()
+                + (hasMedia() ? ", media=" + parts.stream().filter(p -> !(p instanceof LlmContent.Text))
+                        .map(p -> p.getClass().getSimpleName()).collect(Collectors.joining(",")) : "")
+                + (toolCallId != null ? ", toolCallId=" + toolCallId : "")
+                + (toolCalls != null ? ", toolCalls=" + toolCalls : "")
+                + (thinkingBlocks != null ? ", thinkingBlocks=" + thinkingBlocks : "") + "]";
     }
 }

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
@@ -1,6 +1,9 @@
 package ai.mindconnect.llm.domain;
 
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Supported providers. Each constant also declares the {@link AdditionalParamSpec}s
@@ -9,11 +12,11 @@ import java.util.List;
  * providers endpoint of the REST API.
  */
 public enum LlmProvider {
-    LM_STUDIO,
-    OPENAI,
-    AZURE_OPENAI,
-    GROQ,
-    ANTHROPIC(List.of(
+    LM_STUDIO(Set.of(LlmCapability.TOOL_CALLING)),
+    OPENAI(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS)),
+    AZURE_OPENAI(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION)),
+    GROQ(Set.of(LlmCapability.TOOL_CALLING)),
+    ANTHROPIC(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS), List.of(
             AdditionalParamSpec.select("thinking", "Thinking",
                     List.of("adaptive", "disabled"),
                     "Anthropic adaptive thinking. 'adaptive' enables reasoning + interleaved "
@@ -24,23 +27,40 @@ public enum LlmProvider {
                     "Reasoning depth / token spend. Only applies when thinking is set. "
                             + "Leave at 'default' to omit.",
                     LlmConfigType.CHAT))),
-    OLLAMA,
-    MISTRAL,
-    DEEPSEEK,
-    TOGETHER,
-    OPENROUTER,
-    PERPLEXITY,
-    FIREWORKS,
-    GOOGLE_GEMINI;
+    OLLAMA(Set.of(LlmCapability.TOOL_CALLING)),
+    MISTRAL(Set.of(LlmCapability.TOOL_CALLING)),
+    DEEPSEEK(Set.of(LlmCapability.TOOL_CALLING)),
+    TOGETHER(Set.of(LlmCapability.TOOL_CALLING)),
+    OPENROUTER(Set.of(LlmCapability.TOOL_CALLING)),
+    PERPLEXITY(Set.of(LlmCapability.TOOL_CALLING)),
+    FIREWORKS(Set.of(LlmCapability.TOOL_CALLING)),
+    GOOGLE_GEMINI(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS,
+            LlmCapability.AUDIO_INPUT));
 
+    private final Set<LlmCapability> defaultCapabilities;
     private final List<AdditionalParamSpec> additionalParams;
 
-    LlmProvider() {
-        this(List.of());
+    LlmProvider(Set<LlmCapability> defaultCapabilities) {
+        this(defaultCapabilities, List.of());
     }
 
-    LlmProvider(List<AdditionalParamSpec> additionalParams) {
+    LlmProvider(Set<LlmCapability> defaultCapabilities, List<AdditionalParamSpec> additionalParams) {
+        this.defaultCapabilities = defaultCapabilities.isEmpty() ? Set.of()
+                : Collections.unmodifiableSet(EnumSet.copyOf(defaultCapabilities));
         this.additionalParams = additionalParams;
+    }
+
+    /**
+     * What a config of this provider is taken to read and do when it declares
+     * nothing itself ({@link LlmConfig#capabilities()} is {@code null}): the
+     * provider's current mainstream models. Cloud providers whose models all
+     * read images and PDFs get {@code VISION} and {@code DOCUMENTS}; hosts of
+     * arbitrary models (local servers, routers) only {@code TOOL_CALLING}, since
+     * what runs there is anyone's guess — declare it on the config. A declared
+     * set, empty included, always wins over this default.
+     */
+    public Set<LlmCapability> defaultCapabilities() {
+        return defaultCapabilities;
     }
 
     /** The additional-parameter fields this provider's gateway understands. */

--- a/agents/core/mc-llm-gateway-core/src/test/java/ai/mindconnect/llm/domain/LlmMessageTest.java
+++ b/agents/core/mc-llm-gateway-core/src/test/java/ai/mindconnect/llm/domain/LlmMessageTest.java
@@ -1,0 +1,66 @@
+package ai.mindconnect.llm.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** The content-block shape of {@link LlmMessage}, and {@code content()} as the text of it. */
+class LlmMessageTest {
+
+    @Test
+    void aTextMessageIsOneTextBlock() {
+        LlmMessage m = LlmMessage.user("hello");
+
+        assertThat(m.parts()).containsExactly(new LlmContent.Text("hello"));
+        assertThat(m.content()).isEqualTo("hello");
+        assertThat(m.hasMedia()).isFalse();
+    }
+
+    @Test
+    void contentJoinsTheTextBlocksAndSkipsMedia() {
+        LlmMessage m = LlmMessage.user(List.of(
+                new LlmContent.Text("look:"),
+                new LlmContent.Image("AAAA", "image/png"),
+                new LlmContent.Text("what is it?")));
+
+        assertThat(m.content()).isEqualTo("look:\nwhat is it?");
+        assertThat(m.hasMedia()).isTrue();
+    }
+
+    @Test
+    void aToolCallTurnHasNoContent() {
+        LlmMessage m = LlmMessage.assistantWithToolCalls(
+                List.of(new ToolCall("c1", "get_weather", Map.of("city", "Berlin"), null)));
+
+        assertThat(m.parts()).isEmpty();
+        assertThat(m.content()).isNull();
+        assertThat(m.hasMedia()).isFalse();
+    }
+
+    @Test
+    void nullTextIsNoBlock() {
+        assertThat(LlmMessage.assistant(null).parts()).isEmpty();
+        assertThat(LlmMessage.assistant(null).content()).isNull();
+        assertThat(LlmMessage.tool("c1", "ok").content()).isEqualTo("ok");
+        assertThat(LlmMessage.tool("c1", "ok").toolCallId()).isEqualTo("c1");
+    }
+
+    @Test
+    void partsAreUnmodifiable() {
+        LlmMessage m = LlmMessage.user("hello");
+        assertThatThrownBy(() -> m.parts().add(new LlmContent.Text("more")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void toStringNamesTheMediaButNotItsBytes() {
+        LlmMessage m = LlmMessage.user(List.of(
+                new LlmContent.Text("see"), new LlmContent.Image("QUFBQUFBQUFB", "image/png")));
+
+        assertThat(m.toString()).contains("content=see", "media=Image").doesNotContain("QUFBQUFBQUFB");
+    }
+}

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/TraceRedaction.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/TraceRedaction.java
@@ -1,0 +1,85 @@
+package ai.mindconnect.llm.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * The request body as a trace or a debug log should carry it: with the
+ * media payloads cut out. An image or PDF travels inline as base64 — a
+ * megabyte or more per picture — and the {@code LlmCallEvent} is persisted
+ * per call, so the verbatim body would grow the trace store by the size of
+ * every attachment on every turn. The wire request itself is untouched.
+ *
+ * <p>Two shapes are recognised, whatever the provider's field names: a data
+ * URL ({@code data:image/png;base64,…} — OpenAI's {@code image_url} and
+ * {@code file_data}) and a bare base64 string of some length (Anthropic's
+ * {@code source.data}, Gemini's {@code inline_data.data}). Both are replaced
+ * by a short note that keeps the media type and the payload's length, so
+ * the trace still shows what was sent.
+ */
+public final class TraceRedaction {
+
+    /** A bare string this long that is all base64 characters is treated as a payload. */
+    static final int BASE64_MIN_LENGTH = 1024;
+
+    private static final Pattern BASE64 = Pattern.compile("[A-Za-z0-9+/=\\r\\n]+");
+
+    private TraceRedaction() {
+    }
+
+    /** A copy of {@code node} with media payloads replaced; the argument is not modified. */
+    public static JsonNode redactMedia(JsonNode node) {
+        if (node == null) return null;
+        JsonNode copy = node.deepCopy();
+        redactInPlace(copy);
+        return copy;
+    }
+
+    private static void redactInPlace(JsonNode node) {
+        if (node instanceof ObjectNode object) {
+            Iterator<Map.Entry<String, JsonNode>> fields = object.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                JsonNode replacement = redacted(field.getValue());
+                if (replacement != null) {
+                    field.setValue(replacement);
+                } else {
+                    redactInPlace(field.getValue());
+                }
+            }
+        } else if (node instanceof ArrayNode array) {
+            for (int i = 0; i < array.size(); i++) {
+                JsonNode replacement = redacted(array.get(i));
+                if (replacement != null) {
+                    array.set(i, replacement);
+                } else {
+                    redactInPlace(array.get(i));
+                }
+            }
+        }
+    }
+
+    /** The note that stands in for a payload, or {@code null} when the value is not one. */
+    private static JsonNode redacted(JsonNode value) {
+        if (!value.isTextual()) return null;
+        String text = value.asText();
+        if (text.startsWith("data:")) {
+            int comma = text.indexOf(";base64,");
+            if (comma > 0) {
+                String mediaType = text.substring("data:".length(), comma);
+                return new TextNode("data:" + mediaType + ";base64,<"
+                        + (text.length() - comma - ";base64,".length()) + " chars omitted>");
+            }
+        }
+        if (text.length() >= BASE64_MIN_LENGTH && BASE64.matcher(text).matches()) {
+            return new TextNode("<base64, " + text.length() + " chars omitted>");
+        }
+        return null;
+    }
+}

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGateway.java
@@ -2,6 +2,7 @@ package ai.mindconnect.llm.adapter.anthropic;
 
 import ai.mindconnect.common.Cancellation;
 import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import ai.mindconnect.llm.adapter.TraceRedaction;
 import ai.mindconnect.llm.domain.*;
 import ai.mindconnect.llm.port.in.LlmCallListener;
 import ai.mindconnect.llm.port.out.LlmGateway;
@@ -82,7 +83,7 @@ public class ClaudeGateway implements LlmGateway {
         String body;
         try {
             ObjectNode requestNode = buildRequestNode(config, request);
-            try { prettyRequestJson = prettyWriter.writeValueAsString(requestNode); } catch (Exception ignored) {}
+            try { prettyRequestJson = prettyWriter.writeValueAsString(TraceRedaction.redactMedia(requestNode)); } catch (Exception ignored) {}
             logWireRequest(requestNode);
             body = objectMapper.writeValueAsString(requestNode);
         } catch (IOException e) {
@@ -371,7 +372,7 @@ public class ClaudeGateway implements LlmGateway {
     private void logWireRequest(ObjectNode requestNode) {
         if (!wire.isDebugEnabled()) return;
         try {
-            wire.debug("→ stream request:\n{}", prettyWriter.writeValueAsString(requestNode));
+            wire.debug("→ stream request:\n{}", prettyWriter.writeValueAsString(TraceRedaction.redactMedia(requestNode)));
         } catch (Exception e) {
             wire.debug("→ stream request: <serialise failed: {}>", e.getMessage());
         }

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGateway.java
@@ -472,6 +472,27 @@ public class ClaudeGateway implements LlmGateway {
                     block.put("name", tc.name());
                     block.set("input", objectMapper.valueToTree(tc.arguments()));
                 }
+            } else if (msg.hasMedia()) {
+                // A user message with images / documents — content blocks,
+                // media inline as base64.
+                ObjectNode msgNode = messages.addObject();
+                msgNode.put("role", msg.role().name().toLowerCase());
+                ArrayNode content = msgNode.putArray("content");
+                for (LlmContent part : msg.parts()) {
+                    ObjectNode block = content.addObject();
+                    switch (part) {
+                        case LlmContent.Text t -> block.put("type", "text").put("text", t.text());
+                        case LlmContent.Image i -> {
+                            block.put("type", "image");
+                            base64Source(block, i.mediaType(), i.base64());
+                        }
+                        case LlmContent.Document d -> {
+                            block.put("type", "document");
+                            base64Source(block, d.mediaType(), d.base64());
+                            if (d.name() != null) block.put("title", d.name());
+                        }
+                    }
+                }
             } else {
                 ObjectNode msgNode = messages.addObject();
                 msgNode.put("role", msg.role().name().toLowerCase());
@@ -490,5 +511,13 @@ public class ClaudeGateway implements LlmGateway {
         }
 
         return root;
+    }
+
+    /** The {@code source} of an image or document block: inline base64. */
+    private static void base64Source(ObjectNode block, String mediaType, String base64) {
+        ObjectNode source = block.putObject("source");
+        source.put("type", "base64");
+        source.put("media_type", mediaType);
+        source.put("data", base64);
     }
 }

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/gemini/GeminiGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/gemini/GeminiGateway.java
@@ -341,7 +341,8 @@ public class GeminiGateway implements LlmGateway {
      *   <li>Tool definitions use {@code functionDeclarations} under a {@code tools} wrapper.</li>
      * </ul>
      */
-    private ObjectNode buildRequestNode(LlmConfig config, LlmRequest request) throws IOException {
+    // package-private for testing the wire JSON without a live HTTP call
+    ObjectNode buildRequestNode(LlmConfig config, LlmRequest request) throws IOException {
         ObjectNode root = objectMapper.createObjectNode();
 
         // Generation config
@@ -389,6 +390,19 @@ public class GeminiGateway implements LlmGateway {
                     funcCall.put("name", tc.name());
                     funcCall.set("args", objectMapper.valueToTree(tc.arguments()));
                 }
+            } else if (msg.hasMedia()) {
+                // Gemini is parts-shaped already: text parts as {text}, media
+                // as {inline_data} with the base64 payload.
+                turn.put("role", msg.role() == MessageRole.ASSISTANT ? "model" : "user");
+                ArrayNode parts = turn.putArray("parts");
+                for (LlmContent part : msg.parts()) {
+                    ObjectNode node = parts.addObject();
+                    switch (part) {
+                        case LlmContent.Text t -> node.put("text", t.text());
+                        case LlmContent.Image i -> inlineData(node, i.mediaType(), i.base64());
+                        case LlmContent.Document d -> inlineData(node, d.mediaType(), d.base64());
+                    }
+                }
             } else {
                 turn.put("role", msg.role() == MessageRole.ASSISTANT ? "model" : "user");
                 ArrayNode parts = turn.putArray("parts");
@@ -409,5 +423,12 @@ public class GeminiGateway implements LlmGateway {
         }
 
         return root;
+    }
+
+    /** An {@code inline_data} part: the media's type and base64 payload. */
+    private static void inlineData(ObjectNode part, String mediaType, String base64) {
+        ObjectNode data = part.putObject("inline_data");
+        data.put("mime_type", mediaType);
+        data.put("data", base64);
     }
 }

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/gemini/GeminiGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/gemini/GeminiGateway.java
@@ -2,6 +2,7 @@ package ai.mindconnect.llm.adapter.gemini;
 
 import ai.mindconnect.common.Cancellation;
 import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import ai.mindconnect.llm.adapter.TraceRedaction;
 import ai.mindconnect.llm.domain.*;
 import ai.mindconnect.llm.port.in.LlmCallListener;
 import ai.mindconnect.llm.port.out.LlmGateway;
@@ -85,7 +86,7 @@ public class GeminiGateway implements LlmGateway {
         String body;
         try {
             ObjectNode requestNode = buildRequestNode(config, request);
-            try { prettyRequestJson = prettyWriter.writeValueAsString(requestNode); } catch (Exception ignored) {}
+            try { prettyRequestJson = prettyWriter.writeValueAsString(TraceRedaction.redactMedia(requestNode)); } catch (Exception ignored) {}
             logWireRequest(requestNode);
             body = objectMapper.writeValueAsString(requestNode);
         } catch (IOException e) {
@@ -323,7 +324,7 @@ public class GeminiGateway implements LlmGateway {
     private void logWireRequest(ObjectNode requestNode) {
         if (!wire.isDebugEnabled()) return;
         try {
-            wire.debug("→ stream request:\n{}", prettyWriter.writeValueAsString(requestNode));
+            wire.debug("→ stream request:\n{}", prettyWriter.writeValueAsString(TraceRedaction.redactMedia(requestNode)));
         } catch (Exception e) {
             wire.debug("→ stream request: <serialise failed: {}>", e.getMessage());
         }

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/AbstractOpenAiGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/AbstractOpenAiGateway.java
@@ -2,6 +2,7 @@ package ai.mindconnect.llm.adapter.openai;
 
 import ai.mindconnect.common.Cancellation;
 import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import ai.mindconnect.llm.adapter.TraceRedaction;
 import ai.mindconnect.llm.domain.*;
 import ai.mindconnect.llm.port.in.LlmCallListener;
 import ai.mindconnect.llm.port.out.LlmGateway;
@@ -20,9 +21,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 
@@ -85,7 +88,7 @@ abstract class AbstractOpenAiGateway implements LlmGateway {
         String body;
         try {
             requestNode = buildRequestNode(config, request);
-            try { prettyRequestJson = prettyWriter.writeValueAsString(requestNode); } catch (Exception ignored) {}
+            try { prettyRequestJson = prettyWriter.writeValueAsString(TraceRedaction.redactMedia(requestNode)); } catch (Exception ignored) {}
             logWireRequest(requestNode);
             body = objectMapper.writeValueAsString(requestNode);
         } catch (IOException e) {
@@ -386,7 +389,7 @@ abstract class AbstractOpenAiGateway implements LlmGateway {
     private void logWireRequest(ObjectNode requestNode) {
         if (!wire.isDebugEnabled()) return;
         try {
-            wire.debug("→ stream request:\n{}", prettyWriter.writeValueAsString(requestNode));
+            wire.debug("→ stream request:\n{}", prettyWriter.writeValueAsString(TraceRedaction.redactMedia(requestNode)));
         } catch (Exception e) {
             wire.debug("→ stream request: <serialise failed: {}>", e.getMessage());
         }
@@ -425,7 +428,7 @@ abstract class AbstractOpenAiGateway implements LlmGateway {
                     fn.put("arguments", objectMapper.writeValueAsString(tc.arguments()));
                 }
             } else if (msg.hasMedia()) {
-                renderContentBlocks(msgNode.putArray("content"), msg);
+                renderContentBlocks(msgNode.putArray("content"), msg, config);
             } else {
                 msgNode.put("content", msg.content() != null ? msg.content() : "");
             }
@@ -451,22 +454,38 @@ abstract class AbstractOpenAiGateway implements LlmGateway {
     }
 
     /**
+     * The endpoints that take a {@code file} content block. It is OpenAI's
+     * own extension of Chat Completions — OpenRouter mirrors it, Azure serves
+     * OpenAI's models; every other compatible server (LM Studio, Ollama,
+     * Groq, Mistral, …) rejects the request with a 400 for an unknown type.
+     */
+    private static final Set<LlmProvider> FILE_BLOCK_PROVIDERS =
+            EnumSet.of(LlmProvider.OPENAI, LlmProvider.AZURE_OPENAI, LlmProvider.OPENROUTER);
+
+    /**
      * A user message with media as the Chat Completions content array: text
      * blocks as {@code text}, images as a data-URL {@code image_url}, documents
-     * as a {@code file} block with inline {@code file_data}. Text-only messages
-     * never come here — they stay the plain string every endpoint understands.
+     * as a {@code file} block with inline {@code file_data} — where the
+     * endpoint takes one; elsewhere a document becomes a text block that
+     * says what it is, so a config that declares {@code DOCUMENTS} on such a
+     * server still gets an answer instead of a 400. Text-only messages never
+     * come here — they stay the plain string every endpoint understands.
      */
-    private static void renderContentBlocks(ArrayNode content, LlmMessage msg) {
+    private static void renderContentBlocks(ArrayNode content, LlmMessage msg, LlmConfig config) {
+        boolean fileBlocks = config.provider() != null && FILE_BLOCK_PROVIDERS.contains(config.provider());
         for (LlmContent part : msg.parts()) {
             ObjectNode block = content.addObject();
             switch (part) {
                 case LlmContent.Text t -> block.put("type", "text").put("text", t.text());
                 case LlmContent.Image i -> block.put("type", "image_url")
                         .putObject("image_url").put("url", dataUrl(i.mediaType(), i.base64()));
-                case LlmContent.Document d -> block.put("type", "file")
+                case LlmContent.Document d when fileBlocks -> block.put("type", "file")
                         .putObject("file")
                         .put("filename", d.name())
                         .put("file_data", dataUrl(d.mediaType(), d.base64()));
+                case LlmContent.Document d -> block.put("type", "text").put("text",
+                        "[System note — document attached: " + d.name() + " (" + d.mediaType()
+                                + ") — this endpoint takes no file blocks, so its content is not here.]");
             }
         }
     }

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/AbstractOpenAiGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/AbstractOpenAiGateway.java
@@ -392,7 +392,8 @@ abstract class AbstractOpenAiGateway implements LlmGateway {
         }
     }
 
-    private ObjectNode buildRequestNode(LlmConfig config, LlmRequest request) throws IOException {
+    // package-private for testing the wire JSON without a live HTTP call
+    ObjectNode buildRequestNode(LlmConfig config, LlmRequest request) throws IOException {
         ObjectNode root = objectMapper.createObjectNode();
         root.put("model", config.model());
         root.put("stream", true);
@@ -423,6 +424,8 @@ abstract class AbstractOpenAiGateway implements LlmGateway {
                     fn.put("name", tc.name());
                     fn.put("arguments", objectMapper.writeValueAsString(tc.arguments()));
                 }
+            } else if (msg.hasMedia()) {
+                renderContentBlocks(msgNode.putArray("content"), msg);
             } else {
                 msgNode.put("content", msg.content() != null ? msg.content() : "");
             }
@@ -445,5 +448,30 @@ abstract class AbstractOpenAiGateway implements LlmGateway {
         streamOptions.put("include_usage", true);
 
         return root;
+    }
+
+    /**
+     * A user message with media as the Chat Completions content array: text
+     * blocks as {@code text}, images as a data-URL {@code image_url}, documents
+     * as a {@code file} block with inline {@code file_data}. Text-only messages
+     * never come here — they stay the plain string every endpoint understands.
+     */
+    private static void renderContentBlocks(ArrayNode content, LlmMessage msg) {
+        for (LlmContent part : msg.parts()) {
+            ObjectNode block = content.addObject();
+            switch (part) {
+                case LlmContent.Text t -> block.put("type", "text").put("text", t.text());
+                case LlmContent.Image i -> block.put("type", "image_url")
+                        .putObject("image_url").put("url", dataUrl(i.mediaType(), i.base64()));
+                case LlmContent.Document d -> block.put("type", "file")
+                        .putObject("file")
+                        .put("filename", d.name())
+                        .put("file_data", dataUrl(d.mediaType(), d.base64()));
+            }
+        }
+    }
+
+    private static String dataUrl(String mediaType, String base64) {
+        return "data:" + mediaType + ";base64," + base64;
     }
 }

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/LlmConfigCapabilitiesTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/LlmConfigCapabilitiesTest.java
@@ -1,0 +1,86 @@
+package ai.mindconnect.llm;
+
+import ai.mindconnect.llm.domain.LlmCapability;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The capability set on {@link LlmConfig}: always present, stable in order,
+ * carried by every copy, and absent-tolerant in JSON so configs written before
+ * the field existed still load.
+ */
+class LlmConfigCapabilitiesTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static LlmConfig config(Set<LlmCapability> capabilities) {
+        return new LlmConfig(UUID.randomUUID(), "test", LlmProvider.OPENAI,
+                "gpt-5", "https://api.openai.com", "key", 0.7, 4096, Map.of(), null,
+                false, null, null, null, null, capabilities);
+    }
+
+    @Test
+    void nullReadsAsTheEmptySet() {
+        var cfg = config(null);
+        assertThat(cfg.capabilities()).isEmpty();
+        assertThat(cfg.supports(LlmCapability.VISION)).isFalse();
+    }
+
+    @Test
+    void factoriesDeclareNothing() {
+        assertThat(LlmConfig.claude("c", "claude-sonnet-4-6", "k").capabilities()).isEmpty();
+        assertThat(LlmConfig.alias("a", "c").capabilities()).isEmpty();
+    }
+
+    @Test
+    void theSetIsUnmodifiableAndInDeclarationOrder() {
+        var cfg = config(Set.of(LlmCapability.DOCUMENTS, LlmCapability.TOOL_CALLING, LlmCapability.VISION));
+        assertThat(cfg.capabilities())
+                .containsExactly(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS);
+        assertThat(cfg.supports(LlmCapability.VISION)).isTrue();
+        assertThat(cfg.supports(LlmCapability.AUDIO_INPUT)).isFalse();
+        assertThatThrownBy(() -> cfg.capabilities().add(LlmCapability.AUDIO_INPUT))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void copiesCarryTheSet() {
+        var cfg = config(Set.of(LlmCapability.VISION));
+        assertThat(cfg.withApiKey("other").capabilities()).containsExactly(LlmCapability.VISION);
+        assertThat(cfg.withContextWindowTokens(1000).capabilities()).containsExactly(LlmCapability.VISION);
+        assertThat(cfg.resolved().capabilities()).containsExactly(LlmCapability.VISION);
+        assertThat(cfg.withCapabilities(Set.of(LlmCapability.AUDIO_INPUT)).capabilities())
+                .containsExactly(LlmCapability.AUDIO_INPUT);
+        assertThat(cfg.withCapabilities(null).capabilities()).isEmpty();
+    }
+
+    @Test
+    void jsonRoundTripKeepsTheSet() throws Exception {
+        var cfg = config(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION));
+        String json = JSON.writeValueAsString(cfg);
+        assertThat(json).contains("\"capabilities\":[\"TOOL_CALLING\",\"VISION\"]");
+        assertThat(JSON.readValue(json, LlmConfig.class)).isEqualTo(cfg);
+    }
+
+    @Test
+    void jsonWithoutTheFieldLoadsAsTheEmptySet() throws Exception {
+        // A config persisted before capabilities existed.
+        String legacy = """
+                {"id":"00000001-0000-0000-0000-000000000002","name":"claude-default",
+                 "provider":"ANTHROPIC","model":"claude-sonnet-4-6","apiKey":"k",
+                 "defaultTemperature":0.7,"maxOutputTokens":8192}
+                """;
+        LlmConfig cfg = JSON.readValue(legacy, LlmConfig.class);
+        assertThat(cfg.capabilities()).isEmpty();
+        assertThat(cfg.name()).isEqualTo("claude-default");
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/LlmConfigCapabilitiesTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/LlmConfigCapabilitiesTest.java
@@ -14,31 +14,68 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * The capability set on {@link LlmConfig}: always present, stable in order,
- * carried by every copy, and absent-tolerant in JSON so configs written before
- * the field existed still load.
+ * The capability set on {@link LlmConfig}: declared or not, stable in order,
+ * carried by every copy, absent-tolerant in JSON. A config that declares
+ * nothing reads as its provider's default; a declared set — empty included —
+ * always wins.
  */
 class LlmConfigCapabilitiesTest {
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
-    private static LlmConfig config(Set<LlmCapability> capabilities) {
-        return new LlmConfig(UUID.randomUUID(), "test", LlmProvider.OPENAI,
-                "gpt-5", "https://api.openai.com", "key", 0.7, 4096, Map.of(), null,
+    private static LlmConfig config(LlmProvider provider, Set<LlmCapability> capabilities) {
+        return new LlmConfig(UUID.randomUUID(), "test", provider,
+                "some-model", "https://example", "key", 0.7, 4096, Map.of(), null,
                 false, null, null, null, null, capabilities);
     }
 
-    @Test
-    void nullReadsAsTheEmptySet() {
-        var cfg = config(null);
-        assertThat(cfg.capabilities()).isEmpty();
-        assertThat(cfg.supports(LlmCapability.VISION)).isFalse();
+    private static LlmConfig config(Set<LlmCapability> capabilities) {
+        return config(LlmProvider.OPENAI, capabilities);
     }
 
     @Test
-    void factoriesDeclareNothing() {
-        assertThat(LlmConfig.claude("c", "claude-sonnet-4-6", "k").capabilities()).isEmpty();
-        assertThat(LlmConfig.alias("a", "c").capabilities()).isEmpty();
+    void notDeclaredReadsAsTheProvidersDefault() {
+        var cfg = config(LlmProvider.ANTHROPIC, null);
+
+        assertThat(cfg.declaresCapabilities()).isFalse();
+        assertThat(cfg.capabilities()).isNull();
+        assertThat(cfg.effectiveCapabilities())
+                .containsExactly(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS);
+        assertThat(cfg.supports(LlmCapability.VISION)).isTrue();
+        assertThat(cfg.supports(LlmCapability.AUDIO_INPUT)).isFalse();
+    }
+
+    @Test
+    void providersOfArbitraryModelsDefaultToToolCallingOnly() {
+        for (LlmProvider p : Set.of(LlmProvider.LM_STUDIO, LlmProvider.OLLAMA, LlmProvider.OPENROUTER,
+                LlmProvider.TOGETHER, LlmProvider.GROQ, LlmProvider.FIREWORKS)) {
+            assertThat(config(p, null).supports(LlmCapability.VISION)).as(p.name()).isFalse();
+            assertThat(config(p, null).supports(LlmCapability.TOOL_CALLING)).as(p.name()).isTrue();
+        }
+        assertThat(config(LlmProvider.GOOGLE_GEMINI, null).supports(LlmCapability.AUDIO_INPUT)).isTrue();
+    }
+
+    @Test
+    void aDeclaredSetWinsOverTheDefault_theEmptySetIncluded() {
+        var none = config(LlmProvider.ANTHROPIC, Set.of());
+        assertThat(none.declaresCapabilities()).isTrue();
+        assertThat(none.effectiveCapabilities()).isEmpty();
+        assertThat(none.supports(LlmCapability.VISION)).isFalse();
+
+        var vision = config(LlmProvider.LM_STUDIO, Set.of(LlmCapability.VISION));
+        assertThat(vision.supports(LlmCapability.VISION)).isTrue();
+        assertThat(vision.supports(LlmCapability.TOOL_CALLING)).isFalse();
+    }
+
+    @Test
+    void factoriesAndAliasesDeclareNothing() {
+        LlmConfig claude = LlmConfig.claude("c", "claude-sonnet-4-6", "k");
+        assertThat(claude.declaresCapabilities()).isFalse();
+        assertThat(claude.supports(LlmCapability.DOCUMENTS)).isTrue();
+
+        LlmConfig alias = LlmConfig.alias("a", "c");
+        assertThat(alias.declaresCapabilities()).isFalse();
+        assertThat(alias.effectiveCapabilities()).as("no provider, nothing applies").isEmpty();
     }
 
     @Test
@@ -46,8 +83,6 @@ class LlmConfigCapabilitiesTest {
         var cfg = config(Set.of(LlmCapability.DOCUMENTS, LlmCapability.TOOL_CALLING, LlmCapability.VISION));
         assertThat(cfg.capabilities())
                 .containsExactly(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS);
-        assertThat(cfg.supports(LlmCapability.VISION)).isTrue();
-        assertThat(cfg.supports(LlmCapability.AUDIO_INPUT)).isFalse();
         assertThatThrownBy(() -> cfg.capabilities().add(LlmCapability.AUDIO_INPUT))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
@@ -60,27 +95,33 @@ class LlmConfigCapabilitiesTest {
         assertThat(cfg.resolved().capabilities()).containsExactly(LlmCapability.VISION);
         assertThat(cfg.withCapabilities(Set.of(LlmCapability.AUDIO_INPUT)).capabilities())
                 .containsExactly(LlmCapability.AUDIO_INPUT);
-        assertThat(cfg.withCapabilities(null).capabilities()).isEmpty();
+        assertThat(cfg.withCapabilities(null).declaresCapabilities()).isFalse();
     }
 
     @Test
-    void jsonRoundTripKeepsTheSet() throws Exception {
+    void jsonRoundTripKeepsTheSet_andKeepsNotDeclared() throws Exception {
         var cfg = config(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION));
         String json = JSON.writeValueAsString(cfg);
         assertThat(json).contains("\"capabilities\":[\"TOOL_CALLING\",\"VISION\"]");
         assertThat(JSON.readValue(json, LlmConfig.class)).isEqualTo(cfg);
+
+        var undeclared = config(null);
+        LlmConfig read = JSON.readValue(JSON.writeValueAsString(undeclared), LlmConfig.class);
+        assertThat(read.declaresCapabilities()).isFalse();
+        assertThat(read).isEqualTo(undeclared);
     }
 
     @Test
-    void jsonWithoutTheFieldLoadsAsTheEmptySet() throws Exception {
-        // A config persisted before capabilities existed.
+    void jsonWithoutTheFieldLoadsAsNotDeclared() throws Exception {
+        // A config persisted before capabilities existed: its provider decides.
         String legacy = """
                 {"id":"00000001-0000-0000-0000-000000000002","name":"claude-default",
                  "provider":"ANTHROPIC","model":"claude-sonnet-4-6","apiKey":"k",
                  "defaultTemperature":0.7,"maxOutputTokens":8192}
                 """;
         LlmConfig cfg = JSON.readValue(legacy, LlmConfig.class);
-        assertThat(cfg.capabilities()).isEmpty();
+        assertThat(cfg.declaresCapabilities()).isFalse();
+        assertThat(cfg.supports(LlmCapability.VISION)).isTrue();
         assertThat(cfg.name()).isEqualTo("claude-default");
     }
 }

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/LlmConfigResolvedTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/LlmConfigResolvedTest.java
@@ -14,7 +14,7 @@ class LlmConfigResolvedTest {
 
     private static LlmConfig config(String model, String baseUrl, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), "test", LlmProvider.OPENAI,
-                model, baseUrl, apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null);
+                model, baseUrl, apiKey, 0.7, 4096, Map.of(), null, false, null, null, null, null, null);
     }
 
     // --- resolved() — env-var expansion only ---

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/TraceRedactionTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/TraceRedactionTest.java
@@ -1,0 +1,66 @@
+package ai.mindconnect.llm.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What a trace keeps of a request that carries media: everything but the
+ * payload. The three providers spell the payload differently — a data URL,
+ * a bare base64 field — and prose, however long, is never mistaken for one.
+ */
+class TraceRedactionTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String PAYLOAD = "QUJD".repeat(600); // 2,400 base64 chars
+
+    @Test
+    void dataUrlsKeepTheirMediaTypeAndLoseTheirPayload() {
+        ObjectNode request = JSON.createObjectNode();
+        ObjectNode block = request.putArray("messages").addObject().putArray("content").addObject();
+        block.put("type", "image_url").putObject("image_url").put("url", "data:image/png;base64," + PAYLOAD);
+
+        JsonNode redacted = TraceRedaction.redactMedia(request);
+
+        assertThat(redacted.at("/messages/0/content/0/image_url/url").asText())
+                .isEqualTo("data:image/png;base64,<2400 chars omitted>");
+        assertThat(request.at("/messages/0/content/0/image_url/url").asText())
+                .as("the wire request is untouched").endsWith(PAYLOAD);
+    }
+
+    @Test
+    void bareBase64FieldsAreReplaced_whateverTheyAreCalled() {
+        ObjectNode request = JSON.createObjectNode();
+        request.putObject("source").put("type", "base64").put("media_type", "application/pdf").put("data", PAYLOAD);
+        request.putObject("inline_data").put("mime_type", "image/jpeg").put("data", PAYLOAD);
+
+        JsonNode redacted = TraceRedaction.redactMedia(request);
+
+        assertThat(redacted.at("/source/data").asText()).isEqualTo("<base64, 2400 chars omitted>");
+        assertThat(redacted.at("/source/media_type").asText()).isEqualTo("application/pdf");
+        assertThat(redacted.at("/inline_data/data").asText()).isEqualTo("<base64, 2400 chars omitted>");
+    }
+
+    @Test
+    void proseAndShortStringsStay() {
+        String longPrompt = "You are a helpful assistant. ".repeat(200); // spaces: not base64
+        ObjectNode request = JSON.createObjectNode();
+        request.put("system", longPrompt);
+        request.put("model", "claude-sonnet-4-6");
+        request.put("short", "QUJD");
+
+        JsonNode redacted = TraceRedaction.redactMedia(request);
+
+        assertThat(redacted.path("system").asText()).isEqualTo(longPrompt);
+        assertThat(redacted.path("model").asText()).isEqualTo("claude-sonnet-4-6");
+        assertThat(redacted.path("short").asText()).isEqualTo("QUJD");
+    }
+
+    @Test
+    void nullIsNull() {
+        assertThat(TraceRedaction.redactMedia(null)).isNull();
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGatewayContentBlocksTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGatewayContentBlocksTest.java
@@ -1,0 +1,68 @@
+package ai.mindconnect.llm.adapter.anthropic;
+
+import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmContent;
+import ai.mindconnect.llm.domain.LlmMessage;
+import ai.mindconnect.llm.domain.LlmProvider;
+import ai.mindconnect.llm.domain.LlmRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A user message with media as Anthropic content blocks; text-only stays a string. */
+class ClaudeGatewayContentBlocksTest {
+
+    private final EncryptionHelper encryption = new EncryptionHelper("0123456789abcdef");
+    private final ClaudeGateway gateway =
+            new ClaudeGateway(new OkHttpClient(), new ObjectMapper(), encryption);
+
+    private final LlmConfig config = new LlmConfig(java.util.UUID.randomUUID(), "claude", LlmProvider.ANTHROPIC,
+            "claude-sonnet-4-6", "https://api.anthropic.com", "sk-test", 0.7, 8192, Map.of(), 200_000,
+            false, null, null, null, null, null);
+
+    @Test
+    void textOnlyMessagesStayPlainStrings() throws Exception {
+        LlmRequest req = LlmRequest.streaming("claude",
+                List.of(LlmMessage.system("be brief"), LlmMessage.user("hi")));
+
+        JsonNode root = gateway.buildRequestNode(config.resolved(encryption), req);
+
+        assertThat(root.path("system").asText()).isEqualTo("be brief");
+        assertThat(root.path("messages").path(0).path("content").isTextual()).isTrue();
+        assertThat(root.path("messages").path(0).path("content").asText()).isEqualTo("hi");
+    }
+
+    @Test
+    void mediaMessagesBecomeContentBlocksWithBase64Sources() throws Exception {
+        LlmMessage user = LlmMessage.user(List.of(
+                new LlmContent.Text("what is this?"),
+                new LlmContent.Image("QUJD", "image/png"),
+                new LlmContent.Document("UERG", "application/pdf", "spec.pdf")));
+        LlmRequest req = LlmRequest.streaming("claude", List.of(user));
+
+        JsonNode message = gateway.buildRequestNode(config.resolved(encryption), req)
+                .path("messages").path(0);
+        JsonNode content = message.path("content");
+
+        assertThat(message.path("role").asText()).isEqualTo("user");
+        assertThat(content.isArray()).isTrue();
+        assertThat(content).hasSize(3);
+        assertThat(content.get(0).path("type").asText()).isEqualTo("text");
+        assertThat(content.get(0).path("text").asText()).isEqualTo("what is this?");
+        assertThat(content.get(1).path("type").asText()).isEqualTo("image");
+        assertThat(content.get(1).path("source").path("type").asText()).isEqualTo("base64");
+        assertThat(content.get(1).path("source").path("media_type").asText()).isEqualTo("image/png");
+        assertThat(content.get(1).path("source").path("data").asText()).isEqualTo("QUJD");
+        assertThat(content.get(2).path("type").asText()).isEqualTo("document");
+        assertThat(content.get(2).path("source").path("media_type").asText()).isEqualTo("application/pdf");
+        assertThat(content.get(2).path("source").path("data").asText()).isEqualTo("UERG");
+        assertThat(content.get(2).path("title").asText()).isEqualTo("spec.pdf");
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGatewayThinkingTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/anthropic/ClaudeGatewayThinkingTest.java
@@ -33,7 +33,7 @@ class ClaudeGatewayThinkingTest {
     private LlmConfig config(Map<String, Object> additionalParams) {
         return new LlmConfig(java.util.UUID.randomUUID(), "claude", LlmProvider.ANTHROPIC,
                 "claude-opus-4-8", "https://api.anthropic.com", "sk-test",
-                0.7, 8192, additionalParams, 200_000, false, null, null, null, null);
+                0.7, 8192, additionalParams, 200_000, false, null, null, null, null, null);
     }
 
     @Test

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/gemini/GeminiGatewayContentBlocksTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/gemini/GeminiGatewayContentBlocksTest.java
@@ -1,0 +1,61 @@
+package ai.mindconnect.llm.adapter.gemini;
+
+import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmContent;
+import ai.mindconnect.llm.domain.LlmMessage;
+import ai.mindconnect.llm.domain.LlmProvider;
+import ai.mindconnect.llm.domain.LlmRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A user message with media as Gemini parts: text as {@code text}, media as {@code inline_data}. */
+class GeminiGatewayContentBlocksTest {
+
+    private final EncryptionHelper encryption = new EncryptionHelper("0123456789abcdef");
+    private final GeminiGateway gateway =
+            new GeminiGateway(new OkHttpClient(), new ObjectMapper(), encryption);
+
+    private final LlmConfig config = new LlmConfig(java.util.UUID.randomUUID(), "gemini",
+            LlmProvider.GOOGLE_GEMINI, "gemini-2.0-flash", "https://generativelanguage.googleapis.com",
+            "key", 0.7, 8192, Map.of(), 1_000_000, false, null, null, null, null, null);
+
+    @Test
+    void textOnlyMessagesAreOneTextPart() throws Exception {
+        LlmRequest req = LlmRequest.streaming("gemini", List.of(LlmMessage.user("hi")));
+
+        JsonNode parts = gateway.buildRequestNode(config.resolved(encryption), req)
+                .path("contents").path(0).path("parts");
+
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).path("text").asText()).isEqualTo("hi");
+    }
+
+    @Test
+    void mediaMessagesBecomeInlineDataParts() throws Exception {
+        LlmMessage user = LlmMessage.user(List.of(
+                new LlmContent.Text("what is this?"),
+                new LlmContent.Image("QUJD", "image/png"),
+                new LlmContent.Document("UERG", "application/pdf", "spec.pdf")));
+        LlmRequest req = LlmRequest.streaming("gemini", List.of(user));
+
+        JsonNode turn = gateway.buildRequestNode(config.resolved(encryption), req)
+                .path("contents").path(0);
+        JsonNode parts = turn.path("parts");
+
+        assertThat(turn.path("role").asText()).isEqualTo("user");
+        assertThat(parts).hasSize(3);
+        assertThat(parts.get(0).path("text").asText()).isEqualTo("what is this?");
+        assertThat(parts.get(1).path("inline_data").path("mime_type").asText()).isEqualTo("image/png");
+        assertThat(parts.get(1).path("inline_data").path("data").asText()).isEqualTo("QUJD");
+        assertThat(parts.get(2).path("inline_data").path("mime_type").asText()).isEqualTo("application/pdf");
+        assertThat(parts.get(2).path("inline_data").path("data").asText()).isEqualTo("UERG");
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiGatewayContentBlocksTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiGatewayContentBlocksTest.java
@@ -66,4 +66,26 @@ class OpenAiGatewayContentBlocksTest {
         assertThat(content.get(2).path("file").path("file_data").asText())
                 .isEqualTo("data:application/pdf;base64,UERG");
     }
+
+    @Test
+    void aServerWithoutFileBlocksGetsTheDocumentAsANote() throws Exception {
+        // LM Studio, Ollama, Groq, … answer an unknown content type with a 400.
+        LlmConfig local = new LlmConfig(java.util.UUID.randomUUID(), "local", LlmProvider.LM_STUDIO,
+                "some-vision-model", "http://localhost:1234", "lm-studio", 0.7, 4096, Map.of(), 128_000,
+                false, null, null, null, null, null);
+        LlmMessage user = LlmMessage.user(List.of(
+                new LlmContent.Text("summarise"),
+                new LlmContent.Image("QUJD", "image/png"),
+                new LlmContent.Document("UERG", "application/pdf", "spec.pdf")));
+
+        JsonNode content = gateway.buildRequestNode(local.resolved(encryption),
+                LlmRequest.streaming("local", List.of(user))).path("messages").path(0).path("content");
+
+        assertThat(content).hasSize(3);
+        assertThat(content.get(1).path("type").asText()).as("images are universal").isEqualTo("image_url");
+        assertThat(content.get(2).path("type").asText()).isEqualTo("text");
+        assertThat(content.get(2).path("text").asText())
+                .contains("document attached: spec.pdf (application/pdf)")
+                .contains("takes no file blocks");
+    }
 }

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiGatewayContentBlocksTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiGatewayContentBlocksTest.java
@@ -1,0 +1,69 @@
+package ai.mindconnect.llm.adapter.openai;
+
+import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmContent;
+import ai.mindconnect.llm.domain.LlmMessage;
+import ai.mindconnect.llm.domain.LlmProvider;
+import ai.mindconnect.llm.domain.LlmRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * How a user message with media reaches a Chat Completions endpoint: as the
+ * content array — and how a text-only one does not: as the plain string it
+ * always was, so an endpoint that never learned arrays sees no difference.
+ */
+class OpenAiGatewayContentBlocksTest {
+
+    private final EncryptionHelper encryption = new EncryptionHelper("0123456789abcdef");
+    private final OpenAiCompatibleGateway gateway =
+            new OpenAiCompatibleGateway(new OkHttpClient(), new ObjectMapper(), encryption);
+
+    private final LlmConfig config = new LlmConfig(java.util.UUID.randomUUID(), "openai", LlmProvider.OPENAI,
+            "gpt-5", "https://api.openai.com", "sk-test", 0.7, 4096, Map.of(), 128_000,
+            false, null, null, null, null, null);
+
+    @Test
+    void textOnlyMessagesStayPlainStrings() throws Exception {
+        LlmRequest req = LlmRequest.streaming("openai",
+                List.of(LlmMessage.system("be brief"), LlmMessage.user("hi"), LlmMessage.assistant("hello")));
+
+        JsonNode messages = gateway.buildRequestNode(config.resolved(encryption), req).path("messages");
+
+        assertThat(messages).hasSize(3);
+        assertThat(messages.get(1).path("content").isTextual()).isTrue();
+        assertThat(messages.get(1).path("content").asText()).isEqualTo("hi");
+    }
+
+    @Test
+    void mediaMessagesBecomeTheContentArray() throws Exception {
+        LlmMessage user = LlmMessage.user(List.of(
+                new LlmContent.Text("what is this?"),
+                new LlmContent.Image("QUJD", "image/png"),
+                new LlmContent.Document("UERG", "application/pdf", "spec.pdf")));
+        LlmRequest req = LlmRequest.streaming("openai", List.of(user));
+
+        JsonNode content = gateway.buildRequestNode(config.resolved(encryption), req)
+                .path("messages").path(0).path("content");
+
+        assertThat(content.isArray()).isTrue();
+        assertThat(content).hasSize(3);
+        assertThat(content.get(0).path("type").asText()).isEqualTo("text");
+        assertThat(content.get(0).path("text").asText()).isEqualTo("what is this?");
+        assertThat(content.get(1).path("type").asText()).isEqualTo("image_url");
+        assertThat(content.get(1).path("image_url").path("url").asText())
+                .isEqualTo("data:image/png;base64,QUJD");
+        assertThat(content.get(2).path("type").asText()).isEqualTo("file");
+        assertThat(content.get(2).path("file").path("filename").asText()).isEqualTo("spec.pdf");
+        assertThat(content.get(2).path("file").path("file_data").asText())
+                .isEqualTo("data:application/pdf;base64,UERG");
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/service/ThrottlingLlmGatewayTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/service/ThrottlingLlmGatewayTest.java
@@ -27,7 +27,7 @@ class ThrottlingLlmGatewayTest {
     private static LlmConfig config(String name, RateLimitConfig rateLimit) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.OPENAI,
                 "model", "http://x", "key", 0.7, 4096, Map.of(), null,
-                false, null, null, rateLimit, null);
+                false, null, null, rateLimit, null, null);
     }
 
     /** A delegate that records peak concurrency and blocks until released. */

--- a/agents/core/mc-message-repository-core/pom.xml
+++ b/agents/core/mc-message-repository-core/pom.xml
@@ -27,6 +27,12 @@
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-common</artifactId>
         </dependency>
+        <!-- Only the annotations: ContentPart is polymorphic and names its
+             kinds itself, so every adapter's mapper reads it back correctly. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/ContentPart.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/ContentPart.java
@@ -1,0 +1,74 @@
+package ai.mindconnect.message.domain;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * One piece of a {@link Message}: its text, or an image or file the user sent
+ * with it. Media is <em>referenced</em> — by the id the file store gave it —
+ * never carried as bytes: a conversation record stays small, and the bytes
+ * are read by whoever renders the part (the LLM mapper, the chat UI) through
+ * the store, at the moment they are needed.
+ *
+ * <p>The kinds are closed on purpose. A message's text is what every existing
+ * reader sees ({@link Message#content()} mirrors it); the media kinds are what
+ * a vision- or document-capable model gets to see in addition. Audio is not a
+ * kind yet — it arrives with the speech work, as its own record here.
+ *
+ * <p>Serialised with a {@code kind} discriminator so the file store, Postgres
+ * and the REST API all read a part back as what it was.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ContentPart.Text.class, name = "text"),
+        @JsonSubTypes.Type(value = ContentPart.Image.class, name = "image"),
+        @JsonSubTypes.Type(value = ContentPart.File.class, name = "file")
+})
+public sealed interface ContentPart permits ContentPart.Text, ContentPart.Media {
+
+    /** A run of text. */
+    record Text(String text) implements ContentPart {
+        public Text {
+            if (text == null) text = "";
+        }
+    }
+
+    /**
+     * What the media kinds share: the file-store id the bytes live under, and
+     * what the upload said about them — enough to render a placeholder
+     * ("photo.png, image/png, 240 KB") without touching the store.
+     */
+    sealed interface Media extends ContentPart permits Image, File {
+        String fileId();
+        String name();
+        String mediaType();
+        long sizeBytes();
+    }
+
+    /** An image the user sent — for a model that reads images. */
+    record Image(String fileId, String name, String mediaType, long sizeBytes) implements Media {}
+
+    /** A document (PDF, …) the user sent — for a model that reads documents. */
+    record File(String fileId, String name, String mediaType, long sizeBytes) implements Media {}
+
+    /** The one-part list a plain text message is. */
+    static List<ContentPart> text(String text) {
+        return List.of(new Text(text));
+    }
+
+    /**
+     * The text of the parts, joined in order — what {@link Message#content()}
+     * holds for a message made of parts. Media parts contribute nothing; a
+     * message that is only an image has empty text.
+     */
+    static String textOf(List<ContentPart> parts) {
+        if (parts == null) return "";
+        return parts.stream()
+                .filter(Text.class::isInstance)
+                .map(p -> ((Text) p).text())
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/ConversationHistory.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/ConversationHistory.java
@@ -64,18 +64,19 @@ public final class ConversationHistory {
     }
 
     /**
-     * The history grouped into logical turns: each user CHAT opens one, and
-     * everything until the next user CHAT belongs to it. Messages before the
-     * first user CHAT (seeding, migration) are not part of any turn.
+     * The history grouped into logical turns: a user CHAT opens one, and
+     * everything until the next opening user CHAT belongs to it. A user CHAT
+     * that shares the open turn's id continues that turn instead of opening
+     * one — the runtime inserts such messages on the user's behalf within a
+     * turn (an attachment shown again at the assistant's request). Messages
+     * before the first user CHAT (seeding, migration) are not part of any turn.
      */
     public List<ChatTurn> turns() {
         List<ChatTurn> turns = new ArrayList<>();
         Message opener = null;
         List<Message> current = new ArrayList<>();
         for (Message message : messages) {
-            boolean opensTurn = message.type() == MessageType.CHAT
-                    && message.senderType() == ParticipantType.USER;
-            if (opensTurn) {
+            if (opensTurn(message, opener)) {
                 if (opener != null) turns.add(new ChatTurn(opener, current));
                 opener = message;
                 current = new ArrayList<>();
@@ -84,6 +85,36 @@ public final class ConversationHistory {
         }
         if (opener != null) turns.add(new ChatTurn(opener, current));
         return List.copyOf(turns);
+    }
+
+    /**
+     * Does this message open a turn, given the message that opened the
+     * current one ({@code null} before any)? A user CHAT does — unless it
+     * carries the current opener's turn id, then it continues that turn. A
+     * message without a turn id (written before turn ids existed) always opens.
+     */
+    public static boolean opensTurn(Message message, Message currentOpener) {
+        if (message.type() != MessageType.CHAT || message.senderType() != ParticipantType.USER) return false;
+        if (currentOpener == null || message.turnId() == null || currentOpener.turnId() == null) return true;
+        return !message.turnId().equals(currentOpener.turnId());
+    }
+
+    /**
+     * The messages of the current turn of a flat, sequence-ordered list —
+     * from the user CHAT that opened it on. The same grouping as
+     * {@link #turns()}, for callers that hold a list rather than a history.
+     * No user CHAT yet: the whole list.
+     */
+    public static List<Message> currentTurnMessages(List<Message> history) {
+        int start = -1;
+        Message opener = null;
+        for (int i = 0; i < history.size(); i++) {
+            if (opensTurn(history.get(i), opener)) {
+                opener = history.get(i);
+                start = i;
+            }
+        }
+        return start < 0 ? history : history.subList(start, history.size());
     }
 
     /** The newest turn — the one execution decisions are about. Empty before any user message. */

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/Message.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/Message.java
@@ -33,8 +33,11 @@ public record Message(
          * <p>
          * One turn produces one user CHAT (the prompt) plus all the
          * assistant TOOL_CALL / TOOL_RESULT / CHAT messages emitted by the
-         * tool-loop until the final answer. All of them share the same
-         * {@code turnId}.
+         * tool-loop until the final answer — and, now and then, a further
+         * user CHAT the runtime inserts on the user's behalf (an attachment
+         * shown again at the assistant's request). All of them share the
+         * same {@code turnId}; that is what keeps the inserted message in
+         * the turn instead of opening one (see {@code ConversationHistory}).
          * <p>
          * {@code null} on:
          *   • messages persisted before this field existed (no backfill)

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/Message.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/domain/Message.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.message.domain;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -48,12 +49,46 @@ public record Message(
          * {@code task_turn_<turnId>_r<run>} after. {@code null} on messages
          * persisted before this field existed; read it as 0.
          */
-        Integer run
+        Integer run,
+        /**
+         * The message as content parts — text plus the images and files the
+         * user sent with it (see {@link ContentPart}). {@code content} always
+         * mirrors the text of these parts, so readers that only need the text
+         * never look here. {@code null} on messages written before parts
+         * existed and on text-only messages appended through the string API;
+         * {@link #partsOrText()} reads both as one text part.
+         */
+        List<ContentPart> parts
 ) {
+    /** Keeps {@code parts} unmodifiable; {@code null} stays {@code null} (legacy / text-only). */
+    public Message {
+        parts = parts == null ? null : List.copyOf(parts);
+    }
+
     public static Message of(UUID conversationId, UUID senderId, ParticipantType senderType,
                              MessageType type, String content, int seq) {
         return new Message(UUID.randomUUID(), conversationId, senderId, senderType, null,
-                type, content, Map.of(), seq, Instant.now(), false, null, null, null, null, null, null);
+                type, content, Map.of(), seq, Instant.now(), false, null, null, null, null, null, null, null);
+    }
+
+    /**
+     * A message made of content parts. {@code content} is derived — the text
+     * of the parts, joined — so the record keeps its invariant without the
+     * caller having to.
+     */
+    public static Message of(UUID conversationId, UUID senderId, ParticipantType senderType,
+                             MessageType type, List<ContentPart> parts, int seq) {
+        return new Message(UUID.randomUUID(), conversationId, senderId, senderType, null,
+                type, ContentPart.textOf(parts), Map.of(), seq, Instant.now(), false, null, null, null,
+                null, null, null, parts);
+    }
+
+    /**
+     * The parts to read this message by — its own when it has them, else its
+     * {@code content} as one text part. Never {@code null}.
+     */
+    public List<ContentPart> partsOrText() {
+        return parts != null ? parts : ContentPart.text(content == null ? "" : content);
     }
 
     /**
@@ -65,7 +100,7 @@ public record Message(
     public Message withMetadata(Map<String, Object> metadata) {
         return new Message(id, conversationId, senderId, senderType, recipientId,
                 type, content, Map.copyOf(metadata), sequenceNum, sentAt, compressed, compressedContent,
-                tokenCount, compressedTokenCount, durationMs, turnId, run);
+                tokenCount, compressedTokenCount, durationMs, turnId, run, parts);
     }
 
     /**
@@ -76,21 +111,21 @@ public record Message(
     public Message withCompressed(String stub, Integer compressedTokens) {
         return new Message(id, conversationId, senderId, senderType, recipientId,
                 type, content, metadata, sequenceNum, sentAt, true, stub,
-                tokenCount, compressedTokens, durationMs, turnId, run);
+                tokenCount, compressedTokens, durationMs, turnId, run, parts);
     }
 
     /** Returns a copy of this message with the token count set. */
     public Message withTokenCount(int tokens) {
         return new Message(id, conversationId, senderId, senderType, recipientId,
                 type, content, metadata, sequenceNum, sentAt, compressed, compressedContent,
-                tokens, compressedTokenCount, durationMs, turnId, run);
+                tokens, compressedTokenCount, durationMs, turnId, run, parts);
     }
 
     /** Returns a copy of this message with the wall-clock duration set. */
     public Message withDurationMs(long durationMs) {
         return new Message(id, conversationId, senderId, senderType, recipientId,
                 type, content, metadata, sequenceNum, sentAt, compressed, compressedContent,
-                tokenCount, compressedTokenCount, durationMs, turnId, run);
+                tokenCount, compressedTokenCount, durationMs, turnId, run, parts);
     }
 
     /** The run as a primitive — {@code null} (legacy) reads as 0. */
@@ -102,13 +137,13 @@ public record Message(
     public Message withRun(int run) {
         return new Message(id, conversationId, senderId, senderType, recipientId,
                 type, content, metadata, sequenceNum, sentAt, compressed, compressedContent,
-                tokenCount, compressedTokenCount, durationMs, turnId, run);
+                tokenCount, compressedTokenCount, durationMs, turnId, run, parts);
     }
 
     /** Returns a copy of this message tagged with the given chat-turn id. */
     public Message withTurnId(UUID turnId) {
         return new Message(id, conversationId, senderId, senderType, recipientId,
                 type, content, metadata, sequenceNum, sentAt, compressed, compressedContent,
-                tokenCount, compressedTokenCount, durationMs, turnId, run);
+                tokenCount, compressedTokenCount, durationMs, turnId, run, parts);
     }
 }

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/port/in/ConversationManager.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/port/in/ConversationManager.java
@@ -2,6 +2,7 @@ package ai.mindconnect.message.port.in;
 
 import ai.mindconnect.common.Namespace;
 import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.domain.ContentPart;
 import ai.mindconnect.message.domain.Conversation;
 import ai.mindconnect.message.domain.ConversationHistory;
 import ai.mindconnect.message.domain.ConversationType;
@@ -54,6 +55,15 @@ public interface ConversationManager {
      */
     Message addMessageToConversation(UUID conversationId, UUID senderId, ParticipantType senderType,
                                      MessageType type, String content, UUID turnId, Integer run,
+                                     java.util.Map<String, Object> metadata);
+
+    /**
+     * Same, for a message made of {@link ContentPart}s — text plus the images
+     * and files sent with it. The record's {@code content} is derived from the
+     * text parts, so the text-only readers see the message as before.
+     */
+    Message addMessageToConversation(UUID conversationId, UUID senderId, ParticipantType senderType,
+                                     MessageType type, List<ContentPart> parts, UUID turnId, Integer run,
                                      java.util.Map<String, Object> metadata);
 
     /**

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/service/ConversationService.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/service/ConversationService.java
@@ -3,6 +3,7 @@ package ai.mindconnect.message.service;
 import ai.mindconnect.common.DomainException;
 import ai.mindconnect.common.Namespace;
 import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.domain.ContentPart;
 import ai.mindconnect.message.domain.Conversation;
 import ai.mindconnect.message.domain.ConversationType;
 import ai.mindconnect.message.domain.Message;
@@ -51,10 +52,25 @@ public class ConversationService implements ConversationManager {
     public Message addMessageToConversation(UUID conversationId, UUID senderId, ParticipantType senderType,
                                             MessageType type, String content, UUID turnId, Integer run,
                                             java.util.Map<String, Object> metadata) {
+        return append(conversationId, seq -> Message.of(conversationId, senderId, senderType, type, content, seq),
+                turnId, run, metadata);
+    }
+
+    @Override
+    public Message addMessageToConversation(UUID conversationId, UUID senderId, ParticipantType senderType,
+                                            MessageType type, List<ContentPart> parts, UUID turnId, Integer run,
+                                            java.util.Map<String, Object> metadata) {
+        return append(conversationId, seq -> Message.of(conversationId, senderId, senderType, type, parts, seq),
+                turnId, run, metadata);
+    }
+
+    /** The shared tail: the conversation must exist, the sequence is the next free one. */
+    private Message append(UUID conversationId, java.util.function.IntFunction<Message> create,
+                           UUID turnId, Integer run, java.util.Map<String, Object> metadata) {
         conversationRepository.findById(conversationId)
                 .orElseThrow(() -> DomainException.notFound("Conversation", conversationId.toString()));
         int seq = messageRepository.countByConversationId(conversationId) + 1;
-        Message message = Message.of(conversationId, senderId, senderType, type, content, seq)
+        Message message = create.apply(seq)
                 .withTurnId(turnId)
                 .withMetadata(metadata);
         if (run != null) message = message.withRun(run);

--- a/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/domain/ConversationHistoryTurnsTest.java
+++ b/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/domain/ConversationHistoryTurnsTest.java
@@ -1,0 +1,73 @@
+package ai.mindconnect.message.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Turn grouping: a user CHAT opens a turn — unless it carries the open
+ * turn's id, then it continues it (the runtime inserts such messages on the
+ * user's behalf mid-turn). Messages without turn ids keep the old rule.
+ */
+class ConversationHistoryTurnsTest {
+
+    private static final UUID CONVERSATION = UUID.randomUUID();
+    private static final UUID AGENT = UUID.randomUUID();
+
+    private static Message user(int seq, UUID turnId) {
+        return Message.of(CONVERSATION, UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT, "u" + seq, seq)
+                .withTurnId(turnId);
+    }
+
+    private static Message agent(int seq, UUID turnId) {
+        return Message.of(CONVERSATION, AGENT, ParticipantType.AGENT, MessageType.CHAT, "a" + seq, seq)
+                .withTurnId(turnId);
+    }
+
+    @Test
+    void aUserMessageSharingTheOpenTurnsIdContinuesTheTurn() {
+        UUID first = UUID.randomUUID(), second = UUID.randomUUID();
+        List<Message> messages = List.of(
+                user(1, first), agent(2, first),
+                user(3, second), user(4, second), agent(5, second));
+
+        ConversationHistory history = ConversationHistory.of(CONVERSATION, messages);
+
+        assertThat(history.turns()).hasSize(2);
+        assertThat(history.currentTurn()).get().extracting(ChatTurn::turnId).isEqualTo(second);
+        assertThat(history.currentTurn().orElseThrow().messages()).extracting(Message::sequenceNum)
+                .containsExactly(3, 4, 5);
+        assertThat(ConversationHistory.currentTurnMessages(messages)).extracting(Message::sequenceNum)
+                .containsExactly(3, 4, 5);
+    }
+
+    @Test
+    void aUserMessageWithAnotherOrNoTurnIdOpensATurn() {
+        UUID first = UUID.randomUUID();
+        List<Message> messages = List.of(user(1, first), agent(2, first), user(3, null), user(4, UUID.randomUUID()));
+
+        assertThat(ConversationHistory.of(CONVERSATION, messages).turns()).hasSize(3);
+        assertThat(ConversationHistory.currentTurnMessages(messages)).extracting(Message::sequenceNum)
+                .containsExactly(4);
+    }
+
+    @Test
+    void legacyMessagesWithoutTurnIdsOpenATurnEach() {
+        List<Message> messages = List.of(user(1, null), agent(2, null), user(3, null), agent(4, null));
+
+        assertThat(ConversationHistory.of(CONVERSATION, messages).turns()).hasSize(2);
+        assertThat(ConversationHistory.currentTurnMessages(messages)).extracting(Message::sequenceNum)
+                .containsExactly(3, 4);
+    }
+
+    @Test
+    void beforeAnyUserMessageTheWholeListIsTheCurrentEpisode() {
+        List<Message> messages = List.of(agent(1, null));
+
+        assertThat(ConversationHistory.of(CONVERSATION, messages).turns()).isEmpty();
+        assertThat(ConversationHistory.currentTurnMessages(messages)).isSameAs(messages);
+    }
+}

--- a/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/service/ConversationServiceTest.java
+++ b/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/service/ConversationServiceTest.java
@@ -3,6 +3,7 @@ package ai.mindconnect.message.service;
 import ai.mindconnect.common.DomainException;
 import ai.mindconnect.common.Namespace;
 import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.domain.ContentPart;
 import ai.mindconnect.message.domain.Conversation;
 import ai.mindconnect.message.domain.ConversationType;
 import ai.mindconnect.message.domain.Message;
@@ -76,6 +77,50 @@ class ConversationServiceTest {
         Message msg2 = service.addMessageToConversation(conv.id(), sender, ParticipantType.USER, MessageType.CHAT, "msg 2", null);
 
         assertThat(msg2.sequenceNum()).isEqualTo(2);
+    }
+
+    @Test
+    void addMessage_withParts_derivesContentFromTheTextParts() {
+        Conversation conv = service.createConversation(new Namespace("test"), "topic",
+                ConversationType.USER_AGENT, List.of());
+        List<ContentPart> parts = List.of(
+                new ContentPart.Text("What is in this picture?"),
+                new ContentPart.Image("f-1", "photo.png", "image/png", 240_000L));
+
+        Message msg = service.addMessageToConversation(conv.id(), UUID.randomUUID(), ParticipantType.USER,
+                MessageType.CHAT, parts, null, 0, Map.of());
+
+        assertThat(msg.content()).isEqualTo("What is in this picture?");
+        assertThat(msg.parts()).containsExactlyElementsOf(parts);
+        assertThat(msg.partsOrText()).containsExactlyElementsOf(parts);
+        assertThat(msg.sequenceNum()).isEqualTo(1);
+        assertThat(messageRepo.store).containsExactly(msg);
+    }
+
+    @Test
+    void addMessage_withText_hasNoPartsButReadsAsOneTextPart() {
+        Conversation conv = service.createConversation(new Namespace("test"), "topic",
+                ConversationType.USER_AGENT, List.of());
+
+        Message msg = service.addMessageToConversation(conv.id(), UUID.randomUUID(), ParticipantType.USER,
+                MessageType.CHAT, "Hello!", null);
+
+        assertThat(msg.parts()).isNull();
+        assertThat(msg.partsOrText()).containsExactly(new ContentPart.Text("Hello!"));
+    }
+
+    @Test
+    void addMessage_withParts_appendsAfterExistingMessages() {
+        Conversation conv = service.createConversation(new Namespace("test"), "topic",
+                ConversationType.USER_AGENT, List.of());
+        UUID sender = UUID.randomUUID();
+        service.addMessageToConversation(conv.id(), sender, ParticipantType.USER, MessageType.CHAT, "first", null);
+
+        Message msg = service.addMessageToConversation(conv.id(), sender, ParticipantType.USER,
+                MessageType.CHAT, ContentPart.text("second"), null, null, Map.of());
+
+        assertThat(msg.sequenceNum()).isEqualTo(2);
+        assertThat(msg.content()).isEqualTo("second");
     }
 
     @Test

--- a/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/file/FileMessageRepositoryTest.java
+++ b/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/file/FileMessageRepositoryTest.java
@@ -1,0 +1,92 @@
+package ai.mindconnect.message.adapter.file;
+
+import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.domain.ContentPart;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The message JSON on disk: a message made of parts comes back as the same
+ * parts (the {@code kind} discriminator does its job), and a file written
+ * before parts existed still loads.
+ */
+class FileMessageRepositoryTest {
+
+    private final UUID conversation = UUID.randomUUID();
+    private final UUID sender = UUID.randomUUID();
+    private final ObjectMapper json = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @TempDir
+    Path dir;
+
+    private FileMessageRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = new FileMessageRepository(dir, json);
+    }
+
+    @Test
+    void aMessageMadeOfPartsComesBackAsTheSameParts() throws Exception {
+        Message m = Message.of(conversation, sender, ParticipantType.USER, MessageType.CHAT, List.of(
+                new ContentPart.Text("see attached"),
+                new ContentPart.Image("f-1", "photo.png", "image/png", 240_000L),
+                new ContentPart.File("f-2", "spec.pdf", "application/pdf", 1_048_576L)), 1);
+        repo.save(m);
+
+        assertThat(repo.findById(conversation, m.id())).contains(m);
+
+        String written = Files.readString(onlyFile());
+        assertThat(written).contains("\"kind\":\"text\"", "\"kind\":\"image\"", "\"kind\":\"file\"");
+        assertThat(written).contains("\"content\":\"see attached\"");
+    }
+
+    @Test
+    void aTextMessageHasNoPartsInItsJson() throws Exception {
+        Message m = Message.of(conversation, sender, ParticipantType.USER, MessageType.CHAT, "hello", 1);
+        repo.save(m);
+
+        assertThat(repo.findById(conversation, m.id())).contains(m);
+        assertThat(Files.readString(onlyFile())).contains("\"parts\":null");
+    }
+
+    @Test
+    void aFileWrittenBeforePartsExistedStillLoads() throws Exception {
+        UUID id = UUID.randomUUID();
+        Path messages = dir.resolve("conversations").resolve(conversation.toString()).resolve("messages");
+        Files.createDirectories(messages);
+        Files.writeString(messages.resolve("1_" + id + ".json"), """
+                {"id":"%s","conversationId":"%s","senderId":"%s","senderType":"USER",
+                 "recipientId":null,"type":"CHAT","content":"legacy text","metadata":{},
+                 "sequenceNum":1,"sentAt":1.7E9,"compressed":false,"compressedContent":null,
+                 "tokenCount":3,"compressedTokenCount":null,"durationMs":null,"turnId":null,"run":null}
+                """.formatted(id, conversation, sender));
+
+        List<Message> history = repo.findByConversationId(conversation, new PageRequest(0, 10));
+
+        assertThat(history).hasSize(1);
+        Message m = history.get(0);
+        assertThat(m.content()).isEqualTo("legacy text");
+        assertThat(m.parts()).isNull();
+        assertThat(m.partsOrText()).containsExactly(new ContentPart.Text("legacy text"));
+    }
+
+    private Path onlyFile() throws Exception {
+        try (var files = Files.walk(dir)) {
+            return files.filter(p -> p.toString().endsWith(".json")).findFirst().orElseThrow();
+        }
+    }
+}

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/agent-default.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/agent-default.json
@@ -8,5 +8,8 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 32768
+  "contextWindowTokens": 32768,
+  "capabilities": [
+    "TOOL_CALLING"
+  ]
 }

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/azure-openai-default.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/azure-openai-default.json
@@ -8,5 +8,9 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 128000
+  "contextWindowTokens": 128000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION"
+  ]
 }

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/claude-default.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/claude-default.json
@@ -12,6 +12,11 @@
     "effort": "high"
   },
   "contextWindowTokens": 200000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS"
+  ],
   "rateLimit": {
     "maxConcurrentRequests": 3
   },

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/claude-haiku-default.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/claude-haiku-default.json
@@ -9,6 +9,11 @@
   "maxOutputTokens": 8192,
   "additionalParams": {},
   "contextWindowTokens": 200000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS"
+  ],
   "retry": {
     "enabled": true,
     "maxAttempts": 5,

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/gemini-default.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/gemini-default.json
@@ -8,5 +8,11 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 8192,
   "additionalParams": {},
-  "contextWindowTokens": 1000000
+  "contextWindowTokens": 1000000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS",
+    "AUDIO_INPUT"
+  ]
 }

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/lm-studio-default.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/lm-studio-default.json
@@ -8,5 +8,8 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 32768
+  "contextWindowTokens": 32768,
+  "capabilities": [
+    "TOOL_CALLING"
+  ]
 }

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/openai-default.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/openai-default.json
@@ -8,5 +8,10 @@
   "defaultTemperature": 0.7,
   "maxOutputTokens": 4096,
   "additionalParams": {},
-  "contextWindowTokens": 128000
+  "contextWindowTokens": 128000,
+  "capabilities": [
+    "TOOL_CALLING",
+    "VISION",
+    "DOCUMENTS"
+  ]
 }

--- a/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/ChatFileUploadSmokeTest.java
+++ b/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/ChatFileUploadSmokeTest.java
@@ -137,7 +137,7 @@ class ChatFileUploadSmokeTest {
         assertThat(attachments.values().iterator().next()).isGreaterThan(0L);
 
         AgentSession reloaded = sessions.findById(session.id()).orElseThrow();
-        assertThat(reloaded.attachedFiles())
+        assertThat(reloaded.attachedFileNames())
                 .as("the system prompt announces the file")
                 .contains("soup-notes.md");
     }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigDetailComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigDetailComponent.java
@@ -33,6 +33,7 @@ public final class LlmConfigDetailComponent implements UiComponent {
                 .field(UiField.text("provider", "Provider",
                         config.provider() != null ? config.provider().name() : null))
                 .field(UiField.text("type", "Type", config.isEmbedding() ? "Embedding" : "Chat"))
+                .field(UiField.text("capabilities", "Capabilities", capabilitiesSummary(config)))
                 .field(UiField.text("model", "Model", config.model()))
                 .field(UiField.text("baseUrl", "Base URL", config.baseUrl()))
                 .field(UiField.text("apiKey", "API Key", "••••••••"))
@@ -67,6 +68,14 @@ public final class LlmConfigDetailComponent implements UiComponent {
         if (config.additionalParams() == null) return "—";
         Object v = config.additionalParams().get(key);
         return v == null || v.toString().isBlank() ? "—" : v.toString();
+    }
+
+    /** The declared capabilities by label, or "—" when the config declares none. */
+    private static String capabilitiesSummary(LlmConfig config) {
+        if (config.capabilities().isEmpty()) return "—";
+        return config.capabilities().stream()
+                .map(ai.mindconnect.llm.domain.LlmCapability::label)
+                .collect(java.util.stream.Collectors.joining(", "));
     }
 
     /** Human-readable one-liner for the retry policy, or "Off" when none is set. */

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigDetailComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigDetailComponent.java
@@ -70,12 +70,18 @@ public final class LlmConfigDetailComponent implements UiComponent {
         return v == null || v.toString().isBlank() ? "—" : v.toString();
     }
 
-    /** The declared capabilities by label, or "—" when the config declares none. */
+    /**
+     * The effective capabilities by label — the declared ones, or the
+     * provider's default marked as such; "none" for a config that declared
+     * the empty set, "—" when nothing applies (an alias).
+     */
     private static String capabilitiesSummary(LlmConfig config) {
-        if (config.capabilities().isEmpty()) return "—";
-        return config.capabilities().stream()
+        var effective = config.effectiveCapabilities();
+        if (effective.isEmpty()) return config.declaresCapabilities() ? "none (declared)" : "—";
+        String labels = effective.stream()
                 .map(ai.mindconnect.llm.domain.LlmCapability::label)
                 .collect(java.util.stream.Collectors.joining(", "));
+        return config.declaresCapabilities() ? labels : labels + " (" + config.provider() + " default)";
     }
 
     /** Human-readable one-liner for the retry policy, or "Off" when none is set. */

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.adminui.ui.component;
 
 import ai.mindconnect.chatui.ui.UiComponent;
+import ai.mindconnect.llm.domain.LlmCapability;
 import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.llm.domain.LlmProvider;
 import ai.mindconnect.ui.model.UiAction;
@@ -56,8 +57,8 @@ public final class LlmConfigFormComponent implements UiComponent {
 
     /**
      * The type-specific settings, swapped in place when the "Embedding Model"
-     * checkbox toggles. Chat configs carry the sampling/retry knobs; an
-     * embedding model only needs its input window.
+     * checkbox toggles. Chat configs carry the sampling/retry knobs and the
+     * capability declaration; an embedding model only needs its input window.
      */
     public static ai.mindconnect.ui.model.UiFieldGroup typeGroup(boolean isEmbedding, LlmConfig config) {
         var group = ai.mindconnect.ui.model.UiFieldGroup.of("llm-type-cfg",
@@ -68,7 +69,8 @@ public final class LlmConfigFormComponent implements UiComponent {
                     .hint("Optional — the embedding model's input window, used to size chunks"));
             return group;
         }
-        group.field(UiField.number("defaultTemperature", "Temperature",
+        group.field(capabilitiesField(config))
+                .field(UiField.number("defaultTemperature", "Temperature",
                         config == null ? 0.7 : config.defaultTemperature()).asEditable())
                 .field(UiField.number("maxOutputTokens", "Max Output Tokens",
                         config == null ? 4096 : config.maxOutputTokens()).asEditable())
@@ -93,6 +95,24 @@ public final class LlmConfigFormComponent implements UiComponent {
                                 ? config.rateLimit().maxConcurrentRequests() : null).asEditable()
                         .hint("Caps in-flight LLM requests for this config (across turns, sub-agents, tool loops). Leave empty for unlimited. Use it to stay under a provider's rate limit when run_agents fans out."));
         return group;
+    }
+
+    /**
+     * The capability declaration — one option per {@link LlmCapability}, the
+     * config's current set preselected. Informative: the hint says so, so an
+     * admin does not expect ticking "Vision" to change what the runtime sends.
+     */
+    private static UiField capabilitiesField(LlmConfig config) {
+        List<UiField.Option> options = Arrays.stream(LlmCapability.values())
+                .map(c -> UiField.Option.of(c.name(), c.label()))
+                .toList();
+        List<String> current = config == null ? List.of()
+                : config.capabilities().stream().map(Enum::name).toList();
+        return UiField.multiselect("capabilities", "Capabilities", current, options)
+                .asEditable()
+                .hint("What the model can take in and do — tool calling, images, documents, "
+                        + "audio. Informative: shown here and readable by callers, not "
+                        + "enforced by the runtime.");
     }
 
     /**

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
@@ -99,20 +99,25 @@ public final class LlmConfigFormComponent implements UiComponent {
 
     /**
      * The capability declaration — one option per {@link LlmCapability}, the
-     * config's current set preselected. Informative: the hint says so, so an
-     * admin does not expect ticking "Vision" to change what the runtime sends.
+     * config's effective set preselected: what it declares, or its provider's
+     * default when it declares nothing. Saving the form pins that set on the
+     * config; the hint says what Vision and Documents do, so an admin knows
+     * that unticking Vision turns images into placeholders.
      */
     private static UiField capabilitiesField(LlmConfig config) {
         List<UiField.Option> options = Arrays.stream(LlmCapability.values())
                 .map(c -> UiField.Option.of(c.name(), c.label()))
                 .toList();
         List<String> current = config == null ? List.of()
-                : config.capabilities().stream().map(Enum::name).toList();
+                : config.effectiveCapabilities().stream().map(Enum::name).toList();
+        String origin = config == null || config.declaresCapabilities() ? ""
+                : " Not declared yet — the preselection is the " + config.provider() + " default; "
+                        + "saving pins it.";
         return UiField.multiselect("capabilities", "Capabilities", current, options)
                 .asEditable()
-                .hint("What the model can take in and do — tool calling, images, documents, "
-                        + "audio. Informative: shown here and readable by callers, not "
-                        + "enforced by the runtime.");
+                .hint("What the model reads and does. Vision: images sent with a message reach "
+                        + "the model as pictures, otherwise as a placeholder line. Documents: the "
+                        + "same for PDFs. Tool calling and audio are declarative for now." + origin);
     }
 
     /**

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
@@ -9,6 +9,7 @@ import ai.mindconnect.adminui.ui.component.LlmConfigTestComponent;
 import ai.mindconnect.adminui.ui.page.LlmConfigDetailPage;
 import ai.mindconnect.adminui.ui.page.LlmConfigFormPage;
 import ai.mindconnect.adminui.ui.page.LlmConfigListPage;
+import ai.mindconnect.llm.domain.LlmCapability;
 import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.llm.domain.LlmConfigType;
 import ai.mindconnect.llm.domain.LlmProvider;
@@ -190,7 +191,8 @@ public class LlmConfigUiController {
                 isAlias ? body.str("delegatesTo") : null,
                 retryFrom(body),
                 rateLimitFrom(body),
-                typeFrom(body, LlmConfigType.CHAT));
+                typeFrom(body, LlmConfigType.CHAT),
+                capabilitiesFrom(body));
         repository.save(config);
         return list();
     }
@@ -223,7 +225,9 @@ public class LlmConfigUiController {
                             raw.containsKey("maxConcurrentRequests")
                                     ? rateLimitFrom(body) : existing.rateLimit(),
                             raw.containsKey("type")
-                                    ? typeFrom(body, existing.type()) : existing.type());
+                                    ? typeFrom(body, existing.type()) : existing.type(),
+                            raw.containsKey("capabilities")
+                                    ? capabilitiesFrom(body) : existing.capabilities());
                     repository.save(updated);
                     return ResponseEntity.ok(list());
                 })
@@ -340,6 +344,22 @@ public class LlmConfigUiController {
         if (v == null) return;            // field absent from form → leave untouched
         if (v.isBlank()) params.remove(key);
         else params.put(key, v);
+    }
+
+    /**
+     * The capability multiselect as a set — unknown values (a stale form, a
+     * renamed constant) are dropped rather than failing the save.
+     */
+    private static java.util.Set<LlmCapability> capabilitiesFrom(FormBody body) {
+        java.util.Set<LlmCapability> capabilities = java.util.EnumSet.noneOf(LlmCapability.class);
+        for (String raw : body.strList("capabilities")) {
+            try {
+                capabilities.add(LlmCapability.valueOf(raw.trim()));
+            } catch (IllegalArgumentException ignored) {
+                // not a capability we know — leave it out
+            }
+        }
+        return capabilities;
     }
 
     /**

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
@@ -48,17 +48,26 @@ public class AgentApiController {
     private final AgentRegistryService registryService;
     private final AgentSessionService sessionService;
     private final AgentChatService chatService;
+    private final ai.mindconnect.filestore.FileStore fileStore;
     private final ObjectMapper compactMapper;
 
     public AgentApiController(AgentRegistryService registryService,
                             AgentSessionService sessionService,
                             AgentChatService chatService,
+                            ai.mindconnect.filestore.FileStore fileStore,
                             ObjectMapper objectMapper) {
         this.registryService = registryService;
         this.sessionService = sessionService;
         this.chatService = chatService;
+        this.fileStore = fileStore;
         this.compactMapper = objectMapper.copy().disable(
                 com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT);
+    }
+
+    /** A request that names an unknown file or part kind is the caller's mistake: 400, not 500. */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> badRequest(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(Map.of("error", e.getMessage() == null ? "bad request" : e.getMessage()));
     }
 
     // ── Agent CRUD ──────────────────────────────────────────────────────────
@@ -189,10 +198,66 @@ public class AgentApiController {
     public SseEmitter streaming(@PathVariable UUID sessionId, @RequestBody String message) {
         log.info("POST /api/sessions/{}/chat message=\"{}\"", sessionId,
                 message.length() > 80 ? message.substring(0, 80) + "…" : message);
+        return streamTurn(sessionId, ai.mindconnect.message.domain.ContentPart.text(message));
+    }
 
+    /**
+     * The JSON twin: the text plus files sent with it — uploaded beforehand
+     * through {@code POST /api/files}, referenced by id. An image goes to the
+     * model as an image part (a vision model sees it with the question), a
+     * file as a document part; what a model does not read stands in as a
+     * placeholder line.
+     */
+    @Operation(tags = "Sessions", summary = "Send a chat message with files (SSE stream)",
+            description = "JSON body {message, parts:[{kind:image|file, fileId}]}. The files were "
+                    + "uploaded through POST /api/files; the message carries them as content "
+                    + "parts — an image is sent to a vision model as the picture, a PDF to a "
+                    + "document-reading model as the document. Streams the turn as Server-Sent "
+                    + "Events like the plain-text variant.")
+    @PostMapping(value = "/sessions/{sessionId}/chat", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamingWithParts(@PathVariable UUID sessionId,
+                                         @RequestBody ai.mindconnect.agentrest.dto.ChatRequest request) {
+        String message = request.message() == null ? "" : request.message();
+        log.info("POST /api/sessions/{}/chat (json) message=\"{}\" parts={}", sessionId,
+                message.length() > 80 ? message.substring(0, 80) + "…" : message,
+                request.parts() == null ? 0 : request.parts().size());
+        List<ai.mindconnect.message.domain.ContentPart> parts = new java.util.ArrayList<>();
+        parts.add(new ai.mindconnect.message.domain.ContentPart.Text(message));
+        for (var part : request.parts() == null ? List.<ai.mindconnect.agentrest.dto.ChatRequest.Part>of()
+                : request.parts()) {
+            parts.add(toPart(part));
+        }
+        if (message.isBlank() && parts.size() == 1) {
+            throw new IllegalArgumentException("A chat message needs text or at least one part");
+        }
+        return streamTurn(sessionId, parts);
+    }
+
+    /** A requested part as a domain part — the file's name, type and size from the store. */
+    private ai.mindconnect.message.domain.ContentPart toPart(ai.mindconnect.agentrest.dto.ChatRequest.Part part) {
+        if (part.fileId() == null || part.fileId().isBlank()) {
+            throw new IllegalArgumentException("A part needs a fileId — upload via POST /api/files first");
+        }
+        ai.mindconnect.filestore.StoredFile stored = fileStore.find(part.fileId()).orElseThrow(() ->
+                new IllegalArgumentException("Unknown fileId '" + part.fileId()
+                        + "' — upload via POST /api/files first"));
+        String kind = part.kind() == null ? "" : part.kind().toLowerCase(java.util.Locale.ROOT);
+        return switch (kind) {
+            case "image" -> new ai.mindconnect.message.domain.ContentPart.Image(
+                    stored.id(), stored.name(), stored.contentType(), stored.size());
+            case "file", "document" -> new ai.mindconnect.message.domain.ContentPart.File(
+                    stored.id(), stored.name(), stored.contentType(), stored.size());
+            default -> throw new IllegalArgumentException(
+                    "Unknown part kind '" + part.kind() + "' — use image or file");
+        };
+    }
+
+    /** Starts the turn and streams it as Server-Sent Events until it ends. */
+    private SseEmitter streamTurn(UUID sessionId, List<ai.mindconnect.message.domain.ContentPart> parts) {
         SseEmitter emitter = new SseEmitter(120_000L);
 
-        ChatTurnHandle turn = chatService.submitChat(sessionId, message, event -> {
+        ChatTurnHandle turn = chatService.submitChat(sessionId, parts, event -> {
             try {
                 emitter.send(SseEmitter.event().data(
                         compactMapper.writeValueAsString(StreamEventFrame.from(event)),

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/SessionFilesApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/SessionFilesApiController.java
@@ -81,17 +81,31 @@ public class SessionFilesApiController {
         return ResponseEntity.ok(toResponse(sessionFiles.attach(sessionId, stored)));
     }
 
-    /** The files attached to this chat, with the number of searchable chunks each produced. */
+    /**
+     * The files attached to this chat: the file-store id, name, media type
+     * and size of each, and for an ingested file the number of searchable
+     * chunks it produced. An image is attached but not ingested — it goes to
+     * the model with the next message — so its chunk count is 0.
+     */
     @Operation(tags = "Sessions", summary = "List the files attached to a chat",
-            description = "File id \u2192 chunk count. Empty when nothing is attached or when "
-                    + "no vector store is configured.")
+            description = "One entry per attached file: fileId (file store), name, mediaType, "
+                    + "sizeBytes and chunks (searchable chunks; 0 for an image, which goes to "
+                    + "the model with the next message instead of into the vector store).")
     @GetMapping
     public ResponseEntity<List<Map<String, Object>>> listAttachments(@PathVariable UUID sessionId) {
-        var files = sessionFiles.listAttachments(sessionId).entrySet().stream()
-                .map(e -> Map.<String, Object>of(
-                        "fileId", e.getKey(),
-                        "name", java.nio.file.Path.of(e.getKey()).getFileName().toString(),
-                        "chunks", e.getValue()))
+        Map<String, Long> chunksByName = new java.util.HashMap<>();
+        sessionFiles.listAttachments(sessionId).forEach((ingestedId, chunks) ->
+                chunksByName.merge(java.nio.file.Path.of(ingestedId).getFileName().toString(), chunks, Long::sum));
+        var files = sessionFiles.attachments(sessionId).stream()
+                .map(f -> {
+                    Map<String, Object> entry = new java.util.LinkedHashMap<>();
+                    entry.put("fileId", f.id());
+                    entry.put("name", f.name());
+                    entry.put("mediaType", f.mediaType());
+                    entry.put("sizeBytes", f.sizeBytes());
+                    entry.put("chunks", chunksByName.getOrDefault(f.name(), 0L));
+                    return entry;
+                })
                 .toList();
         return ResponseEntity.ok(files);
     }
@@ -107,8 +121,8 @@ public class SessionFilesApiController {
                     + "spooled copy. The file itself stays in the file store.")
     @DeleteMapping
     public ResponseEntity<Void> detach(@PathVariable UUID sessionId,
-                                       @RequestParam("file") String fileId) {
-        sessionFiles.deleteAttachment(sessionId, fileId);
+                                       @RequestParam("file") String fileIdOrName) {
+        sessionFiles.deleteAttachment(sessionId, fileIdOrName);
         return ResponseEntity.noContent().build();
     }
 

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/ChatRequest.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/ChatRequest.java
@@ -1,3 +1,15 @@
 package ai.mindconnect.agentrest.dto;
 
-public record ChatRequest(String message) {}
+import java.util.List;
+
+/**
+ * The JSON body of {@code POST /api/sessions/{id}/chat}: the text, plus the
+ * files sent with it — uploaded beforehand through {@code POST /api/files}
+ * and referenced by id here, never carried inline. {@code kind} is
+ * {@code image} or {@code file}; the file's name, media type and size come
+ * from the store.
+ */
+public record ChatRequest(String message, List<Part> parts) {
+
+    public record Part(String kind, String fileId) {}
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
@@ -123,6 +123,19 @@ public class SessionFileService {
                 sessions.save(session.withoutAttachedFile(fileName)));
     }
 
+    /**
+     * A file the model may read inline is shown with the next message only;
+     * afterwards the model asks for it again through {@code view_attachment}
+     * — activated for the session, like {@code vector_search} on ingest.
+     */
+    private void activateViewer(UUID sessionId) {
+        DynamicToolActivations activations = activationsProvider.getIfAvailable();
+        if (activations != null) {
+            activations.activate(sessionId,
+                    List.of(ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.NAME));
+        }
+    }
+
     public AttachResult attach(UUID sessionId, StoredFile stored) {
         AttachedFile attached = new AttachedFile(stored.id(), stored.name(), stored.contentType(), stored.size());
         if (attached.isImage()) {
@@ -135,6 +148,7 @@ public class SessionFileService {
             }
             sessions.findById(sessionId).ifPresent(session ->
                     sessions.save(session.withAttachedFiles(List.of(attached))));
+            activateViewer(sessionId);
             return new AttachResult(stored, null, true,
                     stored.name() + " attached — it goes to the model with your next message.");
         }
@@ -193,6 +207,7 @@ public class SessionFileService {
             if (activations != null) {
                 activations.activate(sessionId, List.of("vector_search"));
             }
+            if (attached.isPdf()) activateViewer(sessionId);
             // Announce the file in the system prompt (rendered fresh each
             // round) so the model actually reaches for vector_search.
             sessions.findById(sessionId).ifPresent(session ->

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
@@ -1,5 +1,7 @@
 package ai.mindconnect.agentrest.service;
 
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.AttachedFile;
 import ai.mindconnect.agent.port.out.AgentSessionRepository;
 import ai.mindconnect.agent.tools.toolsearch.DynamicToolActivations;
 import ai.mindconnect.filestore.FileStore;
@@ -68,7 +70,16 @@ public class SessionFileService {
         this.spoolBase = Path.of(toolsBaseDir).toAbsolutePath().normalize();
     }
 
-    /** The session's attached files: spooled file id → chunk count. Empty when none. */
+    /**
+     * The files attached to the session, in attach order — the session's own
+     * record, images included. {@link #listAttachments} adds the searchable
+     * chunks each ingested file produced.
+     */
+    public List<AttachedFile> attachments(UUID sessionId) {
+        return sessions.findById(sessionId).map(AgentSession::attachedFiles).orElse(List.of());
+    }
+
+    /** The session's ingested files: spooled file id → chunk count. Empty when none. */
     public Map<String, Long> listAttachments(UUID sessionId) {
         VectorStores stores = storesProvider.getIfAvailable();
         if (stores == null) return Map.of();
@@ -83,25 +94,50 @@ public class SessionFileService {
         return Map.of();
     }
 
-    public void deleteAttachment(UUID sessionId, String fileId) {
+    /**
+     * Detaches a file from the chat, named by its file name or by the id its
+     * chunks were ingested under (the spooled path — what {@link #listAttachments}
+     * keys by). Its chunks leave the session's vector store and the spooled
+     * copy goes with them; an image, never ingested, simply leaves the
+     * session's record. The original in the file store is untouched.
+     */
+    public void deleteAttachment(UUID sessionId, String fileIdOrName) {
+        String fileName = Path.of(fileIdOrName).getFileName().toString();
         VectorStores stores = storesProvider.getIfAvailable();
-        if (stores == null) throw new NotConfiguredException("Vector stores");
-        String storeName = "session-" + sessionId;
-        stores.openWith(stores.settingsFor(storeName)).deleteFile(fileId);
-        Path spooled = spoolBase.resolve(fileId).normalize();
-        if (spooled.startsWith(spoolBase)) {
-            try {
-                Files.deleteIfExists(spooled);
-            } catch (java.io.IOException ignored) {
-                // The searchable chunks are gone; a stale spool file is harmless.
+        if (stores != null) {
+            String storeName = "session-" + sessionId;
+            for (String ingestedId : listAttachments(sessionId).keySet()) {
+                if (!Path.of(ingestedId).getFileName().toString().equals(fileName)) continue;
+                stores.openWith(stores.settingsFor(storeName)).deleteFile(ingestedId);
+                Path spooled = spoolBase.resolve(ingestedId).normalize();
+                if (spooled.startsWith(spoolBase)) {
+                    try {
+                        Files.deleteIfExists(spooled);
+                    } catch (java.io.IOException ignored) {
+                        // The searchable chunks are gone; a stale spool file is harmless.
+                    }
+                }
             }
         }
-        String fileName = Path.of(fileId).getFileName().toString();
         sessions.findById(sessionId).ifPresent(session ->
                 sessions.save(session.withoutAttachedFile(fileName)));
     }
 
     public AttachResult attach(UUID sessionId, StoredFile stored) {
+        AttachedFile attached = new AttachedFile(stored.id(), stored.name(), stored.contentType(), stored.size());
+        if (attached.isImage()) {
+            // An image is not text to index: it goes to the model with the
+            // next message as an image part — or as that part's placeholder
+            // when the model does not read images. Recorded on the session,
+            // nothing else to do.
+            if (sessions.findById(sessionId).isEmpty()) {
+                return new AttachResult(stored, null, false, stored.name() + ": unknown session " + sessionId);
+            }
+            sessions.findById(sessionId).ifPresent(session ->
+                    sessions.save(session.withAttachedFiles(List.of(attached))));
+            return new AttachResult(stored, null, true,
+                    stored.name() + " attached — it goes to the model with your next message.");
+        }
         VectorStores stores = storesProvider.getIfAvailable();
         if (stores == null) {
             return new AttachResult(stored, null, false,
@@ -160,7 +196,7 @@ public class SessionFileService {
             // Announce the file in the system prompt (rendered fresh each
             // round) so the model actually reaches for vector_search.
             sessions.findById(sessionId).ifPresent(session ->
-                    sessions.save(session.withAttachedFiles(List.of(stored.name()))));
+                    sessions.save(session.withAttachedFiles(List.of(attached))));
             return new AttachResult(stored, storeName, true,
                     stored.name() + " attached — the agent can now search it.");
         } catch (Exception e) {

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatAttachmentsComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatAttachmentsComponent.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.chatui.ui.component;
 
+import ai.mindconnect.agent.domain.AttachedFile;
 import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.chatui.ui.controller.ChatFilesUiController;
 
@@ -11,37 +12,66 @@ import ai.mindconnect.ui.model.UiStack;
 import ai.mindconnect.ui.model.UiTable;
 
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 /**
- * The chat page's attached-files panel: file name, chunk count and a Remove
- * action per attachment. Pure rendering — the data (file id → chunk count)
- * comes from {@link ai.mindconnect.agentrest.service.SessionFileService#listAttachments},
- * the domain half that also serves the REST endpoint.
+ * The chat page's attached-files panel: file name, what it is, how it
+ * reaches the model, and a Remove action per attachment. Pure rendering —
+ * the files are the session's record
+ * ({@link ai.mindconnect.agentrest.service.SessionFileService#attachments}),
+ * the chunk counts come from the session's vector store
+ * ({@link ai.mindconnect.agentrest.service.SessionFileService#listAttachments}).
  */
 public final class ChatAttachmentsComponent {
 
     private ChatAttachmentsComponent() {}
 
-    /** Stable id {@code chat-attachments} so attach/delete patches always have a target. */
-    public static UiNode node(UUID sessionId, Map<String, Long> files) {
+    /**
+     * Stable id {@code chat-attachments} so attach/delete patches always have a target.
+     *
+     * @param files  the session's attached files, in attach order
+     * @param chunks ingested file id → searchable chunks, for the files that were indexed
+     */
+    public static UiNode node(UUID sessionId, List<AttachedFile> files, Map<String, Long> chunks) {
         var panel = UiStack.of("chat-attachments").gap(4);
         if (files.isEmpty()) {
             return panel;
         }
+        Map<String, Long> chunksByName = new HashMap<>();
+        chunks.forEach((ingestedId, count) ->
+                chunksByName.merge(Path.of(ingestedId).getFileName().toString(), count, Long::sum));
         var table = UiTable.of("chat-attachments-table", "Attached Files (" + files.size() + ")")
                 .column(UiTable.Column.text("file", "File"))
-                .column(UiTable.Column.text("chunks", "Chunks"))
+                .column(UiTable.Column.text("kind", "Kind"))
+                .column(UiTable.Column.text("reach", "Reaches the model as"))
                 .rowAction(UiAction.danger("remove", "Remove").icon("remove")
-                        .confirm("Remove this file from the conversation? The agent can no longer search it.")
+                        .confirm("Remove this file from the conversation?")
                         .onClick(trigger(on(ChatFilesUiController.class)
                                 .remove(sessionId, ROW_ID.toString()))));
-        files.forEach((fileId, count) -> table.row(Map.of(
-                "id", java.net.URLEncoder.encode(fileId, java.nio.charset.StandardCharsets.UTF_8),
-                "file", Path.of(fileId).getFileName().toString(),
-                "chunks", String.valueOf(count))));
+        for (AttachedFile f : files) {
+            table.row(Map.of(
+                    "id", java.net.URLEncoder.encode(f.name(), java.nio.charset.StandardCharsets.UTF_8),
+                    "file", f.name(),
+                    "kind", kind(f),
+                    "reach", reach(f, chunksByName.getOrDefault(f.name(), 0L))));
+        }
         panel.child(table);
         return panel;
+    }
+
+    private static String kind(AttachedFile f) {
+        if (f.isImage()) return "image";
+        if (f.isPdf()) return "PDF";
+        return f.mediaType() != null && !f.mediaType().isBlank() ? f.mediaType() : "file";
+    }
+
+    /** How the file reaches the model — with the next message, or through vector_search. */
+    private static String reach(AttachedFile f, long chunks) {
+        if (f.isImage()) return "image with the next message";
+        String search = chunks + (chunks == 1 ? " searchable chunk" : " searchable chunks");
+        return f.isPdf() ? "document with the next message · " + search : search;
     }
 }

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
@@ -65,8 +65,12 @@ public final class MessageComponent {
         if (m.parts() != null) {
             for (var part : m.parts()) {
                 if (part instanceof ai.mindconnect.message.domain.ContentPart.Image image) {
-                    out.append("\n\n![").append(markdownSafe(image.name())).append("](")
-                            .append(contentUrl(image.fileId())).append(")");
+                    // A linked image: the thumbnail (sized by the chat's CSS)
+                    // opens the original in a new tab — the markdown renderer
+                    // gives every link target="_blank".
+                    String url = contentUrl(image.fileId());
+                    out.append("\n\n[![").append(markdownSafe(image.name())).append("](")
+                            .append(url).append(")](").append(url).append(")");
                 } else if (part instanceof ai.mindconnect.message.domain.ContentPart.File file) {
                     out.append("\n\n📄 *").append(markdownSafe(file.name())).append("*");
                 }

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
@@ -50,16 +50,40 @@ public final class MessageComponent {
     /**
      * A user message that announced attachments (metadata written by the
      * runtime when the message was persisted) shows them as a line above the
-     * text — rendering only; the stored text is what the user typed.
+     * text — rendering only; the stored text is what the user typed. The
+     * media parts the message carries follow the text: an image as the
+     * picture itself, served from the chat's file endpoint; a document as
+     * its name.
      */
-    private static String withAttachmentChip(Message m) {
+    String withAttachmentChip(Message m) {
         var attached = ai.mindconnect.agent.service.prompt.AttachmentNotice.announcedBy(m);
         var removed = ai.mindconnect.agent.service.prompt.AttachmentNotice.detachedBy(m);
-        if (attached.isEmpty() && removed.isEmpty()) return m.content();
         StringBuilder out = new StringBuilder();
         if (!attached.isEmpty()) out.append("📎 *").append(String.join(", ", attached)).append("*\n\n");
         if (!removed.isEmpty()) out.append("🗑 *").append(String.join(", ", removed)).append(" removed*\n\n");
-        return out.append(m.content()).toString();
+        out.append(m.content() == null ? "" : m.content());
+        if (m.parts() != null) {
+            for (var part : m.parts()) {
+                if (part instanceof ai.mindconnect.message.domain.ContentPart.Image image) {
+                    out.append("\n\n![").append(markdownSafe(image.name())).append("](")
+                            .append(contentUrl(image.fileId())).append(")");
+                } else if (part instanceof ai.mindconnect.message.domain.ContentPart.File file) {
+                    out.append("\n\n📄 *").append(markdownSafe(file.name())).append("*");
+                }
+            }
+        }
+        return out.toString();
+    }
+
+    /** Where the chat serves a file it holds, inline — see {@code ChatFilesUiController#content}. */
+    private String contentUrl(String fileId) {
+        return "/chat/api/sessions/" + sessionId + "/chat-files/"
+                + java.net.URLEncoder.encode(fileId, java.nio.charset.StandardCharsets.UTF_8) + "/content";
+    }
+
+    /** A file name inside markdown link syntax: brackets and parentheses would end it early. */
+    private static String markdownSafe(String name) {
+        return name == null ? "" : name.replaceAll("[\\[\\]()*_`]", "");
     }
 
     private UiList.Item chatItem(Message m, boolean isUser) {

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
@@ -91,8 +91,10 @@ public final class MessageComponent {
     }
 
     private UiList.Item chatItem(Message m, boolean isUser) {
-        boolean inserted = ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.insertedBy(m);
-        String speaker = inserted ? "Attachment shown again" : isUser ? "You" : agent.name();
+        if (ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.insertedBy(m)) {
+            return reshownItem(m);
+        }
+        String speaker = isUser ? "You" : agent.name();
         String time    = timeFormat.format(m.sentAt());
         String label   = speaker + "  [" + time + "]" + messageTokenSuffix(m);
         String css     = isUser ? "user-message" : "bot-message";
@@ -104,9 +106,8 @@ public final class MessageComponent {
         // Regenerate (USER messages only): delete this message + everything
         // after it, then re-run the turn (streaming) with the same text. Uses
         // the STREAM behaviour so the live tokens/task-cards flow exactly like
-        // a normal send. Not for a message the runtime inserted mid-turn —
-        // there is no question to ask again.
-        if (isUser && !inserted) {
+        // a normal send.
+        if (isUser) {
             item.action(UiAction.icon("regen-" + m.id(), "🔄")
                     .confirm("Delete the response(s) after this message and generate a new one?")
                     // Plain dispatch — the regenerated turn streams on the
@@ -124,6 +125,21 @@ public final class MessageComponent {
                         .deleteMessages(sessionId, seq, Integer.MAX_VALUE, null))));
         return item;
     }
+    /**
+     * A message the runtime inserted on the user's behalf — an attachment
+     * shown to the assistant again at its request — is not the user's, and
+     * the picture is already in the bubble it came with: one muted line
+     * naming the file, no thumbnail, no actions.
+     */
+    private UiList.Item reshownItem(Message m) {
+        Object name = m.metadata() == null ? null
+                : m.metadata().get(ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.ATTACHMENT);
+        String line = "🔁 *" + markdownSafe(name == null ? "attachment" : name.toString())
+                + "* shown to the assistant again  [" + timeFormat.format(m.sentAt()) + "]";
+        return UiList.Item.of(m.id().toString(), "")
+                .content(UiMarkdown.of("msg-" + m.id(), line).withCssClass("reshown-message"));
+    }
+
     /** " · 42 tok" for a single message; empty when not counted. */
     private String messageTokenSuffix(Message m) {
         Integer t = m.tokenCount();

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
@@ -59,8 +59,8 @@ public final class MessageComponent {
         var attached = ai.mindconnect.agent.service.prompt.AttachmentNotice.announcedBy(m);
         var removed = ai.mindconnect.agent.service.prompt.AttachmentNotice.detachedBy(m);
         StringBuilder out = new StringBuilder();
-        if (!attached.isEmpty()) out.append("📎 *").append(String.join(", ", attached)).append("*\n\n");
-        if (!removed.isEmpty()) out.append("🗑 *").append(String.join(", ", removed)).append(" removed*\n\n");
+        if (!attached.isEmpty()) out.append(icon("paperclip")).append(" *").append(String.join(", ", attached)).append("*\n\n");
+        if (!removed.isEmpty()) out.append(icon("trash-2")).append(" *").append(String.join(", ", removed)).append(" removed*\n\n");
         out.append(m.content() == null ? "" : m.content());
         if (m.parts() != null) {
             for (var part : m.parts()) {
@@ -72,7 +72,7 @@ public final class MessageComponent {
                     out.append("\n\n[![").append(markdownSafe(image.name())).append("](")
                             .append(url).append(")](").append(url).append(")");
                 } else if (part instanceof ai.mindconnect.message.domain.ContentPart.File file) {
-                    out.append("\n\n📄 *").append(markdownSafe(file.name())).append("*");
+                    out.append("\n\n").append(icon("file-text")).append(" *").append(markdownSafe(file.name())).append("*");
                 }
             }
         }
@@ -83,6 +83,15 @@ public final class MessageComponent {
     private String contentUrl(String fileId) {
         return "/chat/api/sessions/" + sessionId + "/chat-files/"
                 + java.net.URLEncoder.encode(fileId, java.nio.charset.StandardCharsets.UTF_8) + "/content";
+    }
+
+    /**
+     * A sprite icon inside markdown — the same {@code <svg><use>} the framework's
+     * icon renderer emits, so it sizes and colours with the surrounding text.
+     * Markdown passes inline HTML through; the name is a sprite id, never user input.
+     */
+    private static String icon(String name) {
+        return "<svg class=\"sui-icon\" aria-hidden=\"true\"><use href=\"/sui/icons.svg#" + name + "\"></use></svg>";
     }
 
     /** A file name inside markdown link syntax: brackets and parentheses would end it early. */
@@ -108,7 +117,7 @@ public final class MessageComponent {
         // the STREAM behaviour so the live tokens/task-cards flow exactly like
         // a normal send.
         if (isUser) {
-            item.action(UiAction.icon("regen-" + m.id(), "🔄")
+            item.action(UiAction.icon("regen-" + m.id(), "Regenerate").icon("refresh-cw")
                     .confirm("Delete the response(s) after this message and generate a new one?")
                     // Plain dispatch — the regenerated turn streams on the
                     // session's stream like any other.
@@ -118,7 +127,7 @@ public final class MessageComponent {
         // Delete-from-here: remove this message and every message after it.
         // toSeq = MAX_VALUE → the range delete runs to the end of the
         // conversation. Sub-agent sessions are not cleaned up.
-        item.action(UiAction.icon("delete-" + m.id(), "🗑")
+        item.action(UiAction.icon("delete-" + m.id(), "Delete from here").icon("trash-2")
                 .style(UiAction.Style.DANGER)
                 .confirm("Delete this message and all following messages?")
                 .onClick(trigger(on(ChatUiController.class)
@@ -134,7 +143,7 @@ public final class MessageComponent {
     private UiList.Item reshownItem(Message m) {
         Object name = m.metadata() == null ? null
                 : m.metadata().get(ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.ATTACHMENT);
-        String line = "🔁 *" + markdownSafe(name == null ? "attachment" : name.toString())
+        String line = icon("repeat") + " *" + markdownSafe(name == null ? "attachment" : name.toString())
                 + "* shown to the assistant again  [" + timeFormat.format(m.sentAt()) + "]";
         return UiList.Item.of(m.id().toString(), "")
                 .content(UiMarkdown.of("msg-" + m.id(), line).withCssClass("reshown-message"));

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
@@ -87,7 +87,8 @@ public final class MessageComponent {
     }
 
     private UiList.Item chatItem(Message m, boolean isUser) {
-        String speaker = isUser ? "You" : agent.name();
+        boolean inserted = ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.insertedBy(m);
+        String speaker = inserted ? "Attachment shown again" : isUser ? "You" : agent.name();
         String time    = timeFormat.format(m.sentAt());
         String label   = speaker + "  [" + time + "]" + messageTokenSuffix(m);
         String css     = isUser ? "user-message" : "bot-message";
@@ -99,8 +100,9 @@ public final class MessageComponent {
         // Regenerate (USER messages only): delete this message + everything
         // after it, then re-run the turn (streaming) with the same text. Uses
         // the STREAM behaviour so the live tokens/task-cards flow exactly like
-        // a normal send.
-        if (isUser) {
+        // a normal send. Not for a message the runtime inserted mid-turn —
+        // there is no question to ask again.
+        if (isUser && !inserted) {
             item.action(UiAction.icon("regen-" + m.id(), "🔄")
                     .confirm("Delete the response(s) after this message and generate a new one?")
                     // Plain dispatch — the regenerated turn streams on the

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
@@ -57,18 +57,24 @@ public class ChatFilesUiController {
                     : UiToast.error(result.message()).title("Attach failed"));
         }
         patch.patch(UiPatch.Operation.replace("chat-attachments",
-                ai.mindconnect.chatui.ui.component.ChatAttachmentsComponent.node(sessionId, sessionFiles.listAttachments(sessionId))));
+                attachmentsPanel(sessionId)));
         patch.patch(attachmentCountRefresh(sessionId));
         return patch;
     }
 
-    /** Removes a file's chunks from the session store (query param: slashes in ids). */
+    /** The attached-files panel: the session's record, with the chunks each ingested file produced. */
+    private ai.mindconnect.ui.model.UiNode attachmentsPanel(UUID sessionId) {
+        return ai.mindconnect.chatui.ui.component.ChatAttachmentsComponent.node(
+                sessionId, sessionFiles.attachments(sessionId), sessionFiles.listAttachments(sessionId));
+    }
+
+    /** Detaches a file by name: its chunks leave the session store, an image leaves the record. */
     @org.springframework.web.bind.annotation.DeleteMapping
-    public UiPatch remove(@PathVariable UUID sessionId, @RequestParam("file") String fileId) {
-        sessionFiles.deleteAttachment(sessionId, fileId);
+    public UiPatch remove(@PathVariable UUID sessionId, @RequestParam("file") String fileName) {
+        sessionFiles.deleteAttachment(sessionId, fileName);
         return UiPatch.of()
                 .patch(UiPatch.Operation.replace("chat-attachments",
-                        ai.mindconnect.chatui.ui.component.ChatAttachmentsComponent.node(sessionId, sessionFiles.listAttachments(sessionId))))
+                        attachmentsPanel(sessionId)))
                 .patch(attachmentCountRefresh(sessionId))
                 .toast(UiToast.success("Removed from the conversation.").title("File removed"));
     }
@@ -83,7 +89,7 @@ public class ChatFilesUiController {
         var form = new ai.mindconnect.chatui.ui.component.ChatFormComponent(
                         sessionId, agent == null ? null : agent.id(), false)
                 .withModelLabel(agent == null ? null : agent.llmConfigName())
-                .withAttachmentCount(sessionFiles.listAttachments(sessionId).size());
+                .withAttachmentCount(sessionFiles.attachments(sessionId).size());
         return form.reset();
     }
 }

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
@@ -31,15 +31,58 @@ public class ChatFilesUiController {
     private final FileStore fileStore;
     private final SessionFileService sessionFiles;
     private final ai.mindconnect.agent.port.out.AgentSessionRepository sessions;
+    private final ai.mindconnect.agent.service.AgentSessionService sessionService;
     private final ai.mindconnect.agent.service.SessionAgentResolver agentResolver;
 
     public ChatFilesUiController(FileStore fileStore, SessionFileService sessionFiles,
                                  ai.mindconnect.agent.port.out.AgentSessionRepository sessions,
+                                 ai.mindconnect.agent.service.AgentSessionService sessionService,
                                  ai.mindconnect.agent.port.out.AgentDefinitionRepository agents) {
         this.fileStore = fileStore;
         this.sessionFiles = sessionFiles;
         this.sessions = sessions;
+        this.sessionService = sessionService;
         this.agentResolver = new ai.mindconnect.agent.service.SessionAgentResolver(agents);
+    }
+
+    /**
+     * The bytes of a file this chat holds — for the image a message bubble
+     * shows inline. Served only for a file the session references: one of
+     * its attachments, or a part of one of its messages; any other id is
+     * not found, whether or not the store has it.
+     */
+    @org.springframework.web.bind.annotation.GetMapping("/{fileId}/content")
+    public org.springframework.http.ResponseEntity<org.springframework.core.io.InputStreamResource> content(
+            @PathVariable UUID sessionId, @PathVariable String fileId) throws IOException {
+        if (!referencedBySession(sessionId, fileId)) {
+            return org.springframework.http.ResponseEntity.notFound().build();
+        }
+        StoredFile file = fileStore.find(fileId).orElse(null);
+        if (file == null) return org.springframework.http.ResponseEntity.notFound().build();
+        MediaType type = MediaType.APPLICATION_OCTET_STREAM;
+        try {
+            if (file.contentType() != null) type = MediaType.parseMediaType(file.contentType());
+        } catch (org.springframework.http.InvalidMediaTypeException ignored) {
+            // an odd content type from the upload — served as bytes
+        }
+        return org.springframework.http.ResponseEntity.ok()
+                .contentType(type)
+                .header(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION,
+                        "inline; filename=\"" + file.name().replace("\"", "") + "\"")
+                .header(org.springframework.http.HttpHeaders.CACHE_CONTROL, "private, max-age=3600")
+                .body(new org.springframework.core.io.InputStreamResource(fileStore.content(fileId)));
+    }
+
+    /** Does the session hold this file — as an attachment, or as a part of one of its messages? */
+    private boolean referencedBySession(UUID sessionId, String fileId) {
+        var session = sessions.findById(sessionId).orElse(null);
+        if (session == null) return false;
+        if (session.attachedFiles().stream().anyMatch(f -> fileId.equals(f.id()))) return true;
+        return sessionService.loadHistory(sessionId).stream()
+                .filter(m -> m.parts() != null)
+                .flatMap(m -> m.parts().stream())
+                .anyMatch(part -> part instanceof ai.mindconnect.message.domain.ContentPart.Media media
+                        && fileId.equals(media.fileId()));
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -569,7 +569,7 @@ public class ChatUiController {
         var body = ai.mindconnect.ui.model.UiStack.of("chat-attach-body");
         body.gap(12);
         body.child(ai.mindconnect.chatui.ui.component.ChatAttachmentsComponent
-                .node(sessionId, sessionFiles.listAttachments(sessionId)));
+                .node(sessionId, sessionFiles.attachments(sessionId), sessionFiles.listAttachments(sessionId)));
         body.child(ai.mindconnect.chatui.ui.page.ChatPage.attachZone(sessionId));
         var dlg = ai.mindconnect.ui.model.UiDialog.of("Attached files", null, body);
         dlg.setId("chat-dialog");
@@ -884,15 +884,17 @@ public class ChatUiController {
             return ResponseEntity.badRequest().build();
         }
 
-        // Capture the user text at `seq` before we delete it.
-        String text = sessionService.loadHistory(sessionId).stream()
+        // Capture the user message at `seq` before we delete it — its parts,
+        // so an image sent with it is sent again.
+        java.util.List<ai.mindconnect.message.domain.ContentPart> parts = sessionService.loadHistory(sessionId).stream()
                 .filter(m -> m.sequenceNum() == seq)
                 .filter(m -> m.type() == ai.mindconnect.message.domain.MessageType.CHAT)
                 .filter(m -> m.senderType() == ai.mindconnect.message.domain.ParticipantType.USER)
-                .map(Message::content)
+                .map(Message::partsOrText)
                 .findFirst()
                 .orElse(null);
-        if (text == null || text.isBlank()) {
+        String text = parts == null ? null : ai.mindconnect.message.domain.ContentPart.textOf(parts);
+        if (parts == null || (text.isBlank() && parts.size() == 1)) {
             return ResponseEntity.badRequest().build();
         }
 
@@ -905,7 +907,9 @@ public class ChatUiController {
         // initialRefresh=true: push the trimmed conversation to the client
         // before streaming, so the now-deleted messages disappear from the
         // DOM instead of lingering until the end-of-turn refresh.
-        return runChatStream(sessionOpt.get(), agentOpt.get(), text, true);
+        var session = sessionOpt.get();
+        return runTurnStream(session, agentOpt.get(), text, true,
+                handler -> chatService.submitChat(session.id(), parts, handler));
     }
 
     /**

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -890,6 +890,8 @@ public class ChatUiController {
                 .filter(m -> m.sequenceNum() == seq)
                 .filter(m -> m.type() == ai.mindconnect.message.domain.MessageType.CHAT)
                 .filter(m -> m.senderType() == ai.mindconnect.message.domain.ParticipantType.USER)
+                // a message the runtime inserted mid-turn is not a question to ask again
+                .filter(m -> !ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.insertedBy(m))
                 .map(Message::partsOrText)
                 .findFirst()
                 .orElse(null);

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
@@ -521,6 +521,26 @@
     border-radius: 0;
 }
 
+/* An image a message carries: a thumbnail in the bubble, the original one
+   click away (the link opens in a new tab). Capped in both directions so a
+   phone screenshot does not fill the conversation. */
+.user-message img,
+.bot-message img {
+    display: block;
+    max-width: min(100%, 320px);
+    max-height: 240px;
+    width: auto;
+    height: auto;
+    border-radius: 8px;
+    cursor: zoom-in;
+}
+
+.user-message a:has(> img),
+.bot-message a:has(> img) {
+    display: inline-block;
+    line-height: 0;
+}
+
 /* The error variant is the one bot message that still needs a surface. */
 .bot-message.error-message {
     background: var(--sui-color-danger-bg);

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
@@ -541,6 +541,14 @@
     line-height: 0;
 }
 
+/* An attachment the assistant asked to see again: one muted line, no
+   surface — the picture is already in the bubble it came with. */
+.reshown-message {
+    color: var(--sui-color-text-muted, var(--sui-color-text-body));
+    font-size: .85em;
+    padding: .15rem 0;
+}
+
 /* The error variant is the one bot message that still needs a surface. */
 .bot-message.error-message {
     background: var(--sui-color-danger-bg);

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/ChatDialogActionUrlsTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/ChatDialogActionUrlsTest.java
@@ -59,9 +59,14 @@ class ChatDialogActionUrlsTest {
 
     @Test
     void removingAnAttachmentKeepsTheRowPlaceholder() throws Exception {
-        String out = json(ChatAttachmentsComponent.node(SESSION, Map.of("a.pdf", 3L)));
+        String out = json(ChatAttachmentsComponent.node(SESSION,
+                List.of(new ai.mindconnect.agent.domain.AttachedFile("f-1", "a.pdf", "application/pdf", 10),
+                        new ai.mindconnect.agent.domain.AttachedFile("f-2", "photo.png", "image/png", 20)),
+                Map.of("a.pdf", 3L)));
 
         assertThat(out).contains("\"url\":\"/chat/api/sessions/" + SESSION + "/chat-files?file={id}\"");
         assertThat(out).doesNotContain("%7Bid%7D");
+        assertThat(out).contains("document with the next message · 3 searchable chunks");
+        assertThat(out).contains("image with the next message");
     }
 }

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
@@ -31,7 +31,8 @@ class MessageComponentMediaTest {
         String body = component(m).withAttachmentChip(m);
 
         assertThat(body).startsWith("what is this?");
-        assertThat(body).contains("![my photo.png](/chat/api/sessions/" + SESSION + "/chat-files/f-1/content)");
+        String url = "/chat/api/sessions/" + SESSION + "/chat-files/f-1/content";
+        assertThat(body).contains("[![my photo.png](" + url + ")](" + url + ")");
         assertThat(body).contains("📄 *spec.pdf*");
     }
 

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
@@ -37,6 +37,22 @@ class MessageComponentMediaTest {
     }
 
     @Test
+    void anAttachmentShownAgainIsOneMutedLineWithoutThumbnailOrActions() throws Exception {
+        Message m = Message.of(UUID.randomUUID(), UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT,
+                List.of(new ContentPart.Text("[photo.png — image shown again at the assistant's request]"),
+                        new ContentPart.Image("f-1", "photo.png", "image/png", 3)), 2)
+                .withMetadata(java.util.Map.of(
+                        ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.INSERTED_BY,
+                        ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.NAME,
+                        ai.mindconnect.agent.tools.attachment.ViewAttachmentTool.ATTACHMENT, "photo.png"));
+
+        String json = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(component(m).item());
+
+        assertThat(json).contains("shown to the assistant again").contains("reshown-message");
+        assertThat(json).doesNotContain("chat-files/f-1/content").doesNotContain("regen-").doesNotContain("delete-");
+    }
+
+    @Test
     void aTextMessageIsItsTextAlone() {
         Message m = Message.of(UUID.randomUUID(), UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT,
                 "hello", 1);

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
@@ -33,7 +33,8 @@ class MessageComponentMediaTest {
         assertThat(body).startsWith("what is this?");
         String url = "/chat/api/sessions/" + SESSION + "/chat-files/f-1/content";
         assertThat(body).contains("[![my photo.png](" + url + ")](" + url + ")");
-        assertThat(body).contains("📄 *spec.pdf*");
+        assertThat(body).contains("icons.svg#file-text").contains("*spec.pdf*");
+        assertThat(body).doesNotContain("📄");
     }
 
     @Test
@@ -48,7 +49,7 @@ class MessageComponentMediaTest {
 
         String json = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(component(m).item());
 
-        assertThat(json).contains("shown to the assistant again").contains("reshown-message");
+        assertThat(json).contains("shown to the assistant again").contains("reshown-message").contains("icons.svg#repeat");
         assertThat(json).doesNotContain("chat-files/f-1/content").doesNotContain("regen-").doesNotContain("delete-");
     }
 

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/MessageComponentMediaTest.java
@@ -1,0 +1,45 @@
+package ai.mindconnect.chatui.ui.component;
+
+import ai.mindconnect.message.domain.ContentPart;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import org.junit.jupiter.api.Test;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A user message's media parts in its bubble: the image itself, a document by name. */
+class MessageComponentMediaTest {
+
+    private static final UUID SESSION = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+    private static MessageComponent component(Message m) {
+        return new MessageComponent(SESSION, null, m, true, DateTimeFormatter.ISO_INSTANT);
+    }
+
+    @Test
+    void anImagePartRendersAsThePictureFromTheChatsFileEndpoint() {
+        Message m = Message.of(UUID.randomUUID(), UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT,
+                List.of(new ContentPart.Text("what is this?"),
+                        new ContentPart.Image("f-1", "my [photo].png", "image/png", 3),
+                        new ContentPart.File("f-2", "spec.pdf", "application/pdf", 3)), 1);
+
+        String body = component(m).withAttachmentChip(m);
+
+        assertThat(body).startsWith("what is this?");
+        assertThat(body).contains("![my photo.png](/chat/api/sessions/" + SESSION + "/chat-files/f-1/content)");
+        assertThat(body).contains("📄 *spec.pdf*");
+    }
+
+    @Test
+    void aTextMessageIsItsTextAlone() {
+        Message m = Message.of(UUID.randomUUID(), UUID.randomUUID(), ParticipantType.USER, MessageType.CHAT,
+                "hello", 1);
+
+        assertThat(component(m).withAttachmentChip(m)).isEqualTo("hello");
+    }
+}

--- a/website/docs/agents/admin-ui/llm-configs.md
+++ b/website/docs/agents/admin-ui/llm-configs.md
@@ -20,6 +20,9 @@ A config has a `name`, `provider`, `model`, `baseUrl`, `apiKey`,
 settings. The form also covers:
 
 - **Type** — `Chat` or `Embedding` (embedding configs power the vector store);
+- **Capabilities** (chat configs) — what the model can take in and do: tool
+  calling, vision (images), documents (PDF), audio input. This is a
+  declaration for admins and callers, not something the runtime enforces;
 - **alias mode** — *Delegates To* forwards the config to another one by name;
 - **Temperature** and **Max Output Tokens**;
 - provider-specific extra parameters, rendered from the provider catalog;

--- a/website/docs/agents/admin-ui/llm-configs.md
+++ b/website/docs/agents/admin-ui/llm-configs.md
@@ -20,9 +20,12 @@ A config has a `name`, `provider`, `model`, `baseUrl`, `apiKey`,
 settings. The form also covers:
 
 - **Type** — `Chat` or `Embedding` (embedding configs power the vector store);
-- **Capabilities** (chat configs) — what the model can take in and do: tool
-  calling, vision (images), documents (PDF), audio input. This is a
-  declaration for admins and callers, not something the runtime enforces;
+- **Capabilities** (chat configs) — what the model reads and does: tool
+  calling, vision (images), documents (PDF), audio input. Vision and documents
+  steer the runtime: an image or PDF sent with a message reaches the model as
+  a picture or document when the config has the capability, as a placeholder
+  line when it does not. A config that has never declared any shows its
+  provider's default preselected; saving the form pins that set;
 - **alias mode** — *Delegates To* forwards the config to another one by name;
 - **Temperature** and **Max Output Tokens**;
 - provider-specific extra parameters, rendered from the provider catalog;

--- a/website/docs/agents/built-in-tools.md
+++ b/website/docs/agents/built-in-tools.md
@@ -39,6 +39,7 @@ Always available; no API keys required.
 | `run_agent` | Delegates a task to another agent by name — see [sub-agents](./sub-agents.md). | — |
 | `run_agents` | Fans several sub-agent calls out in parallel. | — |
 | `tool_search` | Lets the agent find and activate its *deferred* tools on demand. | The agent's `toolSearch` config |
+| `view_attachment` | Shows an attached image or PDF to the model again — as a message of its own in the running turn, since media goes with a message in its own turn only. Activated for a session when an image or PDF is attached; see [images and documents as message parts](./vector-store.md#images-and-documents-as-message-parts). | — |
 
 The file tools resolve paths against a **base directory**
 (`mindconnect.tools.base-dir`). It defaults to the **user home** — in the Admin

--- a/website/docs/agents/llm-config-json.md
+++ b/website/docs/agents/llm-config-json.md
@@ -25,6 +25,7 @@ The format of a file in
     "effort": "high"
   },
   "contextWindowTokens": 200000,
+  "capabilities": ["TOOL_CALLING", "VISION", "DOCUMENTS"],
   "rateLimit": {
     "maxConcurrentRequests": 3
   },
@@ -65,6 +66,7 @@ A minimal local config (no key needed):
 | `baseUrl` | string | API endpoint (override for proxies / local servers). |
 | `apiKey` | string | API key — almost always an env-var placeholder like `${ANTHROPIC_API_KEY}`. Literal keys are stored encrypted in the Admin UI (the CLI stores them as-is — use placeholders there). |
 | `type` | enum? | `CHAT` (default) or `EMBEDDING` — embedding configs power the vector store. |
+| `capabilities` | string[]? | What the model can take in and do: any of `TOOL_CALLING`, `VISION` (images), `DOCUMENTS` (PDF), `AUDIO_INPUT`. Informative — declared here, shown in the Admin UI, readable by callers via `LlmConfig.supports(...)`; the runtime does not derive its behaviour from it. Omitted means none declared. Chat configs only. |
 | `defaultTemperature` | number | Sampling temperature (e.g. `0.7`). |
 | `maxOutputTokens` | int | Max tokens the model may generate per response. |
 | `contextWindowTokens` | int | Token budget used to size the working-memory window. |

--- a/website/docs/agents/llm-config-json.md
+++ b/website/docs/agents/llm-config-json.md
@@ -66,7 +66,7 @@ A minimal local config (no key needed):
 | `baseUrl` | string | API endpoint (override for proxies / local servers). |
 | `apiKey` | string | API key — almost always an env-var placeholder like `${ANTHROPIC_API_KEY}`. Literal keys are stored encrypted in the Admin UI (the CLI stores them as-is — use placeholders there). |
 | `type` | enum? | `CHAT` (default) or `EMBEDDING` — embedding configs power the vector store. |
-| `capabilities` | string[]? | What the model can take in and do: any of `TOOL_CALLING`, `VISION` (images), `DOCUMENTS` (PDF), `AUDIO_INPUT`. Informative — declared here, shown in the Admin UI, readable by callers via `LlmConfig.supports(...)`; the runtime does not derive its behaviour from it. Omitted means none declared. Chat configs only. |
+| `capabilities` | string[]? | What the model reads and does: any of `TOOL_CALLING`, `VISION` (images), `DOCUMENTS` (PDF), `AUDIO_INPUT`. `VISION` and `DOCUMENTS` decide whether an image or PDF sent with a message reaches the model as content or as a placeholder line. **Omitted means not declared** — the provider's default applies (Anthropic and OpenAI: tool calling, vision, documents; Gemini: those plus audio; Azure OpenAI: tool calling, vision; local servers and routers: tool calling only). A declared list, `[]` included, always wins over that default. Chat configs only. |
 | `defaultTemperature` | number | Sampling temperature (e.g. `0.7`). |
 | `maxOutputTokens` | int | Max tokens the model may generate per response. |
 | `contextWindowTokens` | int | Token budget used to size the working-memory window. |

--- a/website/docs/agents/llm-configs-reference.md
+++ b/website/docs/agents/llm-configs-reference.md
@@ -48,6 +48,7 @@ no API key required — as long as LM Studio is serving a model on
   "baseUrl": "https://api.anthropic.com",
   "apiKey": "${ANTHROPIC_API_KEY}",
   "contextWindowTokens": 200000,
+  "capabilities": ["TOOL_CALLING", "VISION", "DOCUMENTS"],
   "additionalParams": {
     "thinking": "adaptive",
     "effort": "high"
@@ -69,6 +70,7 @@ no API key required — as long as LM Studio is serving a model on
 | `baseUrl` | API endpoint (override for proxies / local servers) |
 | `apiKey` | API key, usually injected from an env var |
 | `contextWindowTokens` | Token budget used to size the working-memory window |
+| `capabilities` | What the model can take in and do — `TOOL_CALLING`, `VISION`, `DOCUMENTS`, `AUDIO_INPUT`. Informative, not enforced |
 | `additionalParams` | Provider-specific options (e.g. Anthropic `thinking` / `effort`) |
 | `rateLimit` | Optional — cap concurrent requests |
 | `retry` | Optional — automatic retry with backoff |

--- a/website/docs/agents/llm-configs-reference.md
+++ b/website/docs/agents/llm-configs-reference.md
@@ -70,7 +70,7 @@ no API key required — as long as LM Studio is serving a model on
 | `baseUrl` | API endpoint (override for proxies / local servers) |
 | `apiKey` | API key, usually injected from an env var |
 | `contextWindowTokens` | Token budget used to size the working-memory window |
-| `capabilities` | What the model can take in and do — `TOOL_CALLING`, `VISION`, `DOCUMENTS`, `AUDIO_INPUT`. Informative, not enforced |
+| `capabilities` | What the model reads and does — `TOOL_CALLING`, `VISION`, `DOCUMENTS`, `AUDIO_INPUT`. Vision and documents decide whether an image or PDF reaches the model as content or as a placeholder. Omitted: the provider's default applies |
 | `additionalParams` | Provider-specific options (e.g. Anthropic `thinking` / `effort`) |
 | `rateLimit` | Optional — cap concurrent requests |
 | `retry` | Optional — automatic retry with backoff |

--- a/website/docs/agents/memory.md
+++ b/website/docs/agents/memory.md
@@ -173,8 +173,15 @@ the default. It maps user and assistant text, tool calls and tool results,
 and renders what a message's metadata means for the model — a user message
 that announced attachments gets the attachment notice ahead of its text
 (see [Vector store](./vector-store.md#how-the-agent-learns-about-an-attachment)).
-The working-memory view in the Admin UI shows the same text and token counts
-the model receives.
+It also renders a message's media parts: an image or document travels as
+the provider's content block when the target model declares it reads that
+kind (`LlmConfig.capabilities`) and the message belongs to the current
+turn, as a placeholder line otherwise (see
+[images and documents as message parts](./vector-store.md#images-and-documents-as-message-parts)).
+The bytes come through the `PartContentReader` port — the host's file
+store. The working-memory view in the Admin UI shows the same text and
+token counts the model receives, with each media part named on a line of
+its own.
 
 It is the read-side extension point, and deliberately the only one: there
 is no per-message-type hook, the mapper sees them all. A Spring host

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -43,6 +43,23 @@ curl -N -X POST http://localhost:8080/api/sessions/$SESSION/chat \
      -H 'Content-Type: text/plain' -d 'Which of our tools can read files?'
 ```
 
+To send an image or a document with the message, upload it first
+(`POST /api/files`, multipart `file`) and reference it by id in a JSON body
+— `kind` is `image` or `file`; the file's name, type and size come from the
+store:
+
+```bash
+curl -N -X POST http://localhost:8080/api/sessions/$SESSION/chat \
+     -H 'Content-Type: application/json' \
+     -d '{"message": "What is in this picture?",
+          "parts": [{"kind": "image", "fileId": "'$FILE_ID'"}]}'
+```
+
+A vision model sees the picture with the question; a model that does not
+read images gets a placeholder line instead (see
+[images and documents as message parts](./vector-store.md#images-and-documents-as-message-parts)).
+An unknown `fileId` or `kind` is a 400.
+
 Each event is one JSON frame with a `type`:
 
 | type | carries |
@@ -147,4 +164,9 @@ See [working memory](./memory.md) for what the strategies do.
 
 The same server exposes LLM configurations, the file store, session
 attachments and the vector stores under `/api` as well. Those follow plain
-CRUD shapes and are best read in the Swagger UI.
+CRUD shapes and are best read in the Swagger UI. One shape worth knowing:
+`GET /api/sessions/{id}/files` lists the attached files with `fileId`,
+`name`, `mediaType`, `sizeBytes` and `chunks` — the searchable chunks an
+ingested file produced, 0 for an image, which goes to the model with the
+next message instead. `DELETE …/files?file=` takes the file's name or its
+ingested id.

--- a/website/docs/agents/vector-store.md
+++ b/website/docs/agents/vector-store.md
@@ -126,7 +126,8 @@ An image or PDF attached to the chat becomes a part of the user's next
 message, so a model that reads it sees the picture with the question:
 
 - The model's `LlmConfig` says what it reads — `capabilities` with `VISION`
-  for images, `DOCUMENTS` for PDFs (see the
+  for images, `DOCUMENTS` for PDFs, or the provider's default when the config
+  declares nothing (see the
   [LLM config reference](./llm-configs-reference.md)). A part the model
   reads travels inline, as the provider's content block; otherwise a
   placeholder line stands in for it — what the file is, and why it is not

--- a/website/docs/agents/vector-store.md
+++ b/website/docs/agents/vector-store.md
@@ -132,7 +132,16 @@ message, so a model that reads it sees the picture with the question:
   reads travels inline, as the provider's content block; otherwise a
   placeholder line stands in for it — what the file is, and why it is not
   here. A PDF a model does not read still reaches it through
-  `vector_search`, the placeholder says so.
+  `vector_search`, the placeholder says so. One caveat on OpenAI-compatible
+  servers: the `file` content block is OpenAI's own (OpenRouter and Azure
+  take it too); on LM Studio, Ollama, Groq, Mistral and the like a config
+  that declares `DOCUMENTS` gets the document as a text note, images as
+  usual.
+- The working-memory budget counts media at an estimate — 1,600 tokens per
+  image, one token per 100 bytes of a document, at least 1,000 — since
+  there is no text to count. The LLM call trace records the request with
+  the base64 payloads replaced by a note (media type and length), so the
+  trace store does not grow by the size of every attachment.
 - Media goes with the message **in the current turn only**. A request
   repeats the whole history, and an image repeated in every request costs
   its tokens every time. From the next turn on the placeholder names the

--- a/website/docs/agents/vector-store.md
+++ b/website/docs/agents/vector-store.md
@@ -94,8 +94,12 @@ scenarios (see `mc-agent-simple-demo`).
 ### How the agent learns about an attachment
 
 A file attached to a chat is ingested into the session's vector store and
-`vector_search` is activated for the session. The model is told twice, in
-two different places:
+`vector_search` is activated for the session — with two exceptions that
+reach the model directly instead (see
+[images and documents](#images-and-documents-as-message-parts) below): an
+**image** is not ingested at all, a **PDF** is ingested *and* sent with the
+next message. For everything else the model is told twice, in two different
+places:
 
 - **In the user's next message.** That message records the newly attached
   files in its metadata; when the request is built, the model reads a short
@@ -113,6 +117,35 @@ message — the record is read in order, so a file attached again after a
 removal is announced again, and an attach notice names only files that are
 still attached. All of this is rendered by the `LlmMessageMapper`
 (see [Memory](./memory.md#how-messages-reach-the-model)).
+
+### Images and documents as message parts
+
+A message is made of **content parts** — its text, plus the images and
+files sent with it, referenced by the id the file store holds them under.
+An image or PDF attached to the chat becomes a part of the user's next
+message, so a model that reads it sees the picture with the question:
+
+- The model's `LlmConfig` says what it reads — `capabilities` with `VISION`
+  for images, `DOCUMENTS` for PDFs (see the
+  [LLM config reference](./llm-configs-reference.md)). A part the model
+  reads travels inline, as the provider's content block; otherwise a
+  placeholder line stands in for it — what the file is, and why it is not
+  here. A PDF a model does not read still reaches it through
+  `vector_search`, the placeholder says so.
+- Media goes with the message **in the current turn only**. A request
+  repeats the whole history, and an image repeated in every request costs
+  its tokens every time. From the next turn on the placeholder names the
+  file and the agent asks for it again with the `view_attachment` tool,
+  which inserts the image or document as a message of its own into the
+  running turn. The tool is activated for a session when an image or PDF is
+  attached; the chat shows the re-shown attachment as such.
+- The chat bubble shows the image; the REST API accepts parts in the JSON
+  chat body, the protocol bridge accepts `Image` and `Document` parts, and
+  `AgentRuntime.chat(sessionId, parts, …)` takes them in an embedding.
+
+Images are not named in the attachment notice or the system-prompt
+section — they are not indexed, and the part (or its placeholder) speaks
+for itself.
 
 ## Configuration
 


### PR DESCRIPTION
## What does this PR do?

Images and PDFs reach the model. Until now an uploaded file was ingested into
the session's vector store and the model only ever saw text about it; an image
was read as UTF-8 and either broke the ingestion workflow or produced garbage
chunks. This PR makes a message a list of **content parts** and carries an
image or PDF through every layer to the provider's native content block, while
keeping every other model working with a placeholder line.

**LLM config capabilities** (`mc-llm-gateway-core`)
- `LlmConfig.capabilities`: a declared set of `TOOL_CALLING`, `VISION`,
  `DOCUMENTS`, `AUDIO_INPUT`. `null` means "not declared" and reads as the
  provider's default (Anthropic / OpenAI: tools, vision, documents; Gemini also
  audio; Azure OpenAI: tools, vision; local servers and routers: tools only).
  A declared set wins, the empty set included.
- Admin UI form has a multiselect, the detail view shows the set, the bundled
  `initial-data` configs declare it. Configs persisted before this field load
  as not declared.

**Content parts on the domain message** (`mc-message-repository-core`)
- `ContentPart` (sealed: `Text`, `Image`, `File` with file-store id, name,
  media type, size) and `Message.parts`; older records read as text without a
  migration in the file store and Postgres.
- `ConversationHistory.opensTurn` / `currentTurnMessages` define the turn a
  message belongs to; a user message carrying the open turn's id continues it.

**Content blocks on the gateway message** (`mc-llm-gateway`)
- `LlmMessage` is made of `LlmContent` blocks (`Text`, `Image`, `Document`
  as base64); `content()` stays as the text convenience. The OpenAI, Anthropic
  and Gemini gateways render content arrays for user messages that carry media.

**The mapper decides by capability** (`mc-agent-runtime-core`)
- `LlmMessageMapper.toMessages` takes the target `LlmConfig`. A media part is
  sent inline when the config supports it, the message is in the current turn
  and the file is under 20 MB; otherwise a placeholder line says what the file
  is and why it is not there. Media is sent in its own turn only; afterwards
  the new `view_attachment` tool shows the file again as a user message of its
  own, so the model never has to re-read a whole history of images.
- `PartContentReader` port, implemented over the file store in
  `mc-agent-runtime`.

**Ingress** (`mc-agent-api-rest`, `mc-agent-chat-ui-rest`, protocol bridge,
builder)
- A session's `attachedFiles` become records (id, name, media type, size).
  Images skip ingestion; PDFs are ingested and sent as a part.
- `POST /api/sessions/{id}/chat` takes a JSON body `{message, parts}` beside
  the plain-text one; `GET /api/sessions/{id}/files` lists id, media type,
  size and chunk count; `DELETE …/files?file=` takes name or ingested id.
- The chat shows the image as a thumbnail that opens the original, a reshown
  attachment as one muted line, and uses sprite icons instead of emoji.
- The protocol bridge accepts `Image` parts; `AgentRuntime.chat(sessionId,
  parts, …)` takes parts in an embedding.

Breaking for hosts with their own `LlmMessageMapper`: the fifth
`LlmConfig` argument. See `CHANGELOG.md` for the user-facing list.

## Affected area

agent runtime · docs

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [x] I added/updated tests where it makes sense.
- [x] I updated docs/README if behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

## Related issues

—

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185b7vo7w9JQeENNZNupPwD

---
_Generated by [Claude Code](https://claude.ai/code/session_0185b7vo7w9JQeENNZNupPwD)_