### PR TITLE
Uploads: JPEG from Windows, size limits, and a message instead of a bare 413

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **agents:** the Admin UI and the agent server take uploads of 25 MB per
+  file and 100 MB per request (`MC_UPLOAD_MAX_FILE_SIZE`,
+  `MC_UPLOAD_MAX_REQUEST_SIZE`). Before, Spring's defaults applied — 1 MB
+  per file, 10 MB per request — and a phone photo, or a few files attached
+  at once, was answered with HTTP 413. An upload above the limits now says
+  so: the chat and the vector-store upload show a toast naming both limits
+  in place of the client's "The request failed (HTTP 413)", the REST API
+  answers 413 with a JSON body (`error`, `maxFileSize`, `maxRequestSize`).
+- **agents:** a `.jpg` uploaded from Windows reaches the model. The browser
+  there reports the file as `image/jpg` or `image/pjpeg`, which Anthropic and
+  OpenAI reject; the media type is folded onto `image/jpeg` (likewise
+  `image/x-png`, `application/x-pdf`, and a trailing charset parameter)
+  before it goes into a message part or a content block.
+
 ## [0.5.0] - 2026-09-07
 
 ### Added
@@ -83,16 +99,6 @@ fresh empty one, so nothing has to be moved by hand at release time.
   OpenAI's `file` content block (LM Studio, Ollama, Groq, Mistral, …) gets
   the document as a text note instead of a 400 from the endpoint; images
   reach every OpenAI-compatible endpoint as before.
-- **agents:** the Admin UI and the agent server take uploads of 25 MB per
-  file and 100 MB per request (`MC_UPLOAD_MAX_FILE_SIZE`,
-  `MC_UPLOAD_MAX_REQUEST_SIZE`). Before, Spring's defaults applied — 1 MB
-  per file, 10 MB per request — and a phone photo, or a few files attached
-  at once, was answered with HTTP 413.
-- **agents:** a `.jpg` uploaded from Windows reaches the model. The browser
-  there reports the file as `image/jpg` or `image/pjpeg`, which Anthropic and
-  OpenAI reject; the media type is folded onto `image/jpeg` (likewise
-  `image/x-png`, `application/x-pdf`, and a trailing charset parameter)
-  before it goes into a message part or a content block.
 - **agents:** an image sent through the protocol bridge
   (`ContentPart.Image` on `AgentRuntimeBackend`) is recorded on the session
   like an upload, so `view_attachment` is activated and the model can ask

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
   OpenAI's `file` content block (LM Studio, Ollama, Groq, Mistral, …) gets
   the document as a text note instead of a 400 from the endpoint; images
   reach every OpenAI-compatible endpoint as before.
