### PR TITLE
An OpenAI Responses client can talk to a Mindconnect agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **An OpenAI Responses client can talk to a Mindconnect agent unchanged.**
+  The new `mc-agent-api-responses-rest` serves `/v1/responses` — create,
+  retrieve, cancel, and the SSE stream — in OpenAI's own wire format, so
+  pointing an official SDK at a Mindconnect server is a `base_url` change and
+  nothing else. Served by the admin UI app; no separate process.
+
+  What the client calls a **model** is an agent or an llm-config here:
+  `model: "web-researcher"` has that agent answer with its prompt, tools and
+  sub-agents, while `model: "claude-haiku-default"` runs the default agent on
+  that model instead. A name that is neither is refused, rather than quietly
+  answered by something else. What the client calls a **conversation** is a
+  session, so `previous_response_id` continues one.
+
+  Client-side function tools are not supported: this runtime executes tools
+  inside the turn rather than handing them back to the caller. Skills are not
+  implemented yet either.
 - **agents:** the Admin UI's LLM-config form reads the models installed in
   LM Studio. Switch the provider to LM Studio and the model field becomes a
   dropdown of what the server at the base URL has (chat models for a chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **agents:** the REST endpoints of both server apps — `/api`, `/chat/api`
+  and `/v1` — answer cross-origin calls from a browser. Every origin may
+  call by default; `mindconnect.cors.allowed-origins` narrows it to a list,
+  and a listed origin may also send the session cookie along.
+
 - **An OpenAI Responses client can talk to a Mindconnect agent unchanged.**
   The new `mc-agent-api-responses-rest` serves `/v1/responses` — create,
   retrieve, cancel, and the SSE stream — in OpenAI's own wire format, so

--- a/agents/pom.xml
+++ b/agents/pom.xml
@@ -61,6 +61,7 @@
         <module>core/mc-mcp-proxy</module>
         <module>core/mc-agent-tools-gmail</module>
         <module>server/mc-agent-api-rest</module>
+        <module>server/mc-agent-api-responses-rest</module>
         <module>server/mc-agent-api-app</module>
         <module>server/mc-agent-chat-ui-rest</module>
         <module>server/mc-agent-admin-ui-rest</module>

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -24,6 +24,13 @@
         <!-- Runtime providers: tools discovered via ServiceLoader, storage
              backends and the script engine for workflow code steps. The UI
              library compiles against none of them. -->
+        <!-- The OpenAI Responses API over this runtime; served alongside
+             the admin UI so one process answers both. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-api-responses-rest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-agent-tools</artifactId>

--- a/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/AdminUiApplication.java
+++ b/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/AdminUiApplication.java
@@ -23,7 +23,8 @@ import org.springframework.context.annotation.Import;
     LlmConfig.class,
     MessageRepositoryConfig.class,
     DefaultAgentRuntimeConfig.class,
-    TodoToolsConfig.class
+    TodoToolsConfig.class,
+    ai.mindconnect.agent.responses.config.ResponsesApiConfiguration.class
 })
 @Slf4j
 public class AdminUiApplication {

--- a/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/SecurityConfig.java
+++ b/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/SecurityConfig.java
@@ -24,6 +24,7 @@ import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
@@ -95,6 +96,9 @@ public class SecurityConfig {
         htmlOnlyRequestCache.setRequestMatcher(htmlAcceptMatcher());
 
         http
+            // Cross-origin calls to the REST endpoints, as CorsConfig in
+            // mc-agent-api-rest allows them; a preflight passes without a login.
+            .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/index.html", "/favicon.ico",
                                  "/js/**", "/css/**",
@@ -154,6 +158,7 @@ public class SecurityConfig {
             HttpSecurity http,
             @Value("${mindconnect.auth.dev-user:mc_user}") String devUser) throws Exception {
         http
+            .cors(Customizer.withDefaults())
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
             // No Keycloak in this mode, but the rest of the app still expects an

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
@@ -70,7 +70,8 @@ springdoc:
   # The admin shell's API section embeds this Swagger UI. Scope it to the
   # runtime's REST API — the admin-ui page controllers return recursive
   # UiNode trees whose schemas freeze Swagger UI's example renderer.
-  paths-to-match: /api/**
+  # The agent API and the OpenAI Responses API; the UI endpoints stay out.
+  paths-to-match: /api/**, /v1/**
   swagger-ui:
     # Operations start collapsed; the standalone Schemas section is hidden
     # (belt and braces against expensive model rendering).

--- a/agents/server/mc-agent-api-responses-rest/pom.xml
+++ b/agents/server/mc-agent-api-responses-rest/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-agent-api-responses-rest</artifactId>
+    <name>mc-agent-api-responses-rest</name>
+    <packaging>jar</packaging>
+    <description>OpenAI Responses API over the Mindconnect runtime — controllers and wire DTOs, no Spring Boot main class</description>
+
+    <dependencies>
+        <!-- The protocol vocabulary this API is the wire format of, and the
+             backend that executes it against the runtime. Everything else
+             here is translation between the two. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-protocol-mc-runtime</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Declared rather than inherited: this module names these types
+             directly (repositories, session service, conversation manager)
+             and must not depend on the backend continuing to expose them. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-runtime-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-llm-gateway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-message-repository-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/ModelResolver.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/ModelResolver.java
@@ -1,0 +1,97 @@
+package ai.mindconnect.agent.responses;
+
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.agent.port.out.AgentDefinitionRepository;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+
+/**
+ * Turns the {@code model} field of an incoming request into the agent that
+ * will answer it.
+ *
+ * <p>An OpenAI client has exactly one field to steer with, and callers mean
+ * two different things by it. Someone porting from OpenAI writes a model —
+ * {@code gpt-5-mini} — and wants that model to answer. Someone using
+ * Mindconnect writes an agent — {@code web-researcher} — and wants its
+ * prompt, tools and sub-agents. Both are served:
+ *
+ * <ol>
+ *   <li>an <b>agent</b> of that name answers as itself;</li>
+ *   <li>otherwise an <b>llm-config</b> of that name runs on the default
+ *       agent, which keeps its tools and prompt but swaps the model;</li>
+ *   <li>otherwise the request is rejected, naming both things that were
+ *       looked for — a client that mistyped an agent should not silently
+ *       get the default one.</li>
+ * </ol>
+ *
+ * <p>The agent wins a name collision. It is the more specific object: it
+ * already names an llm-config of its own, so reading it as a config would
+ * throw away the rest of it.
+ */
+public final class ModelResolver {
+
+    /** What {@code model} asked for, once resolved to something runnable. */
+    public record Resolution(String agentName, String llmConfigOverride) {
+
+        /** The agent runs as configured. */
+        static Resolution agent(String agentName) {
+            return new Resolution(agentName, null);
+        }
+
+        /** The default agent runs on a different model. */
+        static Resolution onModel(String defaultAgent, String llmConfigName) {
+            return new Resolution(defaultAgent, llmConfigName);
+        }
+
+        public boolean overridesModel() {
+            return llmConfigOverride != null;
+        }
+    }
+
+    private final AgentDefinitionRepository agents;
+    private final LlmConfigRepository llmConfigs;
+    private final Namespace namespace;
+    private final String defaultAgentName;
+
+    public ModelResolver(AgentDefinitionRepository agents, LlmConfigRepository llmConfigs,
+                         Namespace namespace, String defaultAgentName) {
+        this.agents = agents;
+        this.llmConfigs = llmConfigs;
+        this.namespace = namespace;
+        this.defaultAgentName = defaultAgentName;
+    }
+
+    /**
+     * @throws UnknownModelException when the name is neither an agent nor an
+     *         llm-config
+     */
+    public Resolution resolve(String model) {
+        if (model == null || model.isBlank()) {
+            return Resolution.agent(defaultAgentName);
+        }
+        String name = model.trim();
+
+        if (agents.findByName(namespace, name).isPresent()) {
+            return Resolution.agent(name);
+        }
+        if (llmConfigs.findByName(name).isPresent()) {
+            return Resolution.onModel(defaultAgentName, name);
+        }
+        throw new UnknownModelException(name);
+    }
+
+    /** Neither an agent nor an llm-config carries this name. */
+    public static class UnknownModelException extends RuntimeException {
+        private final String model;
+
+        public UnknownModelException(String model) {
+            super("The model '" + model + "' is neither an agent nor an llm-config on this server. "
+                    + "Send an agent's name to have that agent answer, or an llm-config's name to run "
+                    + "the default agent on that model.");
+            this.model = model;
+        }
+
+        public String model() {
+            return model;
+        }
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/ResponsesMapper.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/ResponsesMapper.java
@@ -1,0 +1,235 @@
+package ai.mindconnect.agent.responses;
+
+import ai.mindconnect.agent.protocol.IncompleteReason;
+import ai.mindconnect.agent.protocol.Response;
+import ai.mindconnect.agent.protocol.ResponseStatus;
+import ai.mindconnect.agent.protocol.item.ContentPart;
+import ai.mindconnect.agent.protocol.item.ConversationItem;
+import ai.mindconnect.agent.protocol.item.ConversationItemRecord;
+import ai.mindconnect.agent.responses.wire.ResponseDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Translation between the protocol's vocabulary and OpenAI's wire format.
+ *
+ * <p>Little is invented here. The protocol was modelled on the Responses API
+ * to begin with — {@code Response} even carries an {@code output_text} for
+ * the same reason OpenAI does — so most of this is renaming, and the places
+ * that are not are commented.
+ */
+public final class ResponsesMapper {
+
+    private final ObjectMapper json;
+
+    public ResponsesMapper(ObjectMapper json) {
+        this.json = json;
+    }
+
+    // ── Request ─────────────────────────────────────────────────────────────
+
+    /**
+     * The {@code input} field as protocol items. A client may send a bare
+     * string, or the array form; both mean the same thing for the common
+     * case and OpenAI's own SDKs use each.
+     */
+    public List<ConversationItem> toItems(JsonNode input) {
+        if (input == null || input.isNull()) {
+            return List.of();
+        }
+        if (input.isTextual()) {
+            return List.of(ConversationItem.Message.user(input.asText()));
+        }
+        if (!input.isArray()) {
+            throw new IllegalArgumentException("'input' must be a string or an array of items");
+        }
+        List<ConversationItem> items = new ArrayList<>();
+        for (JsonNode node : input) {
+            ConversationItem item = toItem(node);
+            if (item != null) {
+                items.add(item);
+            }
+        }
+        return items;
+    }
+
+    private ConversationItem toItem(JsonNode node) {
+        String type = text(node, "type");
+        // A message is the default: the array form of the simple case omits
+        // "type" entirely and carries only role + content.
+        if (type == null || "message".equals(type)) {
+            return ConversationItem.Message.user(contentText(node.get("content")));
+        }
+        if ("function_call_output".equals(type)) {
+            return new ConversationItem.FunctionCallOutput(
+                    text(node, "call_id"), text(node, "output"), false);
+        }
+        // Anything else is a shape this server does not accept as input.
+        // Silently dropping it would produce an answer to a question the
+        // client did not ask.
+        throw new IllegalArgumentException("Input items of type '" + type + "' are not supported");
+    }
+
+    /** Content is a string in the simple form and a list of parts otherwise. */
+    private String contentText(JsonNode content) {
+        if (content == null || content.isNull()) {
+            return "";
+        }
+        if (content.isTextual()) {
+            return content.asText();
+        }
+        StringBuilder text = new StringBuilder();
+        if (content.isArray()) {
+            for (JsonNode part : content) {
+                String t = text(part, "text");
+                if (t != null) {
+                    text.append(t);
+                }
+            }
+        }
+        return text.toString();
+    }
+
+    // ── Response ────────────────────────────────────────────────────────────
+
+    public ResponseDto toDto(Response response, String model) {
+        List<ResponseDto.OutputItemDto> output = new ArrayList<>();
+        for (ConversationItemRecord record : response.output()) {
+            ResponseDto.OutputItemDto item = toOutputItem(record);
+            if (item != null) {
+                output.add(item);
+            }
+        }
+        return new ResponseDto(
+                response.id(),
+                "response",
+                response.createdAt() == null ? 0 : response.createdAt().getEpochSecond(),
+                status(response.status()),
+                model,
+                output,
+                response.outputText(),
+                usage(response),
+                response.error() == null ? null
+                        : new ResponseDto.ErrorDto(response.error().code(), response.error().message()),
+                incomplete(response.incompleteReason()),
+                response.conversationId() == null ? null
+                        : new ResponseDto.ConversationRefDto(response.conversationId()),
+                response.parentResponseId(),
+                response.metadata() == null || response.metadata().isEmpty() ? null : response.metadata());
+    }
+
+    /**
+     * One output item. Returns {@code null} for protocol items that have no
+     * OpenAI counterpart — the bookkeeping ones a client would not know what
+     * to do with.
+     */
+    public ResponseDto.OutputItemDto toOutputItem(ConversationItemRecord record) {
+        String id = record.id();
+        return switch (record.item()) {
+            case ConversationItem.Message message -> new ResponseDto.OutputItemDto(
+                    id, "message", "completed", role(message),
+                    List.of(ResponseDto.ContentPartDto.outputText(messageText(message))),
+                    null, null, null, null, null);
+
+            case ConversationItem.FunctionCall call -> new ResponseDto.OutputItemDto(
+                    id, "function_call", "completed", null, null,
+                    call.callId(), call.name(), writeArguments(call.arguments()), null, null);
+
+            case ConversationItem.FunctionCallOutput out -> new ResponseDto.OutputItemDto(
+                    id, "function_call_output", out.failed() ? "incomplete" : "completed", null, null,
+                    out.callId(), null, null, out.output(), null);
+
+            case ConversationItem.Reasoning reasoning -> new ResponseDto.OutputItemDto(
+                    id, "reasoning", "completed", null, null, null, null, null, null,
+                    List.of(ResponseDto.ContentPartDto.outputText(reasoning.text())));
+
+            // A sub-agent call is Mindconnect's own; the nearest honest
+            // rendering is a function call, so a client at least sees that
+            // work was delegated and to whom.
+            case ConversationItem.AgentCall agentCall -> new ResponseDto.OutputItemDto(
+                    id, "function_call", "completed", null, null,
+                    agentCall.callId(), "run_agent",
+                    writeArguments(Map.of("agent", agentCall.agentName(), "input", agentCall.input())),
+                    null, null);
+
+            default -> null;
+        };
+    }
+
+    private String messageText(ConversationItem.Message message) {
+        StringBuilder text = new StringBuilder();
+        for (ContentPart part : message.content()) {
+            if (part instanceof ContentPart.Text t) {
+                text.append(t.text());
+            }
+        }
+        return text.toString();
+    }
+
+    private String role(ConversationItem.Message message) {
+        return message.role() == null ? "assistant" : message.role().name().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    /** OpenAI sends arguments as a JSON *string*, not as an object. */
+    private String writeArguments(Map<String, Object> arguments) {
+        try {
+            return json.writeValueAsString(arguments == null ? new LinkedHashMap<>() : arguments);
+        } catch (Exception e) {
+            return "{}";
+        }
+    }
+
+    private ResponseDto.UsageDto usage(Response response) {
+        var usage = response.usage();
+        if (usage == null) {
+            return null;
+        }
+        return new ResponseDto.UsageDto(usage.inputTokens(), usage.outputTokens(),
+                usage.inputTokens() + usage.outputTokens());
+    }
+
+    public static String status(ResponseStatus status) {
+        if (status == null) {
+            return "in_progress";
+        }
+        return switch (status) {
+            case QUEUED -> "queued";
+            case IN_PROGRESS -> "in_progress";
+            case COMPLETED -> "completed";
+            case INCOMPLETE -> "incomplete";
+            case FAILED -> "failed";
+            case CANCELLED -> "cancelled";
+        };
+    }
+
+    /**
+     * OpenAI knows two reasons; Mindconnect has more, because it can pause a
+     * turn for a human. The ones without a counterpart keep their own name —
+     * a client that does not recognise it still sees that the response is
+     * incomplete and why, which is better than a wrong familiar word.
+     */
+    private ResponseDto.IncompleteDetailsDto incomplete(IncompleteReason reason) {
+        if (reason == null) {
+            return null;
+        }
+        String name = switch (reason) {
+            case MAX_OUTPUT_TOKENS -> "max_output_tokens";
+            case MAX_ROUNDS -> "max_tool_calls";
+            default -> reason.name().toLowerCase(java.util.Locale.ROOT);
+        };
+        return new ResponseDto.IncompleteDetailsDto(name);
+    }
+
+    private static String text(JsonNode node, String field) {
+        if (node == null) {
+            return null;
+        }
+        JsonNode value = node.get(field);
+        return value != null && value.isTextual() ? value.asText() : null;
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/SessionBinder.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/SessionBinder.java
@@ -1,0 +1,85 @@
+package ai.mindconnect.agent.responses;
+
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.agent.domain.session.SessionAgentRef;
+import ai.mindconnect.agent.port.out.AgentDefinitionRepository;
+import ai.mindconnect.agent.protocol.Session;
+import ai.mindconnect.agent.protocol.runtime.AgentRuntimeBackend;
+import ai.mindconnect.agent.responses.wire.CreateResponseRequest;
+import ai.mindconnect.agent.service.AgentSessionService;
+
+import java.util.UUID;
+
+/**
+ * Finds the session a request belongs to, and makes it run what the request
+ * asked for.
+ *
+ * <p>A conversation in the Responses API is a session here — the same thing
+ * under two names: the durable thread a series of responses hangs off. So a
+ * client that sends {@code conversation} is naming a session directly, and
+ * one that sends {@code previous_response_id} is naming it indirectly, by
+ * pointing at something that happened in it. Sending neither means starting
+ * a new one.
+ */
+public final class SessionBinder {
+
+    private final AgentRuntimeBackend backend;
+    private final AgentSessionService sessions;
+    private final AgentDefinitionRepository agents;
+    private final Namespace namespace;
+
+    public SessionBinder(AgentRuntimeBackend backend, AgentSessionService sessions,
+                         AgentDefinitionRepository agents, Namespace namespace) {
+        this.backend = backend;
+        this.sessions = sessions;
+        this.agents = agents;
+        this.namespace = namespace;
+    }
+
+    public Session bind(CreateResponseRequest request, ModelResolver.Resolution resolution) {
+        Session session = existing(request).orElseGet(
+                () -> backend.sessions().open(namespace.value(), resolution.agentName()));
+
+        if (resolution.overridesModel()) {
+            applyModelOverride(session, resolution);
+        }
+        return session;
+    }
+
+    private java.util.Optional<Session> existing(CreateResponseRequest request) {
+        String conversationId = request.conversationId();
+        if (conversationId != null) {
+            return backend.sessions().get(conversationId);
+        }
+        if (request.previousResponseId() != null) {
+            // The response knows the session it ran in, which is what makes
+            // previous_response_id enough on its own — the client never has
+            // to have seen a conversation id.
+            return backend.responses().get(request.previousResponseId())
+                    .map(r -> backend.sessions().get(r.sessionId()).orElse(null))
+                    .map(java.util.Optional::ofNullable)
+                    .orElse(java.util.Optional.empty());
+        }
+        return java.util.Optional.empty();
+    }
+
+    /**
+     * The client named an llm-config rather than an agent: the default agent
+     * answers, on that model.
+     *
+     * <p>Written as a session-level override rather than by editing the
+     * agent — the agent is shared, and a request must not change what it is
+     * for everyone else. The override rides on the same {@link SessionAgentRef}
+     * the chat UI writes, so the agent keeps its tools, its prompt and the
+     * agents it may call, and only the model moves.
+     */
+    private void applyModelOverride(Session session, ModelResolver.Resolution resolution) {
+        var definition = agents.findByName(namespace, resolution.agentName()).orElseThrow(
+                () -> new IllegalStateException("The default agent '" + resolution.agentName()
+                        + "' does not exist; a request naming an llm-config has nothing to run on."));
+
+        sessions.replaceSessionAgent(UUID.fromString(session.id()),
+                new SessionAgentRef(definition.id(), true, definition.name(),
+                        resolution.llmConfigOverride(), null, null, null));
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/StreamEvents.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/StreamEvents.java
@@ -1,0 +1,145 @@
+package ai.mindconnect.agent.responses;
+
+import ai.mindconnect.agent.protocol.event.ResponseEvent;
+import ai.mindconnect.agent.protocol.item.ConversationItemRecord;
+import ai.mindconnect.agent.responses.wire.ResponseDto;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Protocol events as the frames an OpenAI client's stream parser expects.
+ *
+ * <p>The two models line up almost exactly, which is no coincidence — the
+ * protocol's events were derived from these. What differs is spelling, and
+ * two structural rules that a client's state machine relies on.
+ *
+ * <p><b>Lifecycle frames repeat the whole response.</b> The protocol sends a
+ * status change and expects the reader to already hold the object; OpenAI
+ * sends the object every time. Hence the supplier: the frame asks for the
+ * current response as it is written, not before.
+ *
+ * <p><b>{@code output_index} is a position, not a constant.</b> A client
+ * resolves a delta by looking up {@code response.output[output_index]} and
+ * asserting it is the kind of item the delta belongs to. Sending 0 for
+ * everything breaks the moment a response starts with anything other than
+ * the assistant message — a tool call, say, which is the normal case for an
+ * agent. Items are therefore numbered in the order they are added, and
+ * deltas cite the index of the item they belong to.
+ *
+ * <p>One instance belongs to one response; it carries that response's item
+ * numbering.
+ */
+public final class StreamEvents {
+
+    /** What goes on the wire: the SSE event name, and its JSON body. */
+    public record Frame(String event, Map<String, Object> data) { }
+
+    /**
+     * Whether this event ends the run. An OpenAI stream terminates when the
+     * response reaches a terminal status — a client reads until the
+     * connection closes, so leaving it open makes a finished response look
+     * like one that is still thinking.
+     */
+    public static boolean isTerminal(ResponseEvent event) {
+        return event instanceof ResponseEvent.Completed
+                || event instanceof ResponseEvent.Incomplete
+                || event instanceof ResponseEvent.Failed
+                || event instanceof ResponseEvent.Cancelled;
+    }
+
+    private final Supplier<ResponseDto> currentResponse;
+    private final ResponsesMapper mapper;
+
+    /** Item id → its position in {@code output}, in the order added. */
+    private final Map<String, Integer> indices = new LinkedHashMap<>();
+
+    public StreamEvents(Supplier<ResponseDto> currentResponse, ResponsesMapper mapper) {
+        this.currentResponse = currentResponse;
+        this.mapper = mapper;
+    }
+
+    /**
+     * @return the frame to write, or {@code null} for a protocol event with
+     *         no counterpart — an extension event, or an item OpenAI has no
+     *         shape for. Inventing a name would break a strict parser for no
+     *         gain, and the item still arrives in the final response.
+     */
+    public Frame frameFor(ResponseEvent event) {
+        return switch (event) {
+            case ResponseEvent.Created e -> lifecycle("response.created", e.seq());
+            case ResponseEvent.InProgress e -> lifecycle("response.in_progress", e.seq());
+            case ResponseEvent.Completed e -> lifecycle("response.completed", e.seq());
+            case ResponseEvent.Incomplete e -> lifecycle("response.incomplete", e.seq());
+            case ResponseEvent.Failed e -> lifecycle("response.failed", e.seq());
+
+            // OpenAI has no cancelled event; a cancelled run ends as failed
+            // from a reader's point of view, and the response object it
+            // carries states the real status.
+            case ResponseEvent.Cancelled e -> lifecycle("response.failed", e.seq());
+
+            case ResponseEvent.OutputItemAdded e ->
+                    itemFrame("response.output_item.added", e.seq(), e.entry());
+            case ResponseEvent.OutputItemDone e ->
+                    itemFrame("response.output_item.done", e.seq(), e.entry());
+
+            case ResponseEvent.OutputTextDelta e ->
+                    delta("response.output_text.delta", e.seq(), e.itemId(), e.delta());
+            case ResponseEvent.ArgumentsDelta e ->
+                    delta("response.function_call_arguments.delta", e.seq(), e.itemId(), e.delta());
+            case ResponseEvent.ReasoningDelta e ->
+                    delta("response.reasoning_summary_text.delta", e.seq(), e.itemId(), e.delta());
+
+            default -> null;
+        };
+    }
+
+    private Frame lifecycle(String type, long seq) {
+        Map<String, Object> data = base(type, seq);
+        data.put("response", currentResponse.get());
+        return new Frame(type, data);
+    }
+
+    private Frame itemFrame(String type, long seq, ConversationItemRecord entry) {
+        ResponseDto.OutputItemDto item = mapper.toOutputItem(entry);
+        if (item == null) {
+            // A protocol item with no OpenAI shape. Numbering it anyway would
+            // shift every later index away from what the response object
+            // shows, which is the one thing the client must be able to trust.
+            return null;
+        }
+        Map<String, Object> data = base(type, seq);
+        data.put("output_index", indexOf(entry.id()));
+        data.put("item", item);
+        return new Frame(type, data);
+    }
+
+    private Frame delta(String type, long seq, String itemId, String delta) {
+        Map<String, Object> data = base(type, seq);
+        data.put("item_id", itemId);
+        data.put("output_index", indexOf(itemId));
+        data.put("content_index", 0);
+        data.put("delta", delta);
+        return new Frame(type, data);
+    }
+
+    /**
+     * The item's position, assigned on first sight. A delta can arrive
+     * before the {@code added} frame for its item, so this must mint an
+     * index rather than assume one already exists.
+     */
+    private int indexOf(String itemId) {
+        if (itemId == null) {
+            return indices.size();
+        }
+        return indices.computeIfAbsent(itemId, id -> indices.size());
+    }
+
+    private Map<String, Object> base(String type, long seq) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", type);
+        data.put("sequence_number", seq);
+        return data;
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/config/ResponsesApiConfiguration.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/config/ResponsesApiConfiguration.java
@@ -1,0 +1,75 @@
+package ai.mindconnect.agent.responses.config;
+
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.agent.port.out.AgentDefinitionRepository;
+import ai.mindconnect.agent.protocol.runtime.AgentRuntimeBackend;
+import ai.mindconnect.agent.responses.ModelResolver;
+import ai.mindconnect.agent.responses.ResponsesMapper;
+import ai.mindconnect.agent.responses.SessionBinder;
+import ai.mindconnect.agent.service.AgentChatService;
+import ai.mindconnect.agent.service.AgentSessionService;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import ai.mindconnect.message.port.in.ConversationManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the Responses API onto whatever runtime the host application already
+ * has. An app includes this module and imports this class; nothing else is
+ * needed, and nothing here is specific to one host.
+ */
+@Configuration
+@ComponentScan(basePackages = "ai.mindconnect.agent.responses.controller")
+public class ResponsesApiConfiguration {
+
+    /**
+     * The agent that answers when {@code model} names an llm-config rather
+     * than an agent — the model moves, the agent stays.
+     */
+    @Value("${mindconnect.responses.default-agent:default-chat}")
+    private String defaultAgent;
+
+    /**
+     * Every request runs as this user until authentication is wired up.
+     * Stated as a property rather than hidden in a constant, so an operator
+     * can see what the API acts as before exposing it.
+     */
+    @Value("${mindconnect.responses.user-id:mc_user}")
+    private String userId;
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AgentRuntimeBackend responsesRuntimeBackend(AgentChatService chat,
+                                                       AgentSessionService sessions,
+                                                       AgentDefinitionRepository agents,
+                                                       ConversationManager conversations) {
+        return new AgentRuntimeBackend(chat, sessions, agents, conversations, userId);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ModelResolver responsesModelResolver(AgentDefinitionRepository agents,
+                                                LlmConfigRepository llmConfigs,
+                                                Namespace namespace) {
+        return new ModelResolver(agents, llmConfigs, namespace, defaultAgent);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SessionBinder responsesSessionBinder(AgentRuntimeBackend backend,
+                                                AgentSessionService sessions,
+                                                AgentDefinitionRepository agents,
+                                                Namespace namespace) {
+        return new SessionBinder(backend, sessions, agents, namespace);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResponsesMapper responsesMapper(ObjectMapper json) {
+        return new ResponsesMapper(json);
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesController.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesController.java
@@ -1,0 +1,163 @@
+package ai.mindconnect.agent.responses.controller;
+
+import ai.mindconnect.agent.protocol.Response;
+import ai.mindconnect.agent.protocol.Session;
+import ai.mindconnect.agent.protocol.api.ResponseRequest;
+import ai.mindconnect.agent.protocol.api.SubscribeRequest;
+import ai.mindconnect.agent.protocol.runtime.AgentRuntimeBackend;
+import ai.mindconnect.agent.responses.ModelResolver;
+import ai.mindconnect.agent.responses.ResponsesMapper;
+import ai.mindconnect.agent.responses.SessionBinder;
+import ai.mindconnect.agent.responses.StreamEvents;
+import ai.mindconnect.agent.responses.wire.CreateResponseRequest;
+import ai.mindconnect.agent.responses.wire.ResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The OpenAI Responses API, served by the Mindconnect runtime.
+ *
+ * <p>Point an OpenAI client's {@code base_url} here and it works unchanged:
+ * the wire format is theirs, the agent behind it is ours. What the client
+ * calls a model is an agent or an llm-config (see {@link ModelResolver}), and
+ * what it calls a conversation is a session.
+ *
+ * <p>This class translates and delegates; it holds no agent logic. The
+ * protocol surface it calls is the same one the OpenAI backend implements in
+ * the other direction, which is what makes the two interchangeable.
+ */
+@RestController
+@RequestMapping("/v1")
+public class ResponsesController {
+
+    private static final Logger log = LoggerFactory.getLogger(ResponsesController.class);
+
+    private final AgentRuntimeBackend backend;
+    private final ModelResolver models;
+    private final SessionBinder sessions;
+    private final ResponsesMapper mapper;
+    private final ObjectMapper json;
+
+    public ResponsesController(AgentRuntimeBackend backend, ModelResolver models,
+                               SessionBinder sessions, ResponsesMapper mapper, ObjectMapper json) {
+        this.backend = backend;
+        this.models = models;
+        this.sessions = sessions;
+        this.mapper = mapper;
+        this.json = json;
+    }
+
+    /**
+     * One route for both forms. The body decides, not the {@code Accept}
+     * header: an OpenAI client asks for a stream by sending
+     * {@code "stream": true} and keeps asking for {@code application/json},
+     * so splitting the mapping by produced type would make the streaming
+     * call unreachable from the official SDKs.
+     */
+    @PostMapping("/responses")
+    public ResponseEntity<?> create(@RequestBody CreateResponseRequest request) {
+        if (request.streaming()) {
+            return ResponseEntity.ok()
+                    .contentType(MediaType.TEXT_EVENT_STREAM)
+                    .body(stream(request));
+        }
+        return ResponseEntity.ok(run(request));
+    }
+
+    private SseEmitter stream(CreateResponseRequest request) {
+        SseEmitter emitter = new SseEmitter(0L);        // a turn can take minutes
+
+        ModelResolver.Resolution resolution = models.resolve(request.model());
+        Session session = sessions.bind(request, resolution);
+
+        // The response object every lifecycle frame repeats. It is filled in
+        // as soon as the run exists and re-read on each frame, so a later
+        // frame carries the later state.
+        AtomicReference<ResponseDto> current = new AtomicReference<>();
+        StreamEvents events = new StreamEvents(current::get, mapper);
+
+        Response created = backend.responses().create(new ResponseRequest(
+                session.id(), mapper.toItems(request.input()), true, java.util.List.of()));
+        current.set(mapper.toDto(created, request.model()));
+
+        var subscription = backend.responses().subscribe(
+                SubscribeRequest.replay(created.id()),
+                event -> {
+                    // Refresh before writing: a lifecycle frame must not
+                    // announce "completed" while carrying the queued object.
+                    backend.responses().get(created.id())
+                            .ifPresent(r -> current.set(mapper.toDto(r, request.model())));
+                    StreamEvents.Frame frame = events.frameFor(event);
+                    if (frame == null) {
+                        return;
+                    }
+                    try {
+                        emitter.send(SseEmitter.event().name(frame.event()).data(frame.data()));
+                    } catch (Exception e) {
+                        // The client hung up. Nothing to recover: the run
+                        // continues and its result stays retrievable by id.
+                        log.debug("Responses stream {} dropped: {}", created.id(), e.toString());
+                        return;
+                    }
+                    if (StreamEvents.isTerminal(event)) {
+                        // The run is over, so the stream is too. A client
+                        // reads until the connection closes; holding it open
+                        // makes a finished response look like a thinking one.
+                        try {
+                            emitter.complete();
+                        } catch (Exception ignore) {
+                            // already gone
+                        }
+                    }
+                });
+
+        emitter.onCompletion(subscription::close);
+        emitter.onError(t -> subscription.close());
+        emitter.onTimeout(subscription::close);
+        return emitter;
+    }
+
+    @GetMapping(value = "/responses/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> get(@PathVariable String id) {
+        return backend.responses().get(id)
+                .<ResponseEntity<?>>map(r -> ResponseEntity.ok(mapper.toDto(r, r.agentName())))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(error("not_found", "No response with id '" + id + "'.")));
+    }
+
+    @PostMapping(value = "/responses/{id}/cancel", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> cancel(@PathVariable String id) {
+        if (!backend.responses().cancel(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(error("not_found", "No cancellable response with id '" + id + "'."));
+        }
+        return get(id);
+    }
+
+    private ResponseDto run(CreateResponseRequest request) {
+        ModelResolver.Resolution resolution = models.resolve(request.model());
+        Session session = sessions.bind(request, resolution);
+        Response response = backend.responses().create(new ResponseRequest(
+                session.id(), mapper.toItems(request.input()),
+                request.detached(), java.util.List.of()));
+        return mapper.toDto(response, request.model());
+    }
+
+    static Map<String, Object> error(String type, String message) {
+        return Map.of("error", Map.of("type", type, "message", message));
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesErrors.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesErrors.java
@@ -1,0 +1,66 @@
+package ai.mindconnect.agent.responses.controller;
+
+import ai.mindconnect.agent.responses.ModelResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+/**
+ * Failures in the shape an OpenAI client can read.
+ *
+ * <p>Without this the container's own error page answers, and an SDK reports
+ * a mistyped model as {@code InternalServerError} with a stack-trace-shaped
+ * body — the caller learns that something broke, but not that the name was
+ * wrong or what names exist. The client library parses
+ * {@code {"error": {"type", "message"}}}, so that is what is sent.
+ *
+ * <p>Scoped to this package: the rest of the application keeps its own error
+ * handling, which speaks to its own clients.
+ */
+@RestControllerAdvice(basePackageClasses = ResponsesController.class)
+public class ResponsesErrors {
+
+    private static final Logger log = LoggerFactory.getLogger(ResponsesErrors.class);
+
+    /** A model name that is neither an agent nor an llm-config. */
+    @ExceptionHandler(ModelResolver.UnknownModelException.class)
+    public ResponseEntity<Map<String, Object>> unknownModel(ModelResolver.UnknownModelException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(error("invalid_request_error", e.getMessage(), "model"));
+    }
+
+    /** A request this server understands but cannot accept as sent. */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> badRequest(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(error("invalid_request_error", e.getMessage(), null));
+    }
+
+    /**
+     * Anything else. The message is passed on rather than hidden: this API
+     * is reached by developers pointing a client at their own server, and a
+     * generic "internal error" would cost them the one clue they have.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> unexpected(Exception e) {
+        log.error("Responses API failed", e);
+        String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(error("server_error", message, null));
+    }
+
+    private static Map<String, Object> error(String type, String message, String param) {
+        Map<String, Object> error = new java.util.LinkedHashMap<>();
+        error.put("type", type);
+        error.put("message", message);
+        if (param != null) {
+            error.put("param", param);
+        }
+        return Map.of("error", error);
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/wire/CreateResponseRequest.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/wire/CreateResponseRequest.java
@@ -1,0 +1,70 @@
+package ai.mindconnect.agent.responses.wire;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The body of {@code POST /v1/responses}, as an OpenAI client sends it.
+ *
+ * <p>Unknown fields are ignored rather than rejected. A client SDK sends what
+ * its own version knows about, and refusing a request over a field this
+ * server has no opinion on would make the API usable only from the SDK
+ * version it was written against.
+ *
+ * @param model               which agent answers — see
+ *                            {@code ModelResolver}. An OpenAI client has no
+ *                            other field to choose with.
+ * @param input               a bare string, or the array form of items.
+ * @param instructions        per-request system prompt; overrides the
+ *                            agent's own for this response.
+ * @param stream              {@code true} switches the response to SSE.
+ * @param previousResponseId  continues the conversation that response
+ *                            belongs to.
+ * @param conversation        a conversation id — a Mindconnect session.
+ * @param background          run detached; the client subscribes separately.
+ * @param tools               client-side tool definitions. Accepted into the
+ *                            model but refused at execution: this runtime
+ *                            runs tools inside the turn.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CreateResponseRequest(
+        @JsonProperty("model") String model,
+        @JsonProperty("input") JsonNode input,
+        @JsonProperty("instructions") String instructions,
+        @JsonProperty("stream") Boolean stream,
+        @JsonProperty("previous_response_id") String previousResponseId,
+        @JsonProperty("conversation") JsonNode conversation,
+        @JsonProperty("background") Boolean background,
+        @JsonProperty("store") Boolean store,
+        @JsonProperty("metadata") Map<String, Object> metadata,
+        @JsonProperty("tools") List<JsonNode> tools
+) {
+
+    public boolean streaming() {
+        return Boolean.TRUE.equals(stream);
+    }
+
+    public boolean detached() {
+        return Boolean.TRUE.equals(background);
+    }
+
+    /**
+     * The conversation id, whichever way the client spelled it. The field is
+     * a string in most SDKs and an object with an {@code id} in some — both
+     * appear in OpenAI's own examples.
+     */
+    public String conversationId() {
+        if (conversation == null || conversation.isNull()) {
+            return null;
+        }
+        if (conversation.isTextual()) {
+            return conversation.asText();
+        }
+        JsonNode id = conversation.get("id");
+        return id != null && id.isTextual() ? id.asText() : null;
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/wire/ResponseDto.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/wire/ResponseDto.java
@@ -1,0 +1,92 @@
+package ai.mindconnect.agent.responses.wire;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The {@code response} object an OpenAI client expects back, from
+ * {@code POST /v1/responses}, {@code GET /v1/responses/{id}}, and inside
+ * every lifecycle event of the stream.
+ *
+ * <p>Nulls are omitted. A client that checks {@code if response.error} must
+ * not see an explicit {@code null} turn into a truthy empty object in some
+ * language's JSON binding.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResponseDto(
+        @JsonProperty("id") String id,
+        @JsonProperty("object") String object,
+        @JsonProperty("created_at") long createdAt,
+        @JsonProperty("status") String status,
+        @JsonProperty("model") String model,
+        @JsonProperty("output") List<OutputItemDto> output,
+        @JsonProperty("output_text") String outputText,
+        @JsonProperty("usage") UsageDto usage,
+        @JsonProperty("error") ErrorDto error,
+        @JsonProperty("incomplete_details") IncompleteDetailsDto incompleteDetails,
+        @JsonProperty("conversation") ConversationRefDto conversation,
+        @JsonProperty("previous_response_id") String previousResponseId,
+        @JsonProperty("metadata") Map<String, Object> metadata
+) {
+
+    /** One entry of {@code output} — a message, a function call, a reasoning block. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record OutputItemDto(
+            @JsonProperty("id") String id,
+            @JsonProperty("type") String type,
+            @JsonProperty("status") String status,
+            @JsonProperty("role") String role,
+            @JsonProperty("content") List<ContentPartDto> content,
+            // function_call
+            @JsonProperty("call_id") String callId,
+            @JsonProperty("name") String name,
+            @JsonProperty("arguments") String arguments,
+            // function_call_output
+            @JsonProperty("output") String output,
+            // reasoning
+            @JsonProperty("summary") List<ContentPartDto> summary
+    ) { }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ContentPartDto(
+            @JsonProperty("type") String type,
+            @JsonProperty("text") String text,
+            @JsonProperty("image_url") String imageUrl,
+            @JsonProperty("file_id") String fileId,
+            @JsonProperty("filename") String filename
+    ) {
+        public static ContentPartDto outputText(String text) {
+            return new ContentPartDto("output_text", text, null, null, null);
+        }
+
+        public static ContentPartDto inputText(String text) {
+            return new ContentPartDto("input_text", text, null, null, null);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record UsageDto(
+            @JsonProperty("input_tokens") long inputTokens,
+            @JsonProperty("output_tokens") long outputTokens,
+            @JsonProperty("total_tokens") long totalTokens
+    ) { }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ErrorDto(
+            @JsonProperty("code") String code,
+            @JsonProperty("message") String message
+    ) { }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record IncompleteDetailsDto(
+            @JsonProperty("reason") String reason
+    ) { }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ConversationRefDto(
+            @JsonProperty("id") String id
+    ) { }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/config/CorsConfig.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/config/CorsConfig.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.agentrest.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Cross-origin calls to the REST endpoints — a browser app on another
+ * origin talking to {@code /api}, {@code /chat/api} or {@code /v1}. Every
+ * origin may call by default ({@code mindconnect.cors.allowed-origins: *});
+ * an operator narrows it to a list of origins, and then the browser may
+ * also send the session cookie along, which it never does for {@code *}.
+ *
+ * <p>Both server apps scan this package, so both get it. The admin UI app's
+ * security chains enable CORS as well, so a preflight passes the filter
+ * without a login.
+ */
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    private final List<String> allowedOrigins;
+
+    public CorsConfig(@Value("${mindconnect.cors.allowed-origins:*}") String allowedOrigins) {
+        this.allowedOrigins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        List<String> origins = allowedOrigins.isEmpty() ? List.of("*") : allowedOrigins;
+        boolean anyOrigin = origins.contains("*");
+        registry.addMapping("/**")
+                .allowedOriginPatterns(origins.toArray(String[]::new))
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                // Credentials only for named origins: the browser refuses
+                // "*" with credentials anyway, and a wildcard must not carry
+                // the admin session to any site that asks.
+                .allowCredentials(!anyOrigin)
+                .maxAge(3600);
+    }
+}

--- a/website/docs/agents/environment-variables.md
+++ b/website/docs/agents/environment-variables.md
@@ -43,6 +43,7 @@ as an env var in `SCREAMING_SNAKE` form (e.g. `MINDCONNECT_DATA_BASE_DIR`).
 | `mindconnect.code-exec.*` | — | Sandbox limits for `code_execute`: `runtime`, `network`, `languages`, `memory`, `cpus`, `timeout-seconds`, `idle-seconds`. |
 | `mindconnect.vector-store.*` | — | Vector-store backend: `backend`, `dir`, `url`, `user`, `password`, `embedding-config` (default `embeddings`). |
 | `mindconnect.file-store.*` | — | File-store backend: `backend`, `dir`. |
+| `mindconnect.cors.allowed-origins` | `*` | Origins that may call the REST endpoints from a browser (`/api`, `/chat/api`, `/v1`), comma-separated. `*` lets every origin call without credentials; a list of origins may also send the session cookie. Both server apps. |
 | `mindconnect.workflow-admin.dir` | `data/workflows` | Where the workflow admin stores workflows. |
 | `mindconnect.agent.trace.max-per-session` | `50` | LLM call-trace retention per session. |
 

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -33,6 +33,34 @@ the parts that need more explanation than a signature.
 | `GET /api/sessions/{id}/history` | the persisted messages |
 | `DELETE /api/sessions/{id}` | delete the session |
 
+## OpenAI Responses API
+
+The admin UI app also serves OpenAI's Responses API, in OpenAI's own wire
+format, so an official OpenAI SDK talks to a Mindconnect agent after a
+`base_url` change and nothing else (`mc-agent-api-responses-rest`; no
+separate process).
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/responses` | create a response — body as OpenAI defines it: `model`, `input`, `instructions`, `previous_response_id`, `stream`; with `stream: true` (in the body, where the SDKs put it) the answer is the SSE event stream |
+| `GET /v1/responses/{id}` | retrieve a response |
+| `POST /v1/responses/{id}/cancel` | cancel one still running |
+
+Two words mean something else here than at OpenAI. The client's **model**
+is an agent or an LLM config: `model: "web-researcher"` has that agent
+answer with its prompt, tools and sub-agents; `model: "claude-haiku-default"`
+runs the default agent on that model, as a session-level override that
+changes nothing for anyone else. A name that is neither is refused rather
+than quietly answered by something else. The client's **conversation** is a
+session, so `previous_response_id` continues the session that response was
+made in.
+
+Not supported: client-side function tools — this runtime executes tools
+inside the turn instead of handing them back to the caller — and skills.
+
+A browser app on another origin may call this API, like every REST endpoint
+here: `mindconnect.cors.allowed-origins` (default `*`) says which origins.
+
 ## Chat
 
 A turn is streamed, not awaited. `POST` the user's message and read


### PR DESCRIPTION
## What does this PR do?

Mindconnect could already call OpenAI — `mc-agent-protocol-openai` speaks the Responses API as a client. The other direction was missing: nothing served that API, so a caller had to learn Mindconnect's own.

The new `mc-agent-api-responses-rest` serves `/v1/responses` — create, retrieve, cancel, and the SSE stream — in OpenAI's own wire format, so pointing an official SDK at a Mindconnect server is a `base_url` change and nothing else. It is served by the admin UI app; no separate process. Little had to be invented: `mc-agent-protocol` was modelled on the Responses API to begin with, and `mc-agent-protocol-mc-runtime` already runs that protocol against the runtime. This module is the HTTP edge: wire format in, protocol out.

Two words are reinterpreted at the boundary. The client's **model** is an agent or an llm-config: `model: "web-researcher"` has that agent answer with its prompt, tools and sub-agents; `model: "claude-haiku-default"` runs the default agent on that model, as a session-level override so a request never changes the shared agent for everyone else. A name that is neither is refused, because a client that mistyped an agent must not silently get a different one. The client's **conversation** is a session, so `previous_response_id` continues one.

Two things the official SDK found that a hand-rolled curl would not have: the `stream` flag lives in the body (the SDK keeps asking for `application/json`, so splitting the mapping by produced content type made streaming unreachable from every official client), and `output_index` is a position, not a constant — a client resolves a delta by looking up `response.output[output_index]`, which breaks as soon as a response starts with a tool call, the normal case for an agent. A terminal event completes the emitter, or a finished response reads as one still thinking.

Client-side function tools are rejected rather than half-supported: this runtime executes tools inside the turn instead of handing them back, which is the actual difference between the two servers. Skills are not implemented yet either.

Rebased onto `main` (75 commits behind); the only conflict was the changelog, and the module's POM now uses the reactor version like its siblings. Two follow-up commits: Swagger lists `/v1/**` (it was scoped to `/api/**`, which made the API look absent) and `rest-api.md` documents the endpoints and the two reinterpreted words; and the REST endpoints of both server apps answer cross-origin calls — `CorsConfig` in `mc-agent-api-rest`, every origin by default, `mindconnect.cors.allowed-origins` to narrow it, credentials only for a listed origin — so a browser front-end on another port can use the API at all.

Verified on a fresh app: `POST /v1/responses` with an unknown model answers 400 in OpenAI's error format, a preflight from `http://localhost:3000` gets the CORS headers, and Swagger shows the three `/v1` operations beside the 42 `/api` ones.

Verified with the official Python SDK (`openai` 2.48) against a fresh app backed by LM Studio (`gpt-oss-120b`): `responses.create` with an agent as `model` answers (`Blue`); a follow-up with `previous_response_id` continues the session (`Orange`); `responses.retrieve` returns the stored response; `responses.stream` delivers `response.created`, `response.in_progress`, `response.output_item.added`, nine `response.output_text.delta`, `response.output_item.done`, `response.completed`, and `get_final_response()` reports `completed`; an llm-config as `model` runs the default agent on it (`OK`). An unknown `model` is refused with a 400 in OpenAI's error format.

## Affected area

agent runtime (a new server module, wired into the admin UI app) · docs

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [ ] I added/updated tests where it makes sense — the module ships without unit tests; verified against the official OpenAI SDK by hand (see above).
- [x] I updated docs/README if behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

## Related issues

—
