### PR TITLE
Admin UI picks LM Studio models from the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Added
+
+- **agents:** the Admin UI's LLM-config form reads the models installed in
+  LM Studio. Switch the provider to LM Studio and the model field becomes a
+  dropdown of what the server at the base URL has (chat models for a chat
+  config, embedding models for an embedding config, each with its context
+  length and load state); picking one fills in the context window — the
+  length the model is loaded with, or its maximum when it is not loaded —
+  and preselects the capabilities LM Studio reports (tool use, vision).
+  A pick also names a config that has no name yet after the model
+  (`openai/gpt-oss-120b` → `gpt-oss-120b`). Changing the base URL reloads
+  the list; when LM Studio does not answer the field stays a text field and
+  says why. LM Studio configs no longer show an API-key field — a local LM
+  Studio takes no key. A new config now starts with no provider selected
+  (the field is required) instead of the first one in the list. The list comes
+  from LM Studio's native REST API (`/api/v0/models`, falling back to
+  `/api/v1/models`); `LmStudioModelCatalog` in `mc-llm-gateway` is the
+  client, usable on its own.
+
 ## [0.5.1] - 2026-09-07
 
 ### Fixed

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModel.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModel.java
@@ -1,0 +1,104 @@
+package ai.mindconnect.llm.adapter.lmstudio;
+
+import ai.mindconnect.llm.domain.LlmCapability;
+import ai.mindconnect.llm.domain.LlmConfigType;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * One model installed in an LM Studio instance, as reported by its native
+ * REST API. Carries what the admin UI needs to pick a model and to fill in
+ * the config: the id LM Studio wants in {@code model}, the kind (chat or
+ * embedding), whether it is currently loaded, and the two context lengths.
+ *
+ * @param id                  the model key, e.g. {@code openai/gpt-oss-120b}
+ * @param displayName         a human-readable name, or the id when LM Studio gives none
+ * @param kind                what the model does
+ * @param loaded              whether an instance is loaded right now
+ * @param maxContextLength    what the model can take, in tokens; null when unknown
+ * @param loadedContextLength what the loaded instance was configured with; null when not loaded
+ * @param toolUse             whether LM Studio flags the model as trained for tool use
+ * @param vision              whether the model takes images
+ */
+public record LmStudioModel(
+        String id,
+        String displayName,
+        Kind kind,
+        boolean loaded,
+        Integer maxContextLength,
+        Integer loadedContextLength,
+        boolean toolUse,
+        boolean vision) {
+
+    /** LM Studio's model types, collapsed to what a config cares about. */
+    public enum Kind {
+        /** Text-only chat model ({@code llm}). */
+        LLM,
+        /** Chat model that also reads images ({@code vlm}). */
+        VLM,
+        /** Embedding model ({@code embeddings}). */
+        EMBEDDING,
+        /** Anything else LM Studio may report in the future. */
+        OTHER;
+
+        static Kind parse(String type) {
+            if (type == null) return OTHER;
+            return switch (type) {
+                case "llm" -> LLM;
+                case "vlm" -> VLM;
+                case "embeddings", "embedding" -> EMBEDDING;
+                default -> OTHER;
+            };
+        }
+    }
+
+    /**
+     * The context length a config should use: what the model is loaded with
+     * when it is loaded (that is the limit requests actually hit), otherwise
+     * the model's maximum. Null when LM Studio reports neither.
+     */
+    public Integer effectiveContextLength() {
+        return loadedContextLength != null ? loadedContextLength : maxContextLength;
+    }
+
+    /** Whether this model fits a config of the given type. */
+    public boolean appliesTo(LlmConfigType type) {
+        return type == LlmConfigType.EMBEDDING
+                ? kind == Kind.EMBEDDING
+                : kind == Kind.LLM || kind == Kind.VLM;
+    }
+
+    /** The capabilities LM Studio's metadata vouches for. */
+    public Set<LlmCapability> capabilities() {
+        Set<LlmCapability> set = EnumSet.noneOf(LlmCapability.class);
+        if (toolUse) set.add(LlmCapability.TOOL_CALLING);
+        if (vision || kind == Kind.VLM) set.add(LlmCapability.VISION);
+        return set;
+    }
+
+    /**
+     * A one-line label for a dropdown: name, context in thousands of tokens,
+     * load state — e.g. {@code GPT-OSS 120B · 32k loaded (max 128k) · tools}.
+     */
+    public String label() {
+        StringBuilder sb = new StringBuilder(displayName == null ? id : displayName);
+        if (loaded) {
+            sb.append(" · ").append(tokens(loadedContextLength)).append(" loaded");
+            if (maxContextLength != null && !maxContextLength.equals(loadedContextLength)) {
+                sb.append(" (max ").append(tokens(maxContextLength)).append(")");
+            }
+        } else if (maxContextLength != null) {
+            sb.append(" · max ").append(tokens(maxContextLength));
+        }
+        if (toolUse) sb.append(" · tools");
+        if (vision || kind == Kind.VLM) sb.append(" · vision");
+        if (kind == Kind.EMBEDDING) sb.append(" · embedding");
+        return sb.toString();
+    }
+
+    private static String tokens(Integer n) {
+        if (n == null) return "?";
+        return n >= 1024 && n % 1024 == 0 ? (n / 1024) + "k" : n.toString();
+    }
+}

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModelCatalog.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModelCatalog.java
@@ -1,0 +1,197 @@
+package ai.mindconnect.llm.adapter.lmstudio;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads the models installed in an LM Studio instance from its native REST
+ * API, so a config can be pointed at one by picking rather than typing, with
+ * the context length taken from what LM Studio reports.
+ *
+ * <p>LM Studio serves three model listings. The OpenAI-compatible
+ * {@code /v1/models} only has ids, so it is of no use here. The native
+ * {@code /api/v0/models} (every 0.3.x) carries {@code max_context_length} and,
+ * for loaded models, {@code loaded_context_length}; the newer
+ * {@code /api/v1/models} carries the same under different names plus a display
+ * name and richer capabilities. This client asks v0 first and falls back to v1,
+ * and folds both shapes onto {@link LmStudioModel}.
+ *
+ * <p>Timeouts are short on purpose — the call sits in a form round-trip and
+ * "LM Studio is not running" must come back as a hint, not a hang.
+ */
+public class LmStudioModelCatalog {
+
+    private static final Logger log = LoggerFactory.getLogger(LmStudioModelCatalog.class);
+
+    /** Where LM Studio serves by default. */
+    public static final String DEFAULT_BASE_URL = "http://localhost:1234";
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
+
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param httpClient a client to derive from — the catalog shortens its
+     *                   timeouts but shares its connection pool
+     */
+    public LmStudioModelCatalog(OkHttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .readTimeout(READ_TIMEOUT)
+                .callTimeout(READ_TIMEOUT.plus(CONNECT_TIMEOUT))
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    public LmStudioModelCatalog() {
+        this(new OkHttpClient(), new ObjectMapper());
+    }
+
+    /**
+     * The outcome of asking one LM Studio instance for its models. Either
+     * {@link #models()} is filled, or {@link #error()} says why not — an
+     * unreachable server is an expected answer, not an exception.
+     */
+    public record Catalog(String baseUrl, List<LmStudioModel> models, String error) {
+
+        public boolean available() {
+            return error == null;
+        }
+
+        /** The model with this id, or null when LM Studio does not list it. */
+        public LmStudioModel find(String id) {
+            if (id == null) return null;
+            return models.stream().filter(m -> id.equals(m.id())).findFirst().orElse(null);
+        }
+    }
+
+    /**
+     * Lists the models of the LM Studio instance at {@code baseUrl} (blank
+     * means {@link #DEFAULT_BASE_URL}). Never throws: a server that is down,
+     * too old, or answering something else yields a {@link Catalog} with an
+     * error message. A server that cannot be reached at all is reported after
+     * the first attempt; only an answer that is not the v0 listing (404 from a
+     * newer LM Studio, an unexpected body) makes it try v1.
+     */
+    public Catalog fetch(String baseUrl) {
+        String base = normalise(baseUrl);
+        String v0Error;
+        try {
+            return new Catalog(base, parseV0(get(base + "/api/v0/models")), null);
+        } catch (Unreachable e) {
+            return new Catalog(base, List.of(), e.getMessage());
+        } catch (IOException e) {
+            v0Error = e.getMessage();
+            log.debug("LM Studio /api/v0/models at {} failed ({}), trying /api/v1/models", base, v0Error);
+        }
+        try {
+            return new Catalog(base, parseV1(get(base + "/api/v1/models")), null);
+        } catch (IOException e) {
+            log.debug("LM Studio /api/v1/models at {} failed ({})", base, e.getMessage());
+            return new Catalog(base, List.of(), v0Error + "; " + e.getMessage());
+        }
+    }
+
+    /** No HTTP conversation at all — nothing listens, or the connection timed out. */
+    private static final class Unreachable extends IOException {
+        Unreachable(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    static String normalise(String baseUrl) {
+        String base = baseUrl == null || baseUrl.isBlank() ? DEFAULT_BASE_URL : baseUrl.trim();
+        while (base.endsWith("/")) base = base.substring(0, base.length() - 1);
+        // Configs sometimes carry the OpenAI prefix; the native API lives next to it.
+        if (base.endsWith("/v1")) base = base.substring(0, base.length() - 3);
+        return base;
+    }
+
+    private JsonNode get(String url) throws IOException {
+        Request request = new Request.Builder().url(url).get().build();
+        Response response;
+        try {
+            response = httpClient.newCall(request).execute();
+        } catch (IOException e) {
+            throw new Unreachable(e.getMessage() == null ? url + " unreachable" : e.getMessage(), e);
+        }
+        try (response) {
+            if (!response.isSuccessful()) {
+                throw new IOException("HTTP " + response.code() + " from " + url);
+            }
+            if (response.body() == null) throw new IOException("Empty response from " + url);
+            return objectMapper.readTree(response.body().byteStream());
+        }
+    }
+
+    /** {@code /api/v0/models}: flat objects with {@code id}, {@code type}, {@code state}. */
+    List<LmStudioModel> parseV0(JsonNode root) throws IOException {
+        JsonNode data = root.path("data");
+        if (!data.isArray()) throw new IOException("Unexpected /api/v0/models shape: no 'data' array");
+        List<LmStudioModel> models = new ArrayList<>();
+        for (JsonNode m : data) {
+            String id = m.path("id").asText(null);
+            if (id == null) continue;
+            boolean toolUse = false;
+            for (JsonNode c : m.path("capabilities")) toolUse |= "tool_use".equals(c.asText());
+            LmStudioModel.Kind kind = LmStudioModel.Kind.parse(m.path("type").asText(null));
+            models.add(new LmStudioModel(
+                    id, id, kind,
+                    "loaded".equals(m.path("state").asText("")),
+                    intOrNull(m.path("max_context_length")),
+                    intOrNull(m.path("loaded_context_length")),
+                    toolUse,
+                    kind == LmStudioModel.Kind.VLM));
+        }
+        return models;
+    }
+
+    /** {@code /api/v1/models}: {@code models[]} with {@code key}, {@code loaded_instances[]}. */
+    List<LmStudioModel> parseV1(JsonNode root) throws IOException {
+        JsonNode data = root.path("models");
+        if (!data.isArray()) throw new IOException("Unexpected /api/v1/models shape: no 'models' array");
+        List<LmStudioModel> models = new ArrayList<>();
+        for (JsonNode m : data) {
+            String id = m.path("key").asText(null);
+            if (id == null) continue;
+            JsonNode caps = m.path("capabilities");
+            boolean vision = caps.path("vision").asBoolean(false);
+            Integer loadedContext = null;
+            for (JsonNode inst : m.path("loaded_instances")) {
+                Integer ctx = intOrNull(inst.path("config").path("context_length"));
+                if (ctx != null && (loadedContext == null || ctx > loadedContext)) loadedContext = ctx;
+            }
+            boolean loaded = m.path("loaded_instances").size() > 0;
+            String type = m.path("type").asText(null);
+            LmStudioModel.Kind kind = LmStudioModel.Kind.parse(type);
+            // v1 reports vision models as plain "llm" with capabilities.vision = true.
+            if (kind == LmStudioModel.Kind.LLM && vision) kind = LmStudioModel.Kind.VLM;
+            models.add(new LmStudioModel(
+                    id,
+                    m.path("display_name").asText(id),
+                    kind,
+                    loaded,
+                    intOrNull(m.path("max_context_length")),
+                    loadedContext,
+                    caps.path("trained_for_tool_use").asBoolean(false),
+                    vision));
+        }
+        return models;
+    }
+
+    private static Integer intOrNull(JsonNode node) {
+        return node.isNumber() ? node.asInt() : null;
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModelCatalogTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModelCatalogTest.java
@@ -1,0 +1,200 @@
+package ai.mindconnect.llm.adapter.lmstudio;
+
+import ai.mindconnect.llm.domain.LlmCapability;
+import ai.mindconnect.llm.domain.LlmConfigType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The catalog against a fake LM Studio: both listing shapes as a real
+ * 0.3.x instance served them, the v1 fallback, and the two ways a server
+ * can be absent.
+ */
+class LmStudioModelCatalogTest {
+
+    private static final String V0 = """
+            {"data":[
+              {"id":"openai/gpt-oss-120b","object":"model","type":"llm","publisher":"openai",
+               "arch":"gpt-oss","compatibility_type":"gguf","quantization":"MXFP4","state":"loaded",
+               "max_context_length":131072,"loaded_context_length":32768,"capabilities":["tool_use"]},
+              {"id":"text-embedding-nomic-embed-text-v1.5","object":"model","type":"embeddings",
+               "publisher":"nomic-ai","arch":"nomic-bert","compatibility_type":"gguf","quantization":"Q4_K_M",
+               "state":"loaded","max_context_length":2048,"loaded_context_length":2048},
+              {"id":"google/gemma-4-e4b","object":"model","type":"vlm","publisher":"google","arch":"gemma4",
+               "compatibility_type":"mlx","quantization":"4bit","state":"not-loaded",
+               "max_context_length":131072,"capabilities":["tool_use"]}
+            ],"object":"list"}
+            """;
+
+    private static final String V1 = """
+            {"models":[
+              {"type":"llm","publisher":"openai","key":"openai/gpt-oss-120b","display_name":"GPT-OSS 120B",
+               "architecture":"gpt-oss","quantization":{"name":"MXFP4","bits_per_weight":4},
+               "size_bytes":63387444066,"params_string":"120B",
+               "loaded_instances":[{"id":"openai/gpt-oss-120b","config":{"context_length":32768,"parallel":4}}],
+               "max_context_length":131072,"format":"gguf",
+               "capabilities":{"vision":false,"trained_for_tool_use":true,
+                 "reasoning":{"allowed_options":["low","medium","high"],"default":"low"}}},
+              {"type":"llm","publisher":"google","key":"google/gemma-4-e4b","display_name":"Gemma 4 E4B",
+               "loaded_instances":[],"max_context_length":131072,"format":"mlx",
+               "capabilities":{"vision":true,"trained_for_tool_use":true}},
+              {"type":"embeddings","publisher":"nomic-ai","key":"text-embedding-nomic-embed-text-v1.5",
+               "display_name":"Nomic Embed v1.5","loaded_instances":[],"max_context_length":2048,"format":"gguf"}
+            ]}
+            """;
+
+    private HttpServer server;
+    private final List<String> requestedPaths = new ArrayList<>();
+    private LmStudioModelCatalog catalog;
+
+    @BeforeEach
+    void start() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        catalog = new LmStudioModelCatalog(new OkHttpClient(), new ObjectMapper());
+    }
+
+    @AfterEach
+    void stop() {
+        server.stop(0);
+    }
+
+    /** Serves each path with its status and body; everything else is a 500. */
+    private void serve(Map<String, Object[]> routes) {
+        server.createContext("/", exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            requestedPaths.add(path);
+            Object[] route = routes.get(path);
+            int status = route == null ? 500 : (int) route[0];
+            byte[] body = route == null || route[1] == null ? new byte[0]
+                    : ((String) route[1]).getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, body.length == 0 ? -1 : body.length);
+            if (body.length > 0) exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+    }
+
+    private String baseUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @Test
+    void readsTheV0Listing() {
+        serve(Map.of("/api/v0/models", new Object[]{200, V0}));
+
+        var result = catalog.fetch(baseUrl());
+
+        assertThat(result.available()).isTrue();
+        assertThat(result.models()).hasSize(3);
+
+        LmStudioModel gptOss = result.find("openai/gpt-oss-120b");
+        assertThat(gptOss.kind()).isEqualTo(LmStudioModel.Kind.LLM);
+        assertThat(gptOss.loaded()).isTrue();
+        assertThat(gptOss.maxContextLength()).isEqualTo(131072);
+        assertThat(gptOss.loadedContextLength()).isEqualTo(32768);
+        assertThat(gptOss.effectiveContextLength()).as("loaded wins over max").isEqualTo(32768);
+        assertThat(gptOss.capabilities()).containsExactly(LlmCapability.TOOL_CALLING);
+        assertThat(gptOss.appliesTo(LlmConfigType.CHAT)).isTrue();
+        assertThat(gptOss.appliesTo(LlmConfigType.EMBEDDING)).isFalse();
+
+        LmStudioModel gemma = result.find("google/gemma-4-e4b");
+        assertThat(gemma.kind()).isEqualTo(LmStudioModel.Kind.VLM);
+        assertThat(gemma.loaded()).isFalse();
+        assertThat(gemma.effectiveContextLength()).as("not loaded: the maximum").isEqualTo(131072);
+        assertThat(gemma.capabilities()).containsExactlyInAnyOrder(LlmCapability.TOOL_CALLING, LlmCapability.VISION);
+
+        LmStudioModel nomic = result.find("text-embedding-nomic-embed-text-v1.5");
+        assertThat(nomic.kind()).isEqualTo(LmStudioModel.Kind.EMBEDDING);
+        assertThat(nomic.appliesTo(LlmConfigType.EMBEDDING)).isTrue();
+        assertThat(nomic.appliesTo(LlmConfigType.CHAT)).isFalse();
+    }
+
+    @Test
+    void fallsBackToV1WhenV0IsGone() {
+        serve(Map.of(
+                "/api/v0/models", new Object[]{404, null},
+                "/api/v1/models", new Object[]{200, V1}));
+
+        var result = catalog.fetch(baseUrl());
+
+        assertThat(result.available()).isTrue();
+        assertThat(requestedPaths).containsExactly("/api/v0/models", "/api/v1/models");
+
+        LmStudioModel gptOss = result.find("openai/gpt-oss-120b");
+        assertThat(gptOss.displayName()).isEqualTo("GPT-OSS 120B");
+        assertThat(gptOss.loaded()).isTrue();
+        assertThat(gptOss.loadedContextLength()).isEqualTo(32768);
+        assertThat(gptOss.maxContextLength()).isEqualTo(131072);
+        assertThat(gptOss.toolUse()).isTrue();
+
+        LmStudioModel gemma = result.find("google/gemma-4-e4b");
+        assertThat(gemma.kind()).as("v1 says llm + vision, which is a VLM").isEqualTo(LmStudioModel.Kind.VLM);
+        assertThat(gemma.loaded()).isFalse();
+        assertThat(gemma.loadedContextLength()).isNull();
+
+        assertThat(result.find("text-embedding-nomic-embed-text-v1.5").kind())
+                .isEqualTo(LmStudioModel.Kind.EMBEDDING);
+    }
+
+    @Test
+    void aServerThatIsNotLmStudioIsReportedNotThrown() {
+        serve(Map.of());
+
+        var result = catalog.fetch(baseUrl());
+
+        assertThat(result.available()).isFalse();
+        assertThat(result.models()).isEmpty();
+        assertThat(result.error()).contains("HTTP 500").contains("/api/v0/models").contains("/api/v1/models");
+        assertThat(result.find("anything")).isNull();
+    }
+
+    @Test
+    void nothingListeningIsReportedAfterOneAttempt() {
+        String url = baseUrl();
+        server.stop(0);
+
+        var result = catalog.fetch(url);
+
+        assertThat(result.available()).isFalse();
+        assertThat(result.error()).isNotBlank();
+        assertThat(result.baseUrl()).isEqualTo(url);
+        assertThat(requestedPaths).isEmpty();
+    }
+
+    @Test
+    void normalisesTheBaseUrl() {
+        assertThat(LmStudioModelCatalog.normalise(null)).isEqualTo("http://localhost:1234");
+        assertThat(LmStudioModelCatalog.normalise("  ")).isEqualTo("http://localhost:1234");
+        assertThat(LmStudioModelCatalog.normalise("http://box:1234/")).isEqualTo("http://box:1234");
+        assertThat(LmStudioModelCatalog.normalise("http://box:1234/v1")).isEqualTo("http://box:1234");
+    }
+
+    @Test
+    void labelsReadAtAGlance() {
+        var loaded = new LmStudioModel("openai/gpt-oss-120b", "GPT-OSS 120B", LmStudioModel.Kind.LLM,
+                true, 131072, 32768, true, false);
+        assertThat(loaded.label()).isEqualTo("GPT-OSS 120B · 32k loaded (max 128k) · tools");
+
+        var idle = new LmStudioModel("google/gemma-4-e4b", "google/gemma-4-e4b", LmStudioModel.Kind.VLM,
+                false, 131072, null, true, false);
+        assertThat(idle.label()).isEqualTo("google/gemma-4-e4b · max 128k · tools · vision");
+
+        var embedding = new LmStudioModel("nomic", "nomic", LmStudioModel.Kind.EMBEDDING,
+                true, 2048, 2048, false, false);
+        assertThat(embedding.label()).isEqualTo("nomic · 2k loaded · embedding");
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
@@ -1,8 +1,11 @@
 package ai.mindconnect.adminui.ui.component;
 
 import ai.mindconnect.chatui.ui.UiComponent;
+import ai.mindconnect.llm.adapter.lmstudio.LmStudioModel;
+import ai.mindconnect.llm.adapter.lmstudio.LmStudioModelCatalog;
 import ai.mindconnect.llm.domain.LlmCapability;
 import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigType;
 import ai.mindconnect.llm.domain.LlmProvider;
 import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.ui.model.UiField;
@@ -10,27 +13,74 @@ import ai.mindconnect.ui.model.UiTrigger;
 import ai.mindconnect.ui.model.UiForm;
 import ai.mindconnect.ui.model.UiLink;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Edit form for an LLM configuration. Same component for both "new"
  * (null config) and "edit" (existing config) modes — the differences
  * are confined to factory-derived defaults, form id, and the submit
  * target (POST vs PUT).
+ *
+ * <p>For the LM Studio provider the model field is a dropdown of what the
+ * LM Studio instance at the base URL has installed, read from its REST API;
+ * picking a model fills the context window and the capabilities from what
+ * LM Studio reports. Every other provider keeps the free-text model field.
  */
 public final class LlmConfigFormComponent implements UiComponent {
 
     private final LlmConfig config;
     private final List<LlmConfig> allConfigs;
+    private final LmStudioModelCatalog.Catalog lmStudio;
 
     /**
      * @param config     the config being edited, or {@code null} for the "new config" form
      * @param allConfigs all stored configs — used to populate the "Delegates To" dropdown
      */
     public LlmConfigFormComponent(LlmConfig config, List<LlmConfig> allConfigs) {
+        this(config, allConfigs, null);
+    }
+
+    /**
+     * @param lmStudio the LM Studio catalog for the config's base URL — only
+     *                 for a config whose provider is LM Studio, {@code null}
+     *                 otherwise (the model stays a text field)
+     */
+    public LlmConfigFormComponent(LlmConfig config, List<LlmConfig> allConfigs,
+                                  LmStudioModelCatalog.Catalog lmStudio) {
         this.config = config;
         this.allConfigs = allConfigs;
+        this.lmStudio = lmStudio;
+    }
+
+    /**
+     * What the form fills in after a model was picked from LM Studio's
+     * catalog: the context length LM Studio reports for it and the
+     * capabilities its metadata vouches for, plus the hint that says where
+     * the number came from. {@code null} means "nothing to prefill — show
+     * what the config has".
+     */
+    public record LmStudioPrefill(Integer contextWindowTokens, Set<LlmCapability> capabilities, String hint) {
+
+        public static LmStudioPrefill of(LmStudioModel model) {
+            Integer ctx = model.effectiveContextLength();
+            String hint;
+            if (ctx == null) {
+                hint = null;
+            } else if (model.loaded()) {
+                hint = "From LM Studio: the model is loaded with " + ctx + " tokens";
+                if (model.maxContextLength() != null && !model.maxContextLength().equals(ctx)) {
+                    hint += " (it takes up to " + model.maxContextLength() + ")";
+                }
+                hint += ".";
+            } else {
+                hint = "From LM Studio: the model's maximum, " + ctx + " tokens. It is not loaded "
+                        + "right now — LM Studio may load it with a smaller context; lower this if so.";
+            }
+            return new LmStudioPrefill(ctx, model.capabilities(), hint);
+        }
     }
 
     @Override
@@ -61,22 +111,34 @@ public final class LlmConfigFormComponent implements UiComponent {
      * capability declaration; an embedding model only needs its input window.
      */
     public static ai.mindconnect.ui.model.UiFieldGroup typeGroup(boolean isEmbedding, LlmConfig config) {
+        return typeGroup(isEmbedding, config, null);
+    }
+
+    /**
+     * @param prefill values picked up from LM Studio for the model just
+     *                chosen, or {@code null} to show the config's own
+     */
+    public static ai.mindconnect.ui.model.UiFieldGroup typeGroup(boolean isEmbedding, LlmConfig config,
+                                                                 LmStudioPrefill prefill) {
         var group = ai.mindconnect.ui.model.UiFieldGroup.of("llm-type-cfg",
                 isEmbedding ? "Embedding settings" : "Chat settings");
+        Integer contextWindow = prefill != null && prefill.contextWindowTokens() != null
+                ? prefill.contextWindowTokens()
+                : config == null ? null : config.contextWindowTokens();
+        String contextHint = prefill != null && prefill.hint() != null ? prefill.hint() : null;
         if (isEmbedding) {
-            group.field(UiField.number("contextWindowTokens", "Max Input Tokens",
-                    config == null ? null : config.contextWindowTokens()).asEditable()
-                    .hint("Optional — the embedding model's input window, used to size chunks"));
+            group.field(UiField.number("contextWindowTokens", "Max Input Tokens", contextWindow).asEditable()
+                    .hint(contextHint != null ? contextHint
+                            : "Optional — the embedding model's input window, used to size chunks"));
             return group;
         }
-        group.field(capabilitiesField(config))
+        group.field(capabilitiesField(config, prefill == null ? null : prefill.capabilities()))
                 .field(UiField.number("defaultTemperature", "Temperature",
                         config == null ? 0.7 : config.defaultTemperature()).asEditable())
                 .field(UiField.number("maxOutputTokens", "Max Output Tokens",
                         config == null ? 4096 : config.maxOutputTokens()).asEditable())
-                .field(UiField.number("contextWindowTokens", "Context Window Tokens",
-                        config == null ? null : config.contextWindowTokens()).asEditable()
-                        .hint("Optional — used for token budget calculations"))
+                .field(UiField.number("contextWindowTokens", "Context Window Tokens", contextWindow).asEditable()
+                        .hint(contextHint != null ? contextHint : "Optional — used for token budget calculations"))
                 .field(UiField.bool("retryEnabled", "Retry on rate limit (429/529)",
                         config != null && config.retry() != null && config.retry().enabled())
                         .asEditable()
@@ -102,17 +164,25 @@ public final class LlmConfigFormComponent implements UiComponent {
      * config's effective set preselected: what it declares, or its provider's
      * default when it declares nothing. Saving the form pins that set on the
      * config; the hint says what Vision and Documents do, so an admin knows
-     * that unticking Vision turns images into placeholders.
+     * that unticking Vision turns images into placeholders. A set picked up
+     * from LM Studio's model metadata wins over both.
      */
-    private static UiField capabilitiesField(LlmConfig config) {
+    private static UiField capabilitiesField(LlmConfig config, Set<LlmCapability> fromLmStudio) {
         List<UiField.Option> options = Arrays.stream(LlmCapability.values())
                 .map(c -> UiField.Option.of(c.name(), c.label()))
                 .toList();
-        List<String> current = config == null ? List.of()
-                : config.effectiveCapabilities().stream().map(Enum::name).toList();
-        String origin = config == null || config.declaresCapabilities() ? ""
-                : " Not declared yet — the preselection is the " + config.provider() + " default; "
-                        + "saving pins it.";
+        List<String> current;
+        String origin;
+        if (fromLmStudio != null) {
+            current = fromLmStudio.stream().map(Enum::name).toList();
+            origin = " Preselected from what LM Studio reports for the model; saving pins it.";
+        } else {
+            current = config == null ? List.of()
+                    : config.effectiveCapabilities().stream().map(Enum::name).toList();
+            origin = config == null || config.declaresCapabilities() ? ""
+                    : " Not declared yet — the preselection is the " + config.provider() + " default; "
+                            + "saving pins it.";
+        }
         return UiField.multiselect("capabilities", "Capabilities", current, options)
                 .asEditable()
                 .hint("What the model reads and does. Vision: images sent with a message reach "
@@ -177,15 +247,37 @@ public final class LlmConfigFormComponent implements UiComponent {
      * hidden entirely in alias mode. Values come from the submitted form when
      * the swap is triggered by a toggle (so typed input survives), from the
      * stored config on first render.
+     *
+     * <p>LM Studio is the one provider whose server can be asked what it
+     * offers, so its base group differs: the model is a dropdown of the
+     * installed models (a text field with a hint when LM Studio does not
+     * answer), the base URL defaults to LM Studio's port and reloads the list
+     * when changed, and there is no API-key field — a local LM Studio takes
+     * no key.
+     *
+     * @param lmStudio the catalog read from the base URL when the provider is
+     *                 LM Studio; {@code null} for every other provider
      */
     public static ai.mindconnect.ui.model.UiFieldGroup baseGroup(
             boolean isAlias, String type, String provider, String model, String baseUrl,
-            String apiKey, String formId, java.util.UUID configId) {
+            String apiKey, String formId, java.util.UUID configId,
+            LmStudioModelCatalog.Catalog lmStudio) {
         var group = ai.mindconnect.ui.model.UiFieldGroup.of("llm-base-cfg", null);
         if (isAlias) group.hidden();
-        List<UiField.Option> providerOptions = Arrays.stream(LlmProvider.values())
+        boolean isLmStudio = LlmProvider.LM_STUDIO.name().equals(provider);
+        if (isLmStudio && (baseUrl == null || baseUrl.isBlank())) {
+            baseUrl = LmStudioModelCatalog.DEFAULT_BASE_URL;
+        }
+        LlmConfigType configType = LlmConfigType.EMBEDDING.name().equals(type)
+                ? LlmConfigType.EMBEDDING : LlmConfigType.CHAT;
+        // A new config starts with no provider: the picker must not appear for
+        // a provider nobody chose, so the first option is a blank the admin
+        // has to move off before saving.
+        List<UiField.Option> providerOptions = new ArrayList<>();
+        if (provider == null) providerOptions.add(UiField.Option.of("", "— pick a provider —"));
+        Arrays.stream(LlmProvider.values())
                 .map(p -> UiField.Option.of(p.name(), p.name()))
-                .toList();
+                .forEach(providerOptions::add);
         String swapUrl = "/admin/api/llm-configs/field-groups?form=" + formId
                 + (configId == null ? "" : "&id=" + configId);
         group.field(UiField.select("type", "Type",
@@ -197,24 +289,98 @@ public final class LlmConfigFormComponent implements UiComponent {
                                 + "search); no sampling settings, Test embeds the text instead of chatting.")
                         // Switching swaps the type-specific settings group below.
                         .onChange(UiTrigger.api("POST", swapUrl, formId)))
-                .field(UiField.select("provider", "Provider", provider, providerOptions)
-                        .asEditable()
+                .field(UiField.select("provider", "Provider", provider == null ? "" : provider, providerOptions)
+                        .asEditable().asRequired()
                         // Switching re-renders the provider-parameter group below.
                         .onChange(UiTrigger.api("POST", swapUrl, formId)))
-                .field(UiField.text("model", "Model", model)
-                        .asEditable()
-                        .hint("e.g. gpt-4o, gpt-5, claude-sonnet-4-6"))
-                .field(UiField.text("baseUrl", "Base URL", baseUrl)
-                        .asEditable()
-                        .hint("Leave empty to use provider default"))
-                .field(apiKeyField(apiKey, formId));
+                .field(modelField(model, isLmStudio ? lmStudio : null, configType, swapUrl, formId));
+        if (isLmStudio) {
+            group.field(UiField.text("baseUrl", "Base URL", baseUrl)
+                    .asEditable()
+                    .hint("The LM Studio server. Its models are read from " + baseUrl
+                            + "/api/v0/models — change the URL to reload the list.")
+                    // A different server has different models.
+                    .onChange(UiTrigger.api("POST", swapUrl, formId)));
+        } else {
+            group.field(UiField.text("baseUrl", "Base URL", baseUrl)
+                            .asEditable()
+                            .hint("Leave empty to use provider default"))
+                    .field(apiKeyField(apiKey, formId));
+        }
         return group;
+    }
+
+    /**
+     * The model field. A text field for every provider but LM Studio; for LM
+     * Studio a dropdown of the models its server lists for this config type
+     * (chat models for a chat config, embedding models for an embedding
+     * config). A stored model the server no longer has stays selectable, so
+     * opening the form never silently drops it. When the server does not
+     * answer, the text field returns with the reason as its hint.
+     */
+    static UiField modelField(String model, LmStudioModelCatalog.Catalog lmStudio, LlmConfigType type,
+                              String swapUrl, String formId) {
+        if (lmStudio == null) {
+            return UiField.text("model", "Model", model)
+                    .asEditable()
+                    .hint("e.g. gpt-4o, gpt-5, claude-sonnet-4-6");
+        }
+        if (!lmStudio.available()) {
+            return UiField.text("model", "Model", model)
+                    .asEditable()
+                    .hint("LM Studio at " + lmStudio.baseUrl() + " did not answer (" + lmStudio.error()
+                            + "). Type the model id, or start LM Studio and re-enter the Base URL "
+                            + "to load the list.");
+        }
+        List<UiField.Option> options = new ArrayList<>();
+        options.add(UiField.Option.of("", "— pick a model —"));
+        boolean listed = false;
+        for (LmStudioModel m : lmStudio.models()) {
+            if (!m.appliesTo(type)) continue;
+            options.add(UiField.Option.of(m.id(), m.label()));
+            listed |= m.id().equals(model);
+        }
+        boolean hasModel = model != null && !model.isBlank();
+        if (hasModel && !listed) {
+            options.add(UiField.Option.of(model, model + " (not installed in LM Studio)"));
+        }
+        String what = type == LlmConfigType.EMBEDDING ? "embedding" : "chat";
+        String hint = options.size() == 1
+                ? "LM Studio at " + lmStudio.baseUrl() + " lists no " + what + " models."
+                : "Installed in LM Studio at " + lmStudio.baseUrl()
+                        + ". Picking a model fills in its context window below.";
+        return UiField.select("model", "Model", hasModel ? model : "", options)
+                .asEditable()
+                .hint(hint)
+                // The pick decides the context window: re-render with reason=model.
+                .onChange(UiTrigger.api("POST", swapUrl + "&reason=model", formId));
     }
 
     /** Marks the group hidden in alias mode — fields stay in the DOM. */
     public static ai.mindconnect.ui.model.UiFieldGroup withHiddenIf(
             boolean hide, ai.mindconnect.ui.model.UiFieldGroup group) {
         return hide ? group.<ai.mindconnect.ui.model.UiFieldGroup>hidden() : group;
+    }
+
+    /**
+     * The name field — also rebuilt by the field-groups patch when a model
+     * picked from LM Studio names a config that has no name yet.
+     */
+    public static UiField nameField(String name) {
+        return UiField.text("name", "Name", name).asEditable().asRequired();
+    }
+
+    /**
+     * A config name suggested by a model id: the last path segment, so
+     * {@code openai/gpt-oss-120b} becomes {@code gpt-oss-120b} — config names
+     * travel in URLs and agent definitions, where a slash would get in the way.
+     */
+    public static String suggestedName(String modelId) {
+        if (modelId == null || modelId.isBlank()) return null;
+        String id = modelId.trim();
+        int slash = id.lastIndexOf('/');
+        String name = slash >= 0 && slash < id.length() - 1 ? id.substring(slash + 1) : id;
+        return name.isBlank() ? null : name;
     }
 
     @Override
@@ -224,8 +390,7 @@ public final class LlmConfigFormComponent implements UiComponent {
         java.util.UUID configId = isNew ? null : config.id();
 
         return UiForm.of(id(), isNew ? "New LLM Config" : "Edit LLM Config: " + config.name())
-                .field(UiField.text("name", "Name", isNew ? null : config.name())
-                        .asEditable().asRequired())
+                .field(nameField(isNew ? null : config.name()))
                 .field(UiField.bool("isAlias", "Is Alias", isAlias)
                         .asEditable()
                         .hint("If set, this config just points at another config by name — handy for a swappable 'default'")
@@ -241,7 +406,7 @@ public final class LlmConfigFormComponent implements UiComponent {
                         isNew ? null : config.model(),
                         isNew ? null : config.baseUrl(),
                         isNew ? null : config.apiKey(),
-                        id(), configId))
+                        id(), configId, lmStudio))
                 .content(withHiddenIf(isAlias, typeGroup(!isNew && config.isEmbedding(), config)))
                 .content(withHiddenIf(isAlias, providerParamsGroup(
                         isNew ? null : config.provider(),

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
@@ -9,6 +9,8 @@ import ai.mindconnect.adminui.ui.component.LlmConfigTestComponent;
 import ai.mindconnect.adminui.ui.page.LlmConfigDetailPage;
 import ai.mindconnect.adminui.ui.page.LlmConfigFormPage;
 import ai.mindconnect.adminui.ui.page.LlmConfigListPage;
+import ai.mindconnect.llm.adapter.lmstudio.LmStudioModel;
+import ai.mindconnect.llm.adapter.lmstudio.LmStudioModelCatalog;
 import ai.mindconnect.llm.domain.LlmCapability;
 import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.llm.domain.LlmConfigType;
@@ -20,6 +22,8 @@ import ai.mindconnect.chatui.ui.controller.FormBody;
 import ai.mindconnect.ui.model.UiDialog;
 import ai.mindconnect.ui.model.UiPage;
 import ai.mindconnect.ui.model.UiPatch;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,16 +36,36 @@ public class LlmConfigUiController {
 
     private static final String MASKED_KEY = "••••••••";
 
+    /**
+     * What an LM Studio config stores as its key. LM Studio takes no key, the
+     * form has no field for one, and the OpenAI-compatible gateway still sends
+     * a bearer header — so it sends this, as the bundled configs always have.
+     */
+    static final String LM_STUDIO_KEY = "lm-studio";
+
     private final LlmConfigRepository repository;
     private final LlmConfigTestService testService;
     private final EncryptionHelper encryption;
+    private final LmStudioModelCatalog lmStudio;
 
+    @org.springframework.beans.factory.annotation.Autowired
     public LlmConfigUiController(LlmConfigRepository repository,
                                     LlmConfigTestService testService,
-                                    EncryptionHelper encryption) {
+                                    EncryptionHelper encryption,
+                                    OkHttpClient httpClient,
+                                    ObjectMapper objectMapper) {
+        this(repository, testService, encryption, new LmStudioModelCatalog(httpClient, objectMapper));
+    }
+
+    /** For tests: a catalog that answers without an LM Studio. */
+    LlmConfigUiController(LlmConfigRepository repository,
+                          LlmConfigTestService testService,
+                          EncryptionHelper encryption,
+                          LmStudioModelCatalog lmStudio) {
         this.repository = repository;
         this.testService = testService;
         this.encryption = encryption;
+        this.lmStudio = lmStudio;
     }
 
     /**
@@ -71,15 +95,23 @@ public class LlmConfigUiController {
     }
 
     /**
-     * isAlias, type or provider switched: re-render every dependent group.
-     * Alias mode collapses the form to the delegation target; provider mode
-     * shows the base fields plus the type- and provider-specific groups.
-     * Values the admin already typed ride along in the submitted form body
-     * and win over the stored config, so toggling never loses input.
+     * isAlias, type, provider, base URL or model switched: re-render every
+     * dependent group. Alias mode collapses the form to the delegation target;
+     * provider mode shows the base fields plus the type- and provider-specific
+     * groups. Values the admin already typed ride along in the submitted form
+     * body and win over the stored config, so toggling never loses input.
+     *
+     * <p>With LM Studio as the provider the base URL is asked for its models
+     * (so the model field becomes a dropdown), and when the trigger was the
+     * model pick itself ({@code reason=model}) — or the context window is
+     * still empty — the picked model's context length and capabilities are
+     * written into the settings group. A pick also names a config that has
+     * no name yet, after the model.
      */
     @PostMapping("/field-groups")
     public UiPatch fieldGroups(@RequestParam("form") String formId,
                                @RequestParam(value = "id", required = false) UUID id,
+                               @RequestParam(value = "reason", required = false) String reason,
                                @RequestBody Map<String, Object> raw) {
         var body = new FormBody(raw);
         LlmConfig config = id == null ? null : repository.findById(id).orElse(null);
@@ -88,7 +120,30 @@ public class LlmConfigUiController {
         LlmConfigType type = typeFrom(body, config != null ? config.type() : LlmConfigType.CHAT);
         LlmProvider provider = providerFrom(body);
         if (provider == null && config != null) provider = config.provider();
-        return UiPatch.of()
+        String model = or(body.str("model"), config == null ? null : config.model());
+        String baseUrl = or(body.str("baseUrl"), config == null ? null : config.baseUrl());
+
+        LmStudioModelCatalog.Catalog catalog = null;
+        LlmConfigFormComponent.LmStudioPrefill prefill = null;
+        String suggestedName = null;
+        if (!isAlias && provider == LlmProvider.LM_STUDIO) {
+            catalog = lmStudio.fetch(baseUrl);
+            LmStudioModel picked = catalog.find(model);
+            boolean modelPicked = "model".equals(reason);
+            boolean contextEmpty = body.numOrNull("contextWindowTokens") == null;
+            if (picked != null && (modelPicked || contextEmpty)) {
+                prefill = LlmConfigFormComponent.LmStudioPrefill.of(picked);
+            }
+            String name = body.str("name");
+            if (modelPicked && picked != null && (name == null || name.isBlank())) {
+                suggestedName = LlmConfigFormComponent.suggestedName(picked.id());
+            }
+        }
+        UiPatch patch = UiPatch.of();
+        if (suggestedName != null) {
+            patch.patch(UiPatch.Operation.replace("name", LlmConfigFormComponent.nameField(suggestedName)));
+        }
+        return patch
                 .patch(UiPatch.Operation.replace("llm-alias-cfg",
                         LlmConfigFormComponent.aliasGroup(isAlias,
                                 or(body.str("delegatesTo"), config == null ? null : config.delegatesTo()),
@@ -97,13 +152,13 @@ public class LlmConfigUiController {
                         LlmConfigFormComponent.baseGroup(isAlias,
                                 type.name(),
                                 provider == null ? null : provider.name(),
-                                or(body.str("model"), config == null ? null : config.model()),
-                                or(body.str("baseUrl"), config == null ? null : config.baseUrl()),
+                                model,
+                                baseUrl,
                                 or(body.str("apiKey"), config == null ? null : config.apiKey()),
-                                formId, id)))
+                                formId, id, catalog)))
                 .patch(UiPatch.Operation.replace("llm-type-cfg",
                         LlmConfigFormComponent.withHiddenIf(isAlias,
-                                LlmConfigFormComponent.typeGroup(type == LlmConfigType.EMBEDDING, config))))
+                                LlmConfigFormComponent.typeGroup(type == LlmConfigType.EMBEDDING, config, prefill))))
                 .patch(UiPatch.Operation.replace("llm-provider-params",
                         LlmConfigFormComponent.withHiddenIf(isAlias,
                                 LlmConfigFormComponent.providerParamsGroup(provider, type, config))));
@@ -112,6 +167,42 @@ public class LlmConfigUiController {
     /** First non-null value — form input wins over the stored config. */
     private static String or(String formValue, String stored) {
         return formValue != null ? formValue : stored;
+    }
+
+    /**
+     * The key to store for a new config: what the form sent, except for LM
+     * Studio, whose form has no key field — there it is {@link #LM_STUDIO_KEY}.
+     */
+    static String apiKeyFor(LlmProvider provider, String apiKey) {
+        if (provider == LlmProvider.LM_STUDIO && (apiKey == null || apiKey.isBlank())) {
+            return LM_STUDIO_KEY;
+        }
+        return apiKey;
+    }
+
+    /**
+     * The key to store on update: the form's key, or the existing one when the
+     * form sent the mask. For LM Studio the form has no key field: a config
+     * that was LM Studio before keeps its key (a placeholder, say), one that
+     * was just switched to LM Studio must not carry its old provider's secret
+     * to a local server and gets {@link #LM_STUDIO_KEY}.
+     */
+    static String apiKeyForUpdate(LlmConfig existing, LlmProvider provider, String formKey) {
+        if (provider == LlmProvider.LM_STUDIO) {
+            boolean wasLmStudio = existing.provider() == LlmProvider.LM_STUDIO;
+            String kept = wasLmStudio ? existing.apiKey() : null;
+            return apiKeyFor(provider, kept);
+        }
+        return MASKED_KEY.equals(formKey) ? existing.apiKey() : formKey;
+    }
+
+    /** The form's provider, which a non-alias config must have. */
+    private static LlmProvider requiredProvider(FormBody body) {
+        String raw = body.str("provider");
+        if (raw == null || raw.isBlank()) {
+            throw new IllegalArgumentException("Provider is required — pick one before saving");
+        }
+        return LlmProvider.valueOf(raw);
     }
 
     /** The form's provider select, tolerant of missing/unknown values. */
@@ -160,11 +251,19 @@ public class LlmConfigUiController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /** The edit form; for an LM Studio config with its server's model list. */
     @GetMapping("/{id}/edit")
     public ResponseEntity<UiPage> editForm(@PathVariable UUID id) {
         return repository.findById(id)
-                .map(c -> ResponseEntity.ok(new LlmConfigFormPage(c, repository.findAll()).render()))
+                .map(c -> ResponseEntity.ok(new LlmConfigFormPage(c, repository.findAll(),
+                        lmStudioCatalogFor(c)).render()))
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    /** The LM Studio catalog for an LM Studio config, {@code null} for any other. */
+    private LmStudioModelCatalog.Catalog lmStudioCatalogFor(LlmConfig config) {
+        if (config.isAlias() || config.provider() != LlmProvider.LM_STUDIO) return null;
+        return lmStudio.fetch(config.baseUrl());
     }
 
     @PostMapping
@@ -173,7 +272,7 @@ public class LlmConfigUiController {
         boolean isAlias = body.bool("isAlias", false);
         // Hidden fields still submit (by design) — an alias must not absorb
         // the invisible provider fields, and vice versa.
-        LlmProvider provider = isAlias ? null : LlmProvider.valueOf(body.str("provider"));
+        LlmProvider provider = isAlias ? null : requiredProvider(body);
         var config = new LlmConfig(
                 UUID.randomUUID(),
                 body.str("name"),
@@ -182,7 +281,7 @@ public class LlmConfigUiController {
                 isAlias ? null : body.str("baseUrl"),
                 // Defensive: the form pre-fills the masked sentinel for existing
                 // keys; never persist the bullets themselves as an API key.
-                isAlias || MASKED_KEY.equals(body.str("apiKey")) ? null : body.str("apiKey"),
+                isAlias ? null : apiKeyFor(provider, MASKED_KEY.equals(body.str("apiKey")) ? null : body.str("apiKey")),
                 body.dbl("defaultTemperature", 0.7),
                 body.num("maxOutputTokens", 4096),
                 additionalParamsFrom(body, Map.of(), provider),
@@ -203,18 +302,15 @@ public class LlmConfigUiController {
         var body = new FormBody(raw);
         return repository.findById(id)
                 .map(existing -> {
-                    String apiKey = MASKED_KEY.equals(body.str("apiKey"))
-                            ? existing.apiKey()
-                            : body.str("apiKey");
                     boolean isAlias = body.bool("isAlias", existing.isAlias());
-                    LlmProvider provider = isAlias ? null : LlmProvider.valueOf(body.str("provider"));
+                    LlmProvider provider = isAlias ? null : requiredProvider(body);
                     var updated = new LlmConfig(
                             existing.id(),
                             body.str("name"),
                             provider,
                             isAlias ? null : body.str("model"),
                             isAlias ? null : body.str("baseUrl"),
-                            isAlias ? null : apiKey,
+                            isAlias ? null : apiKeyForUpdate(existing, provider, body.str("apiKey")),
                             body.dbl("defaultTemperature", existing.defaultTemperature()),
                             body.num("maxOutputTokens", existing.maxOutputTokens()),
                             additionalParamsFrom(body, existing.additionalParams(), provider),

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/page/LlmConfigFormPage.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/page/LlmConfigFormPage.java
@@ -2,6 +2,7 @@ package ai.mindconnect.adminui.ui.page;
 
 import ai.mindconnect.adminui.ui.AdminPage;
 import ai.mindconnect.adminui.ui.component.LlmConfigFormComponent;
+import ai.mindconnect.llm.adapter.lmstudio.LmStudioModelCatalog;
 import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.ui.model.UiPage;
 
@@ -15,10 +16,21 @@ public final class LlmConfigFormPage extends AdminPage {
 
     private final LlmConfig config;
     private final List<LlmConfig> allConfigs;
+    private final LmStudioModelCatalog.Catalog lmStudio;
 
     public LlmConfigFormPage(LlmConfig config, List<LlmConfig> allConfigs) {
+        this(config, allConfigs, null);
+    }
+
+    /**
+     * @param lmStudio the LM Studio catalog for an LM Studio config's base
+     *                 URL, {@code null} for any other config
+     */
+    public LlmConfigFormPage(LlmConfig config, List<LlmConfig> allConfigs,
+                             LmStudioModelCatalog.Catalog lmStudio) {
         this.config = config;
         this.allConfigs = allConfigs;
+        this.lmStudio = lmStudio;
     }
 
     @Override
@@ -26,6 +38,6 @@ public final class LlmConfigFormPage extends AdminPage {
         String url = config == null
                 ? "/admin/llm-configs/new"
                 : "/admin/llm-configs/" + config.id() + "/edit";
-        return UiPage.of(url, new LlmConfigFormComponent(config, allConfigs).render());
+        return UiPage.of(url, new LlmConfigFormComponent(config, allConfigs, lmStudio).render());
     }
 }

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/LlmConfigFormLmStudioTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/LlmConfigFormLmStudioTest.java
@@ -1,0 +1,201 @@
+package ai.mindconnect.adminui.ui.component;
+
+import ai.mindconnect.llm.adapter.lmstudio.LmStudioModel;
+import ai.mindconnect.llm.adapter.lmstudio.LmStudioModelCatalog;
+import ai.mindconnect.llm.domain.LlmCapability;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigType;
+import ai.mindconnect.ui.model.UiField;
+import ai.mindconnect.ui.model.UiFieldGroup;
+import ai.mindconnect.ui.model.UiNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The LM Studio model picker: a dropdown of the server's models only when
+ * the provider is LM Studio, a text field with the reason when the server
+ * does not answer, no API-key field for LM Studio, and the picked model's
+ * context length and capabilities landing in the settings group.
+ */
+class LlmConfigFormLmStudioTest {
+
+    private static final String FORM = "llm-config-new";
+
+    private static final LmStudioModel GPT_OSS = new LmStudioModel(
+            "openai/gpt-oss-120b", "openai/gpt-oss-120b", LmStudioModel.Kind.LLM,
+            true, 131072, 32768, true, false);
+    private static final LmStudioModel GEMMA = new LmStudioModel(
+            "google/gemma-4-e4b", "google/gemma-4-e4b", LmStudioModel.Kind.VLM,
+            false, 131072, null, true, false);
+    private static final LmStudioModel NOMIC = new LmStudioModel(
+            "text-embedding-nomic-embed-text-v1.5", "text-embedding-nomic-embed-text-v1.5",
+            LmStudioModel.Kind.EMBEDDING, true, 2048, 2048, false, false);
+
+    private static final LmStudioModelCatalog.Catalog CATALOG = new LmStudioModelCatalog.Catalog(
+            "http://localhost:1234", List.of(GPT_OSS, GEMMA, NOMIC), null);
+    private static final LmStudioModelCatalog.Catalog DOWN = new LmStudioModelCatalog.Catalog(
+            "http://localhost:1234", List.of(), "Failed to connect to localhost/127.0.0.1:1234");
+
+    private static UiField field(UiFieldGroup group, String id) {
+        for (UiNode node : group.getContent()) {
+            if (node instanceof UiField f && id.equals(f.getId())) return f;
+        }
+        return null;
+    }
+
+    private static List<String> optionValues(UiField field) {
+        return field.getOptions().stream().map(UiField.Option::getValue).toList();
+    }
+
+    @Test
+    void lmStudioGetsADropdownOfChatModelsAndNoKeyField() {
+        UiFieldGroup group = LlmConfigFormComponent.baseGroup(false, "CHAT", "LM_STUDIO",
+                "openai/gpt-oss-120b", "http://localhost:1234", null, FORM, null, CATALOG);
+
+        UiField model = field(group, "model");
+        assertThat(model.getFieldType()).isEqualTo(UiField.FieldType.SELECT);
+        assertThat(model.getValue()).isEqualTo("openai/gpt-oss-120b");
+        assertThat(optionValues(model))
+                .as("the embedding model is not offered to a chat config")
+                .containsExactly("", "openai/gpt-oss-120b", "google/gemma-4-e4b");
+        assertThat(model.getOptions().get(1).getLabel()).isEqualTo("openai/gpt-oss-120b · 32k loaded (max 128k) · tools");
+        assertThat(model.getOnChange().getUrl()).contains("/field-groups").contains("reason=model");
+
+        assertThat(field(group, "apiKey")).as("LM Studio takes no key").isNull();
+        UiField baseUrl = field(group, "baseUrl");
+        assertThat(baseUrl.getOnChange()).as("a new URL reloads the models").isNotNull();
+    }
+
+    @Test
+    void anEmbeddingConfigSeesOnlyEmbeddingModels() {
+        UiFieldGroup group = LlmConfigFormComponent.baseGroup(false, "EMBEDDING", "LM_STUDIO",
+                null, null, null, FORM, null, CATALOG);
+
+        UiField model = field(group, "model");
+        assertThat(optionValues(model)).containsExactly("", "text-embedding-nomic-embed-text-v1.5");
+        assertThat(model.getValue()).as("nothing picked yet").isEqualTo("");
+        assertThat(field(group, "baseUrl").getValue())
+                .as("an empty base URL defaults to LM Studio's port")
+                .isEqualTo("http://localhost:1234");
+    }
+
+    @Test
+    void aStoredModelTheServerNoLongerHasStaysSelectable() {
+        UiFieldGroup group = LlmConfigFormComponent.baseGroup(false, "CHAT", "LM_STUDIO",
+                "qwen/qwen3-32b", "http://localhost:1234", null, FORM, null, CATALOG);
+
+        UiField model = field(group, "model");
+        assertThat(model.getValue()).isEqualTo("qwen/qwen3-32b");
+        assertThat(optionValues(model)).contains("qwen/qwen3-32b");
+        assertThat(model.getOptions().get(model.getOptions().size() - 1).getLabel())
+                .contains("not installed in LM Studio");
+    }
+
+    @Test
+    void whenLmStudioIsDownTheModelIsATextFieldWithTheReason() {
+        UiFieldGroup group = LlmConfigFormComponent.baseGroup(false, "CHAT", "LM_STUDIO",
+                "openai/gpt-oss-120b", "http://localhost:1234", null, FORM, null, DOWN);
+
+        UiField model = field(group, "model");
+        assertThat(model.getFieldType()).isEqualTo(UiField.FieldType.TEXT);
+        assertThat(model.getValue()).isEqualTo("openai/gpt-oss-120b");
+        assertThat(model.getHint()).contains("did not answer").contains("Failed to connect");
+        assertThat(field(group, "apiKey")).isNull();
+    }
+
+    @Test
+    void otherProvidersKeepTheTextFieldAndTheKey() {
+        UiFieldGroup group = LlmConfigFormComponent.baseGroup(false, "CHAT", "OPENAI",
+                "gpt-5", null, "${OPENAI_API_KEY}", FORM, null, null);
+
+        UiField model = field(group, "model");
+        assertThat(model.getFieldType()).isEqualTo(UiField.FieldType.TEXT);
+        assertThat(model.getOnChange()).isNull();
+        assertThat(field(group, "apiKey")).isNotNull();
+        assertThat(field(group, "baseUrl").getOnChange()).isNull();
+    }
+
+    @Test
+    void aNewConfigStartsWithNoProviderAndNoPicker() {
+        UiFieldGroup group = LlmConfigFormComponent.baseGroup(false, "CHAT", null,
+                null, null, null, FORM, null, null);
+
+        UiField provider = field(group, "provider");
+        assertThat(provider.getValue()).isEqualTo("");
+        assertThat(provider.isRequired()).isTrue();
+        assertThat(optionValues(provider).get(0)).as("a blank the admin has to move off").isEqualTo("");
+        assertThat(optionValues(provider)).contains("LM_STUDIO", "OPENAI");
+        assertThat(field(group, "model").getFieldType()).isEqualTo(UiField.FieldType.TEXT);
+        assertThat(field(group, "apiKey")).isNotNull();
+
+        UiFieldGroup chosen = LlmConfigFormComponent.baseGroup(false, "CHAT", "OPENAI",
+                null, null, null, FORM, null, null);
+        assertThat(optionValues(field(chosen, "provider")))
+                .as("once a provider is chosen the blank is gone")
+                .doesNotContain("");
+    }
+
+    @Test
+    void aCatalogForAnotherProviderIsIgnored() {
+        // The controller only fetches for LM Studio, but the component must not
+        // rely on that: a catalog with a non-LM-Studio provider changes nothing.
+        UiFieldGroup group = LlmConfigFormComponent.baseGroup(false, "CHAT", "OLLAMA",
+                "llama3", null, null, FORM, null, CATALOG);
+
+        assertThat(field(group, "model").getFieldType()).isEqualTo(UiField.FieldType.TEXT);
+        assertThat(field(group, "apiKey")).isNotNull();
+    }
+
+    @Test
+    void thePickedModelFillsContextWindowAndCapabilities() {
+        var prefill = LlmConfigFormComponent.LmStudioPrefill.of(GPT_OSS);
+        assertThat(prefill.contextWindowTokens()).as("loaded context wins").isEqualTo(32768);
+        assertThat(prefill.capabilities()).containsExactly(LlmCapability.TOOL_CALLING);
+        assertThat(prefill.hint()).contains("32768").contains("131072");
+
+        UiFieldGroup chat = LlmConfigFormComponent.typeGroup(false, null, prefill);
+        assertThat(field(chat, "contextWindowTokens").getValue()).isEqualTo(32768);
+        assertThat(field(chat, "contextWindowTokens").getHint()).startsWith("From LM Studio");
+        assertThat(field(chat, "capabilities").getValue()).isEqualTo(List.of("TOOL_CALLING"));
+        assertThat(field(chat, "capabilities").getHint()).contains("LM Studio");
+
+        var vision = LlmConfigFormComponent.LmStudioPrefill.of(GEMMA);
+        assertThat(vision.contextWindowTokens()).as("not loaded: the maximum").isEqualTo(131072);
+        assertThat(vision.capabilities()).containsExactlyInAnyOrder(LlmCapability.TOOL_CALLING, LlmCapability.VISION);
+        assertThat(vision.hint()).contains("not loaded");
+
+        UiFieldGroup embedding = LlmConfigFormComponent.typeGroup(true, null,
+                LlmConfigFormComponent.LmStudioPrefill.of(NOMIC));
+        assertThat(field(embedding, "contextWindowTokens").getValue()).isEqualTo(2048);
+    }
+
+    @Test
+    void withoutAPrefillTheConfigsOwnValuesShow() {
+        LlmConfig config = LlmConfig.lmStudio("lm", "openai/gpt-oss-120b", "http://localhost:1234");
+
+        UiFieldGroup chat = LlmConfigFormComponent.typeGroup(false, config, null);
+        assertThat(field(chat, "contextWindowTokens").getValue()).isEqualTo(config.contextWindowTokens());
+        assertThat(field(chat, "contextWindowTokens").getHint()).doesNotContain("LM Studio");
+        assertThat(field(chat, "capabilities").getValue())
+                .isEqualTo(config.effectiveCapabilities().stream().map(Enum::name).toList());
+    }
+
+    @Test
+    void theEditFormCarriesTheCatalogIntoTheBaseGroup() throws Exception {
+        LlmConfig config = LlmConfig.lmStudio("lm", "openai/gpt-oss-120b", "http://localhost:1234");
+        assertThat(config.type()).isEqualTo(LlmConfigType.CHAT);
+        var mapper = new ObjectMapper();
+
+        String withCatalog = mapper.writeValueAsString(
+                new LlmConfigFormComponent(config, List.of(config), CATALOG).render());
+        String withoutCatalog = mapper.writeValueAsString(
+                new LlmConfigFormComponent(config, List.of(config)).render());
+
+        assertThat(withCatalog).contains("google/gemma-4-e4b").doesNotContain("\"apiKey\"");
+        assertThat(withoutCatalog).doesNotContain("google/gemma-4-e4b").doesNotContain("\"apiKey\"");
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiControllerKeysTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiControllerKeysTest.java
@@ -1,0 +1,54 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.adminui.ui.component.LlmConfigFormComponent;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The LM Studio form has no API-key field, so the controller decides what an
+ * LM Studio config stores as its key — and a model picked from the catalog
+ * suggests a name for a config that has none.
+ */
+class LlmConfigUiControllerKeysTest {
+
+    @Test
+    void aNewLmStudioConfigGetsThePlaceholderKey() {
+        assertThat(LlmConfigUiController.apiKeyFor(LlmProvider.LM_STUDIO, null))
+                .isEqualTo(LlmConfigUiController.LM_STUDIO_KEY);
+        assertThat(LlmConfigUiController.apiKeyFor(LlmProvider.LM_STUDIO, "  "))
+                .isEqualTo(LlmConfigUiController.LM_STUDIO_KEY);
+        assertThat(LlmConfigUiController.apiKeyFor(LlmProvider.OPENAI, null)).isNull();
+        assertThat(LlmConfigUiController.apiKeyFor(LlmProvider.OPENAI, "sk-x")).isEqualTo("sk-x");
+    }
+
+    @Test
+    void anUpdatedLmStudioConfigKeepsItsOwnKeyButNotAnotherProviders() {
+        LlmConfig lm = LlmConfig.lmStudio("lm", "openai/gpt-oss-120b", "http://localhost:1234")
+                .withApiKey("${LM_KEY}");
+        assertThat(LlmConfigUiController.apiKeyForUpdate(lm, LlmProvider.LM_STUDIO, null))
+                .as("a placeholder on an LM Studio config stays")
+                .isEqualTo("${LM_KEY}");
+
+        LlmConfig claude = LlmConfig.claude("c", "claude-sonnet-4-6", "sk-ant-secret");
+        assertThat(LlmConfigUiController.apiKeyForUpdate(claude, LlmProvider.LM_STUDIO, null))
+                .as("switching to LM Studio does not carry the cloud key along")
+                .isEqualTo(LlmConfigUiController.LM_STUDIO_KEY);
+
+        assertThat(LlmConfigUiController.apiKeyForUpdate(claude, LlmProvider.ANTHROPIC, "••••••••"))
+                .as("the mask means: keep the stored key")
+                .isEqualTo("sk-ant-secret");
+        assertThat(LlmConfigUiController.apiKeyForUpdate(claude, LlmProvider.ANTHROPIC, "sk-new"))
+                .isEqualTo("sk-new");
+    }
+
+    @Test
+    void aPickedModelSuggestsAName() {
+        assertThat(LlmConfigFormComponent.suggestedName("openai/gpt-oss-120b")).isEqualTo("gpt-oss-120b");
+        assertThat(LlmConfigFormComponent.suggestedName("qwen3.8-27b-mlx")).isEqualTo("qwen3.8-27b-mlx");
+        assertThat(LlmConfigFormComponent.suggestedName(" ")).isNull();
+        assertThat(LlmConfigFormComponent.suggestedName(null)).isNull();
+    }
+}

--- a/website/docs/agents/admin-ui/llm-configs.md
+++ b/website/docs/agents/admin-ui/llm-configs.md
@@ -31,6 +31,35 @@ settings. The form also covers:
 - provider-specific extra parameters, rendered from the provider catalog;
 - an **Encrypt** button next to the API-key field for literal keys.
 
+## LM Studio: pick a model instead of typing it {#lm-studio}
+
+A new config starts with no provider selected; the field is required. With
+**LM Studio** as the provider the form asks the server at the base URL
+what it has installed, and the model field becomes a dropdown:
+
+- the list comes from LM Studio's native REST API (`GET {baseUrl}/api/v0/models`,
+  falling back to `/api/v1/models` on newer versions) and is filtered by the
+  config's type — chat models (`llm`, `vlm`) for a chat config, embedding
+  models for an embedding config;
+- each entry shows the model's context length and whether it is loaded, e.g.
+  `openai/gpt-oss-120b · 32k loaded (max 128k) · tools`;
+- picking a model fills in **Context Window Tokens** with the length the model
+  is *loaded* with (that is the limit requests hit), or its maximum when it is
+  not loaded yet — LM Studio may then load it with a smaller context, so check
+  the value after the first call. The **Capabilities** preselection follows
+  what LM Studio reports (tool use, vision). Both stay editable;
+- a config that has no name yet is named after the picked model — the last
+  path segment, so `openai/gpt-oss-120b` becomes `gpt-oss-120b`;
+- the base URL defaults to `http://localhost:1234`; changing it reloads the
+  list, so a second LM Studio on another machine works the same way;
+- a model the config names but the server no longer has stays selectable,
+  marked *not installed in LM Studio*;
+- there is no API-key field — a local LM Studio takes no key.
+
+When LM Studio is not running (or the URL points elsewhere) the model field
+stays a text field and its hint says what went wrong; type the model id as
+before, or start LM Studio and re-enter the base URL to load the list.
+
 ## Testing a config
 
 Each config's detail view has a **Test** button. It opens a dialog where you


### PR DESCRIPTION
## Summary

With **LM Studio** as the provider, the LLM-config form in the Admin UI now asks the server at the base URL what it has installed instead of making the admin type a model id.

- **`LmStudioModelCatalog`** (`mc-llm-gateway`) reads LM Studio's native `GET /api/v0/models` and falls back to `/api/v1/models`. Both shapes fold onto `LmStudioModel`: id, kind (llm / vlm / embeddings), load state, max and loaded context length, tool-use and vision flags. Short timeouts; an unreachable or foreign server comes back as a result with an error text, never as an exception. Usable on its own.
- **Model dropdown** filtered by config type (chat models for a chat config, embedding models for an embedding config), each entry labelled like `openai/gpt-oss-120b · 32k loaded (max 128k) · tools`. A stored model the server no longer lists stays selectable, marked *not installed in LM Studio*. When LM Studio does not answer, the field stays a text field and its hint says why.
- **Picking a model** fills *Context Window Tokens* with the length the model is loaded with (the limit requests actually hit), or its maximum when it is not loaded, preselects the capabilities LM Studio reports (tool use, vision), and names a config that has no name yet after the model (`openai/gpt-oss-120b` → `gpt-oss-120b`).
- **Base URL** defaults to `http://localhost:1234` and reloads the list when changed.
- **No API-key field** for LM Studio. Such configs store the `lm-studio` placeholder (as the bundled ones always did); an existing LM Studio key survives an update, and a config switched over from a cloud provider does not carry that provider's key to the local server.
- **New config starts with no provider selected** (required field), so the picker only appears once LM Studio is chosen.

Every other provider keeps the free-text model field, unchanged.

## Verification

- `mc-llm-gateway`: 68 tests, 0 failures (6 new: both listing shapes against a JDK `HttpServer`, v1 fallback, 404 and nothing-listening cases, labels, URL normalisation).
- `mc-agent-admin-ui-rest`: 27 tests, 0 failures (13 new for the form and the key handling).
- Manually in the Admin UI against a local LM Studio 0.3.x: new config → provider LM Studio → dropdown lists the four installed chat models, base URL prefilled, no key field → pick `openai/gpt-oss-120b` → name `gpt-oss-120b`, context window `32768`, capabilities *Tool calling* → Save → stored JSON has `contextWindowTokens: 32768`, `capabilities: ["TOOL_CALLING"]`, encrypted placeholder key. Edit form of that config shows the dropdown preselected.

## Known limitation (pre-existing, now more visible)

Re-rendering the *Chat settings* group (on provider, type or model change) shows the stored values for temperature, max output tokens and retry, so a value typed before picking a model is reset. Same behaviour as the existing provider/type switch; a follow-up can pass the typed values through like `baseGroup` does for model and base URL.

## Docs / changelog

- `CHANGELOG.md` under *Unreleased*.
- `website/docs/agents/admin-ui/llm-configs.md`: new section *LM Studio: pick a model instead of typing it*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
