### PR TITLE
The root build knows the Responses API module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <module>agents/server/mc-agent-api-app</module>
         <module>agents/server/mc-agent-chat-ui-rest</module>
         <module>agents/server/mc-agent-admin-ui-rest</module>
+        <module>agents/server/mc-agent-api-responses-rest</module>
         <module>agents/server/mc-agent-admin-ui-app</module>
         <module>agents/client/mc-agent-cli</module>
     </modules>


### PR DESCRIPTION
## What does this PR do?

The root `pom.xml` lists the agents modules one by one, and #46 added `mc-agent-api-responses-rest` to `agents/pom.xml` only. Building the area from `agents/pom.xml` worked, which is how the PR was verified; building from the root — what a fresh checkout and the release do — fails on the admin UI app:

```
Could not find artifact ai.mindconnect:mc-agent-api-responses-rest:jar:0.5.2-…-SNAPSHOT
```

One line: the module joins the root aggregator next to the other server modules. Verified with `mvn install -DskipTests` from the root.

## Affected area

build

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [x] I added/updated tests where it makes sense — nothing to test, a module list.
- [x] I updated docs/README if behaviour changed — no behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

## Related issues

Follow-up to #46.