+- **agents:** the Admin UI and the agent server take uploads of 25 MB per
+  file and 100 MB per request (`MC_UPLOAD_MAX_FILE_SIZE`,
+  `MC_UPLOAD_MAX_REQUEST_SIZE`). Before, Spring's defaults applied — 1 MB
+  per file, 10 MB per request — and a phone photo, or a few files attached
+  at once, was answered with HTTP 413.
 - **agents:** a `.jpg` uploaded from Windows reaches the model. The browser
   there reports the file as `image/jpg` or `image/pjpeg`, which Anthropic and
   OpenAI reject; the media type is folded onto `image/jpeg` (likewise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
   OpenAI's `file` content block (LM Studio, Ollama, Groq, Mistral, …) gets
   the document as a text note instead of a 400 from the endpoint; images
   reach every OpenAI-compatible endpoint as before.
+- **agents:** a `.jpg` uploaded from Windows reaches the model. The browser
+  there reports the file as `image/jpg` or `image/pjpeg`, which Anthropic and
+  OpenAI reject; the media type is folded onto `image/jpeg` (likewise
+  `image/x-png`, `application/x-pdf`, and a trailing charset parameter)
+  before it goes into a message part or a content block.
 - **agents:** an image sent through the protocol bridge
   (`ContentPart.Image` on `AgentRuntimeBackend`) is recorded on the session
   like an upload, so `view_attachment` is activated and the model can ask

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AttachedFile.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/AttachedFile.java
@@ -67,7 +67,7 @@ public record AttachedFile(
      */
     @JsonIgnore
     public String effectiveMediaType() {
-        if (hasSpecificMediaType()) return mediaType;
+        if (hasSpecificMediaType()) return MediaTypes.normalize(mediaType);
         return switch (extension()) {
             case "png" -> "image/png";
             case "jpg", "jpeg" -> "image/jpeg";

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/MediaTypes.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/domain/MediaTypes.java
@@ -1,0 +1,37 @@
+package ai.mindconnect.agent.domain;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * The media type as a provider wants to see it. Uploads carry whatever the
+ * browser or tool reported: Windows registers {@code .jpg} as
+ * {@code image/jpg} or {@code image/pjpeg} on some machines, old tooling
+ * says {@code image/x-png} or {@code application/x-pdf}, and a charset
+ * parameter may trail. Anthropic and OpenAI reject all of those with a 400
+ * — {@code image/jpeg} is the one JPEG type they take — so every media type
+ * that reaches a message part or a content block passes through here.
+ */
+public final class MediaTypes {
+
+    private static final Map<String, String> ALIASES = Map.of(
+            "image/jpg", "image/jpeg",
+            "image/pjpeg", "image/jpeg",
+            "image/x-png", "image/png",
+            "application/x-pdf", "application/pdf");
+
+    private MediaTypes() {
+    }
+
+    /**
+     * Lower-cased, without parameters, with the known aliases folded onto
+     * the canonical type; {@code null} and blank stay as they are.
+     */
+    public static String normalize(String mediaType) {
+        if (mediaType == null || mediaType.isBlank()) return mediaType;
+        String type = mediaType.trim().toLowerCase(Locale.ROOT);
+        int semicolon = type.indexOf(';');
+        if (semicolon >= 0) type = type.substring(0, semicolon).trim();
+        return ALIASES.getOrDefault(type, type);
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/MessageToLlmMessageMapper.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/MessageToLlmMessageMapper.java
@@ -3,6 +3,7 @@ package ai.mindconnect.agent.service;
 import ai.mindconnect.agent.tool.Tool;
 import ai.mindconnect.agent.domain.AgentDefinition;
 import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.MediaTypes;
 import ai.mindconnect.agent.port.out.PartContentReader;
 import ai.mindconnect.agent.service.prompt.AttachmentNotice;
 import ai.mindconnect.agent.service.ContextTokenBudget;
@@ -212,7 +213,8 @@ public class MessageToLlmMessageMapper implements ai.mindconnect.agent.port.out.
             return null;
         }
         String base64 = Base64.getEncoder().encodeToString(content.bytes());
-        String mediaType = part.mediaType() != null ? part.mediaType() : content.mediaType();
+        String mediaType = MediaTypes.normalize(
+                part.mediaType() != null ? part.mediaType() : content.mediaType());
         return part instanceof ContentPart.Image
                 ? new LlmContent.Image(base64, mediaType)
                 : new LlmContent.Document(base64, mediaType, part.name());

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AttachedFileTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/AttachedFileTest.java
@@ -42,6 +42,15 @@ class AttachedFileTest {
     }
 
     @Test
+    void aWindowsJpgUploadIsSentAsImageJpeg() {
+        // Windows reports .jpg as image/jpg or image/pjpeg; the providers take image/jpeg only.
+        AttachedFile jpg = new AttachedFile("f", "IMG_0001.jpg", "image/jpg", 1);
+        assertThat(jpg.isImage()).isTrue();
+        assertThat(jpg.effectiveMediaType()).isEqualTo("image/jpeg");
+        assertThat(new AttachedFile("f", "scan.jpg", "image/pjpeg", 1).effectiveMediaType()).isEqualTo("image/jpeg");
+    }
+
+    @Test
     void onlyAFileWithAnIdAndAReadableKindIsSendableAsAPart() {
         assertThat(new AttachedFile("f", "photo.png", "image/png", 1).sendableAsPart()).isTrue();
         assertThat(new AttachedFile("f", "spec.pdf", "application/pdf", 1).sendableAsPart()).isTrue();

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/MediaTypesTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/domain/MediaTypesTest.java
@@ -1,0 +1,37 @@
+package ai.mindconnect.agent.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What an upload's media type becomes before a provider sees it: the one
+ * spelling the provider takes. A Windows browser reports a {@code .jpg} as
+ * {@code image/jpg} or {@code image/pjpeg}, and Anthropic answers that
+ * with a 400.
+ */
+class MediaTypesTest {
+
+    @Test
+    void theJpegAliasesFoldOntoImageJpeg() {
+        assertThat(MediaTypes.normalize("image/jpg")).isEqualTo("image/jpeg");
+        assertThat(MediaTypes.normalize("image/pjpeg")).isEqualTo("image/jpeg");
+        assertThat(MediaTypes.normalize("image/jpeg")).isEqualTo("image/jpeg");
+    }
+
+    @Test
+    void otherAliasesCaseAndParametersAreNormalisedToo() {
+        assertThat(MediaTypes.normalize("image/x-png")).isEqualTo("image/png");
+        assertThat(MediaTypes.normalize("application/x-pdf")).isEqualTo("application/pdf");
+        assertThat(MediaTypes.normalize("Image/PNG")).isEqualTo("image/png");
+        assertThat(MediaTypes.normalize("text/plain; charset=UTF-8")).isEqualTo("text/plain");
+        assertThat(MediaTypes.normalize(" image/webp ")).isEqualTo("image/webp");
+    }
+
+    @Test
+    void unknownTypesPassAndNothingStaysNothing() {
+        assertThat(MediaTypes.normalize("application/octet-stream")).isEqualTo("application/octet-stream");
+        assertThat(MediaTypes.normalize(null)).isNull();
+        assertThat(MediaTypes.normalize("")).isEmpty();
+    }
+}

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
@@ -53,6 +53,13 @@ spring:
   web:
     resources:
       static-locations: classpath:/static/
+  servlet:
+    multipart:
+      # Chat and vector-store uploads. Spring's defaults (1MB per file, 10MB
+      # per request) answer a phone photo, or three of them, with HTTP 413.
+      # The runtime sends a file inline to the model up to 20MB.
+      max-file-size: ${MC_UPLOAD_MAX_FILE_SIZE:25MB}
+      max-request-size: ${MC_UPLOAD_MAX_REQUEST_SIZE:100MB}
 
 springdoc:
   # The admin shell's API section embeds this Swagger UI. Scope it to the

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
@@ -1,5 +1,10 @@
 server:
   port: 9090
+  tomcat:
+    # How much of a rejected upload Tomcat still reads before answering.
+    # Below the request limit the browser sees the "upload too large" toast;
+    # a bigger body has its connection closed and shows as a network error.
+    max-swallow-size: ${MC_UPLOAD_MAX_REQUEST_SIZE:100MB}
 
 logging:
   pattern:

--- a/agents/server/mc-agent-api-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-api-app/src/main/resources/application.yaml
@@ -1,6 +1,14 @@
 spring:
   application:
     name: mc-agent-api-app
+  servlet:
+    multipart:
+      # File uploads (POST /api/files, /api/sessions/{id}/files). Spring's
+      # defaults (1MB per file, 10MB per request) answer a phone photo, or
+      # three of them, with HTTP 413. The runtime sends a file inline to the
+      # model up to 20MB.
+      max-file-size: ${MC_UPLOAD_MAX_FILE_SIZE:25MB}
+      max-request-size: ${MC_UPLOAD_MAX_REQUEST_SIZE:100MB}
 
 server:
   port: 8080

--- a/agents/server/mc-agent-api-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-api-app/src/main/resources/application.yaml
@@ -12,6 +12,11 @@ spring:
 
 server:
   port: 8080
+  tomcat:
+    # How much of a rejected upload Tomcat still reads before answering.
+    # Below the request limit the client gets the 413 with its body; a
+    # bigger body has its connection closed.
+    max-swallow-size: ${MC_UPLOAD_MAX_REQUEST_SIZE:100MB}
 
 mindconnect:
   # Where everything is stored: "file" under data.base-dir (default), or

--- a/agents/server/mc-agent-api-rest/pom.xml
+++ b/agents/server/mc-agent-api-rest/pom.xml
@@ -67,6 +67,11 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/UploadLimitAdvice.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/UploadLimitAdvice.java
@@ -1,0 +1,62 @@
+package ai.mindconnect.agentrest.controller;
+
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.Map;
+
+/**
+ * What an upload above the multipart limits gets instead of a bare 413.
+ * Spring throws {@link MaxUploadSizeExceededException} while it parses the
+ * request, before any controller is chosen, so only a global advice can
+ * answer it; this one keeps the 413 and adds a body that says what the
+ * limits are — {@code spring.servlet.multipart.max-file-size} and
+ * {@code max-request-size}, {@code MC_UPLOAD_MAX_FILE_SIZE} and
+ * {@code MC_UPLOAD_MAX_REQUEST_SIZE} in the apps.
+ *
+ * <p>Lowest precedence: a UI module on the same classpath (the chat UI)
+ * registers an advice of its own that turns the same exception into a
+ * toast for the UI routes and delegates here for the API ones.
+ */
+@RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class UploadLimitAdvice {
+
+    private final MultipartProperties multipart;
+
+    public UploadLimitAdvice(MultipartProperties multipart) {
+        this.multipart = multipart;
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, Object>> tooLarge(MaxUploadSizeExceededException e) {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(Map.of(
+                "error", message(multipart),
+                "maxFileSize", human(multipart.getMaxFileSize()),
+                "maxRequestSize", human(multipart.getMaxRequestSize())));
+    }
+
+    /** The one sentence a person needs: the two limits, and what to do about them. */
+    public static String message(MultipartProperties multipart) {
+        return "Upload too large — at most " + human(multipart.getMaxFileSize()) + " per file and "
+                + human(multipart.getMaxRequestSize()) + " per upload. Attach fewer files at once, or smaller ones.";
+    }
+
+    static String human(DataSize size) {
+        if (size == null || size.isNegative()) return "unlimited";
+        long bytes = size.toBytes();
+        if (bytes >= DataSize.ofGigabytes(1).toBytes() && bytes % DataSize.ofGigabytes(1).toBytes() == 0) {
+            return size.toGigabytes() + " GB";
+        }
+        if (bytes >= DataSize.ofMegabytes(1).toBytes()) return size.toMegabytes() + " MB";
+        if (bytes >= DataSize.ofKilobytes(1).toBytes()) return size.toKilobytes() + " KB";
+        return bytes + " bytes";
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/UploadLimitAdviceTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/UploadLimitAdviceTest.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.agentrest.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A 413 that says what the limits are, in the units a person reads. */
+class UploadLimitAdviceTest {
+
+    private static MultipartProperties limits(DataSize file, DataSize request) {
+        var props = new MultipartProperties();
+        props.setMaxFileSize(file);
+        props.setMaxRequestSize(request);
+        return props;
+    }
+
+    @Test
+    void theBodyNamesBothLimits() {
+        var advice = new UploadLimitAdvice(limits(DataSize.ofMegabytes(25), DataSize.ofMegabytes(100)));
+
+        ResponseEntity<Map<String, Object>> response = advice.tooLarge(new MaxUploadSizeExceededException(-1));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+        assertThat(response.getBody())
+                .containsEntry("maxFileSize", "25 MB")
+                .containsEntry("maxRequestSize", "100 MB");
+        assertThat((String) response.getBody().get("error"))
+                .isEqualTo("Upload too large — at most 25 MB per file and 100 MB per upload. "
+                        + "Attach fewer files at once, or smaller ones.");
+    }
+
+    @Test
+    void sizesReadAsPeopleWriteThem() {
+        assertThat(UploadLimitAdvice.human(DataSize.ofKilobytes(512))).isEqualTo("512 KB");
+        assertThat(UploadLimitAdvice.human(DataSize.ofMegabytes(1))).isEqualTo("1 MB");
+        assertThat(UploadLimitAdvice.human(DataSize.ofMegabytes(1536))).isEqualTo("1536 MB");
+        assertThat(UploadLimitAdvice.human(DataSize.ofGigabytes(2))).isEqualTo("2 GB");
+        assertThat(UploadLimitAdvice.human(DataSize.ofBytes(-1))).isEqualTo("unlimited");
+        assertThat(UploadLimitAdvice.human(null)).isEqualTo("unlimited");
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/pom.xml
+++ b/agents/server/mc-agent-chat-ui-rest/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/UploadLimitUiAdvice.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/UploadLimitUiAdvice.java
@@ -1,0 +1,55 @@
+package ai.mindconnect.chatui.ui.controller;
+
+import ai.mindconnect.agentrest.controller.UploadLimitAdvice;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiToast;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+/**
+ * An upload above the multipart limits, as the UI shows it: a toast that
+ * names the limits, in place of the client's generic "The request failed
+ * (HTTP 413)". The semantic-ui client applies a {@link UiPatch} only from a
+ * 2xx response and ignores the body of any other, so the UI routes answer
+ * 200 with the toast; the API routes ({@code /api/**}) keep their 413 with
+ * the JSON body of {@link UploadLimitAdvice}.
+ *
+ * <p>Highest precedence, so on a classpath that carries both advices this
+ * one is asked first — the exception is thrown before any controller is
+ * chosen, and a package-restricted advice would not apply to it.
+ */
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class UploadLimitUiAdvice {
+
+    private final MultipartProperties multipart;
+    private final UploadLimitAdvice api;
+
+    public UploadLimitUiAdvice(MultipartProperties multipart, UploadLimitAdvice api) {
+        this.multipart = multipart;
+        this.api = api;
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<?> tooLarge(MaxUploadSizeExceededException e, HttpServletRequest request) {
+        if (isApiRoute(request)) return api.tooLarge(e);
+        return ResponseEntity.ok(UiPatch.of().toast(
+                UiToast.error(UploadLimitAdvice.message(multipart)).title("Upload failed").sticky()));
+    }
+
+    /** The REST API lives under {@code /api/}; everything else on the classpath is a UI route. */
+    static boolean isApiRoute(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String context = request.getContextPath();
+        if (context != null && !context.isEmpty() && path.startsWith(context)) {
+            path = path.substring(context.length());
+        }
+        return path.startsWith("/api/");
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/controller/UploadLimitUiAdviceTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/controller/UploadLimitUiAdviceTest.java
@@ -1,0 +1,72 @@
+package ai.mindconnect.chatui.ui.controller;
+
+import ai.mindconnect.agentrest.controller.UploadLimitAdvice;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiToast;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The same too-large upload, answered by route: a toast the UI client can
+ * show (it only applies a patch from a 2xx), a 413 with a body for the API.
+ */
+class UploadLimitUiAdviceTest {
+
+    private final MultipartProperties limits = limits();
+    private final UploadLimitUiAdvice advice = new UploadLimitUiAdvice(limits, new UploadLimitAdvice(limits));
+    private final MaxUploadSizeExceededException tooLarge = new MaxUploadSizeExceededException(-1);
+
+    private static MultipartProperties limits() {
+        var props = new MultipartProperties();
+        props.setMaxFileSize(DataSize.ofMegabytes(25));
+        props.setMaxRequestSize(DataSize.ofMegabytes(100));
+        return props;
+    }
+
+    @Test
+    void aUiUploadGetsAToastOnA200() {
+        var request = new MockHttpServletRequest("POST", "/chat/api/sessions/s-1/chat-files");
+
+        ResponseEntity<?> response = advice.tooLarge(tooLarge, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        UiPatch patch = (UiPatch) response.getBody();
+        assertThat(patch.getToasts()).hasSize(1);
+        UiToast toast = patch.getToasts().get(0);
+        assertThat(toast.getLevel()).isEqualTo(UiToast.Level.ERROR);
+        assertThat(toast.getTitle()).isEqualTo("Upload failed");
+        assertThat(toast.getMessage()).startsWith("Upload too large — at most 25 MB per file and 100 MB per upload.");
+    }
+
+    @Test
+    void anApiUploadKeepsThe413WithTheJsonBody() {
+        var request = new MockHttpServletRequest("POST", "/api/sessions/s-1/files");
+
+        ResponseEntity<?> response = advice.tooLarge(tooLarge, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertThat(body).containsEntry("maxFileSize", "25 MB");
+    }
+
+    @Test
+    void theApiIsRecognisedBehindAContextPath() {
+        var request = new MockHttpServletRequest("POST", "/mc/api/files");
+        request.setContextPath("/mc");
+        assertThat(UploadLimitUiAdvice.isApiRoute(request)).isTrue();
+
+        var ui = new MockHttpServletRequest("POST", "/mc/admin/vector-stores/x/upload");
+        ui.setContextPath("/mc");
+        assertThat(UploadLimitUiAdvice.isApiRoute(ui)).isFalse();
+    }
+}

--- a/website/docs/agents/environment-variables.md
+++ b/website/docs/agents/environment-variables.md
@@ -25,6 +25,7 @@ export TAVILY_API_KEY=tvly-...
 | `MC_PERSISTENCE` | `file` | `file` keeps everything under `mindconnect.data.base-dir`; `postgres` keeps it in the database — see [Persistence](./persistence.md#postgres). Since 0.3.0. |
 | `MC_POSTGRES_URL` | `jdbc:postgresql://localhost:5432/mindconnect` | JDBC URL, used with `MC_PERSISTENCE=postgres`. Tables are created on start. |
 | `MC_POSTGRES_USER` / `MC_POSTGRES_PASSWORD` | _(empty)_ | Database credentials. |
+| `MC_UPLOAD_MAX_FILE_SIZE` / `MC_UPLOAD_MAX_REQUEST_SIZE` | `25MB` / `100MB` | Upload limits — one file, and all files of one upload request (the chat's attach dialog sends every selected file in one request). Bound to `spring.servlet.multipart.max-file-size` / `max-request-size`; an upload above either is answered with HTTP 413. The runtime sends a file inline to the model up to 20MB. |
 
 ## Runtime configuration (Spring properties)
 


### PR DESCRIPTION
## What does this PR do?

Three follow-ups to the content-parts work (#43), found while attaching
files in the Admin UI.

**A `.jpg` from Windows reaches the model** (`mc-agent-runtime-core`)
- Windows registers `.jpg` as `image/jpg` or `image/pjpeg` on some machines
  and the browser reports that on upload. The file counted as an image, but
  the part carried the alias, and Anthropic and OpenAI answer it with a 400
  (`image/jpeg` is the one JPEG type they take).
- `MediaTypes.normalize` folds the known aliases (also `image/x-png`,
  `application/x-pdf`), lower-cases the type and drops a trailing parameter;
  `AttachedFile.effectiveMediaType` and the mapper's content blocks go
  through it.

**Upload limits** (`mc-agent-admin-ui-app`, `mc-agent-api-app`)
- Neither app set a multipart limit, so Spring's defaults applied: 1 MB per
  file, 10 MB per request. A phone photo, or a few files attached in one go
  (the chat's attach dialog sends every selected file in one request), came
  back as HTTP 413.
- Both apps now allow 25 MB per file and 100 MB per request, overridable
  through `MC_UPLOAD_MAX_FILE_SIZE` and `MC_UPLOAD_MAX_REQUEST_SIZE`; the
  per-file limit sits above the 20 MB the runtime sends inline to a model.
  Tomcat's `max-swallow-size` follows the request limit so a rejected
  upload still gets its answer instead of a closed connection.

**An upload above the limits says so** (`mc-agent-api-rest`,
`mc-agent-chat-ui-rest`)
- Spring throws `MaxUploadSizeExceededException` while parsing the request,
  before a controller is chosen, and the semantic-ui client turns any
  non-2xx into "The request failed (HTTP 413)" without reading the body.
- Two global advices answer the exception: the chat UI's returns 200 with an
  error toast naming both limits (chat and vector-store upload alike), the
  REST API's keeps the 413 and adds a JSON body (`error`, `maxFileSize`,
  `maxRequestSize`). Highest / lowest precedence, so the UI advice wins
  where both are on the classpath and the API advice serves the agent
  server alone.

Verified against the running Admin UI app: a 30 MB file and three files of
120 MB on the chat route return the toast, the same file on `/api/files`
the 413 body, a small file goes through to the controller. Both server
modules gained `spring-boot-starter-test` for the advice tests.

## Affected area

agent runtime · docs

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [x] I added/updated tests where it makes sense.
- [x] I updated docs/README if behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

## Related issues

Follow-up to #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185b7vo7w9JQeENNZNupPwD

---
_Generated by [Claude Code](https://claude.ai/code/session_0185b7vo7w9JQeENNZNupPwD)_