### PR TITLE
The Responses API takes images and files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **agents:** the Responses API takes images and files. A user message's
+  `content` may carry `input_image` (`image_url` as an http(s) or `data:`
+  URL, or `file_id`) and `input_file` (`file_data` with `filename`,
+  `file_url`, or `file_id`) parts beside `input_text`, as OpenAI defines
+  them; `POST /v1/files` uploads a file once for `file_id`, `GET
+  /v1/files/{id}` and `/content` read it back. A part lands in the file
+  store and on the session like a chat upload — an image or PDF goes to
+  the model with the message, another document is ingested for
+  `vector_search`. Before, a non-text part was dropped without a word and
+  the model answered a question about a file it never saw; now a part the
+  server cannot take is refused with a 400.
+
 - **agents:** the REST endpoints of both server apps — `/api`, `/chat/api`
   and `/v1` — answer cross-origin calls from a browser. Every origin may
   call by default; `mindconnect.cors.allowed-origins` narrows it to a list,

--- a/agents/server/mc-agent-api-responses-rest/pom.xml
+++ b/agents/server/mc-agent-api-responses-rest/pom.xml
@@ -41,6 +41,18 @@
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-message-repository-core</artifactId>
         </dependency>
+        <!-- File support: an uploaded or inline file goes to the host's file
+             store and is attached to the session the way a chat upload is. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-file-store-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-api-rest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/InputParts.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/InputParts.java
@@ -1,0 +1,232 @@
+package ai.mindconnect.agent.responses;
+
+import ai.mindconnect.agent.protocol.item.ContentPart;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * The content parts of a user message, as OpenAI's Responses API defines
+ * them, turned into the protocol's parts:
+ *
+ * <ul>
+ *   <li>{@code input_text} — {@code text}</li>
+ *   <li>{@code input_image} — one of {@code image_url} (an http(s) URL or a
+ *       {@code data:} URL) or {@code file_id}; optional {@code detail}</li>
+ *   <li>{@code input_file} — one of {@code file_data} (a {@code data:} URL,
+ *       with {@code filename}), {@code file_url} or {@code file_id}</li>
+ * </ul>
+ *
+ * <p>A URL is fetched here and carried inline, so the runtime sees every
+ * source the same way; a data URL is decoded; a file id names a file the
+ * client uploaded through {@code /v1/files}. A part of any other type is
+ * refused — the alternative, an answer to the part of the question the
+ * server understood, is worse than an error.
+ */
+final class InputParts {
+
+    /** The most a fetched file may weigh — a document, not a dataset. */
+    static final long MAX_FETCH_BYTES = 25L * 1024 * 1024;
+
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    private InputParts() {}
+
+    /** The parts of a message's {@code content}: a string is one text part. */
+    static List<ContentPart> parse(JsonNode content) {
+        if (content == null || content.isNull()) {
+            return List.of();
+        }
+        if (content.isTextual()) {
+            return List.of(new ContentPart.Text(content.asText()));
+        }
+        if (!content.isArray()) {
+            throw new IllegalArgumentException("A message's 'content' is a string or an array of parts");
+        }
+        List<ContentPart> parts = new ArrayList<>();
+        for (JsonNode part : content) {
+            parts.add(parsePart(part));
+        }
+        return parts;
+    }
+
+    static ContentPart parsePart(JsonNode part) {
+        String type = text(part, "type");
+        if (type == null) {
+            throw new IllegalArgumentException("A content part needs a 'type' (input_text, input_image, input_file)");
+        }
+        return switch (type) {
+            case "input_text", "text" -> new ContentPart.Text(orEmpty(text(part, "text")));
+            case "input_image" -> image(part);
+            case "input_file" -> file(part);
+            default -> throw new IllegalArgumentException("Content parts of type '" + type
+                    + "' are not supported; send input_text, input_image or input_file");
+        };
+    }
+
+    private static ContentPart image(JsonNode part) {
+        String fileId = text(part, "file_id");
+        String url = text(part, "image_url");
+        if (url == null && part.get("image_url") != null && part.get("image_url").isObject()) {
+            // The chat-completions spelling, {"image_url": {"url": …}} — met in the wild.
+            url = text(part.get("image_url"), "url");
+        }
+        ContentPart.MediaSource source;
+        if (fileId != null) {
+            source = new ContentPart.MediaSource.FileId(fileId);
+        } else if (url != null) {
+            source = url.startsWith("data:") ? dataUrl(url) : fetched(url, null);
+        } else {
+            throw new IllegalArgumentException("An input_image needs 'image_url' (an http(s) or data: URL) or 'file_id'");
+        }
+        return new ContentPart.Image(source, detail(text(part, "detail")));
+    }
+
+    private static ContentPart file(JsonNode part) {
+        String fileId = text(part, "file_id");
+        String data = text(part, "file_data");
+        String url = text(part, "file_url");
+        String name = text(part, "filename");
+        if (fileId != null) {
+            return new ContentPart.Document(new ContentPart.MediaSource.FileId(fileId), name);
+        }
+        if (data != null) {
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException("An input_file with 'file_data' needs a 'filename'");
+            }
+            ContentPart.MediaSource.Inline inline = data.startsWith("data:") ? dataUrl(data)
+                    // Bare base64, as some clients send it: the name says what it is.
+                    : new ContentPart.MediaSource.Inline(data, mediaTypeFor(name));
+            return new ContentPart.Document(inline, name);
+        }
+        if (url != null) {
+            return new ContentPart.Document(fetched(url, name), name != null ? name : nameFrom(url));
+        }
+        throw new IllegalArgumentException("An input_file needs 'file_data' (with 'filename'), 'file_url' or 'file_id'");
+    }
+
+    /** {@code data:<media type>;base64,<data>} — the media type may be missing, the encoding must be base64. */
+    static ContentPart.MediaSource.Inline dataUrl(String url) {
+        int comma = url.indexOf(',');
+        if (comma < 0) {
+            throw new IllegalArgumentException("Not a data URL: no ',' between the header and the data");
+        }
+        String header = url.substring("data:".length(), comma);
+        String payload = url.substring(comma + 1).strip();
+        String[] fields = header.split(";");
+        String mediaType = fields[0].isBlank() ? "application/octet-stream" : fields[0].strip();
+        boolean base64 = false;
+        for (String f : fields) {
+            if (f.strip().equalsIgnoreCase("base64")) base64 = true;
+        }
+        if (!base64) {
+            throw new IllegalArgumentException("A data URL must be base64-encoded (data:<type>;base64,…)");
+        }
+        try {
+            Base64.getDecoder().decode(payload);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("The data URL's payload is not valid base64: " + e.getMessage());
+        }
+        return new ContentPart.MediaSource.Inline(payload, mediaType);
+    }
+
+    /** An http(s) URL, fetched now and carried inline — the way OpenAI reads a file_url or image_url. */
+    static ContentPart.MediaSource.Inline fetched(String url, String name) {
+        URI uri;
+        try {
+            uri = URI.create(url);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Not a URL: " + url);
+        }
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!scheme.equals("http") && !scheme.equals("https")) {
+            throw new IllegalArgumentException("Only http(s) URLs can be fetched: " + url);
+        }
+        try {
+            HttpResponse<byte[]> response = HTTP.send(
+                    HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(30)).GET().build(),
+                    HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() / 100 != 2) {
+                throw new IllegalArgumentException("Fetching " + url + " answered HTTP " + response.statusCode());
+            }
+            byte[] body = response.body();
+            if (body.length > MAX_FETCH_BYTES) {
+                throw new IllegalArgumentException("The file at " + url + " is larger than "
+                        + (MAX_FETCH_BYTES / (1024 * 1024)) + " MB");
+            }
+            String mediaType = response.headers().firstValue("content-type")
+                    .map(ct -> ct.split(";")[0].strip())
+                    .filter(ct -> !ct.isBlank())
+                    .orElse(mediaTypeFor(name != null ? name : nameFrom(url)));
+            return new ContentPart.MediaSource.Inline(Base64.getEncoder().encodeToString(body), mediaType);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Fetching " + url + " failed: " + e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException("Fetching " + url + " was interrupted");
+        }
+    }
+
+    static ContentPart.Image.Detail detail(String raw) {
+        if (raw == null) return ContentPart.Image.Detail.AUTO;
+        return switch (raw.toLowerCase(Locale.ROOT)) {
+            case "low" -> ContentPart.Image.Detail.LOW;
+            case "high" -> ContentPart.Image.Detail.HIGH;
+            default -> ContentPart.Image.Detail.AUTO;
+        };
+    }
+
+    /** The last path segment of a URL, or a generic name. */
+    static String nameFrom(String url) {
+        String path = URI.create(url).getPath();
+        if (path == null || path.isBlank() || path.endsWith("/")) return "download";
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    /** A media type from a file name's extension — for a client that sent bare base64 or an untyped URL. */
+    static String mediaTypeFor(String name) {
+        if (name == null) return "application/octet-stream";
+        String n = name.toLowerCase(Locale.ROOT);
+        int dot = n.lastIndexOf('.');
+        String ext = dot < 0 ? "" : n.substring(dot + 1);
+        return switch (ext) {
+            case "pdf" -> "application/pdf";
+            case "png" -> "image/png";
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "gif" -> "image/gif";
+            case "webp" -> "image/webp";
+            case "svg" -> "image/svg+xml";
+            case "txt" -> "text/plain";
+            case "md" -> "text/markdown";
+            case "csv" -> "text/csv";
+            case "json" -> "application/json";
+            case "html", "htm" -> "text/html";
+            case "docx" -> "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+            case "xlsx" -> "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+            case "pptx" -> "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+            default -> "application/octet-stream";
+        };
+    }
+
+    private static String orEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    private static String text(JsonNode node, String field) {
+        if (node == null) return null;
+        JsonNode value = node.get(field);
+        return value != null && value.isTextual() ? value.asText() : null;
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/ResponsesMapper.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/ResponsesMapper.java
@@ -63,7 +63,15 @@ public final class ResponsesMapper {
         // A message is the default: the array form of the simple case omits
         // "type" entirely and carries only role + content.
         if (type == null || "message".equals(type)) {
-            return ConversationItem.Message.user(contentText(node.get("content")));
+            String role = text(node, "role");
+            if (role != null && !role.equalsIgnoreCase("user")) {
+                throw new IllegalArgumentException("Only user messages are accepted as input here; the "
+                        + "conversation keeps the earlier turns — continue it with previous_response_id");
+            }
+            // Text, images and files, as OpenAI defines the parts; the
+            // runtime attaches a file to the session and sends an image
+            // with the message, so the model sees what the client sent.
+            return new ConversationItem.Message(ai.mindconnect.agent.protocol.item.Role.USER, InputParts.parse(node.get("content")));
         }
         if ("function_call_output".equals(type)) {
             return new ConversationItem.FunctionCallOutput(
@@ -73,26 +81,6 @@ public final class ResponsesMapper {
         // Silently dropping it would produce an answer to a question the
         // client did not ask.
         throw new IllegalArgumentException("Input items of type '" + type + "' are not supported");
-    }
-
-    /** Content is a string in the simple form and a list of parts otherwise. */
-    private String contentText(JsonNode content) {
-        if (content == null || content.isNull()) {
-            return "";
-        }
-        if (content.isTextual()) {
-            return content.asText();
-        }
-        StringBuilder text = new StringBuilder();
-        if (content.isArray()) {
-            for (JsonNode part : content) {
-                String t = text(part, "text");
-                if (t != null) {
-                    text.append(t);
-                }
-            }
-        }
-        return text.toString();
     }
 
     // ── Response ────────────────────────────────────────────────────────────

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/config/ResponsesApiConfiguration.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/config/ResponsesApiConfiguration.java
@@ -41,13 +41,34 @@ public class ResponsesApiConfiguration {
     @Value("${mindconnect.responses.user-id:mc_user}")
     private String userId;
 
+    /**
+     * The backend, with file support when the host has a file store and the
+     * chat's attach service: an {@code input_file} or {@code input_image}
+     * part lands in the store and on the session the way a chat upload
+     * does — a document is ingested for {@code vector_search}, an image or
+     * PDF goes to the model with the message.
+     */
     @Bean
     @ConditionalOnMissingBean
     public AgentRuntimeBackend responsesRuntimeBackend(AgentChatService chat,
                                                        AgentSessionService sessions,
                                                        AgentDefinitionRepository agents,
-                                                       ConversationManager conversations) {
-        return new AgentRuntimeBackend(chat, sessions, agents, conversations, userId);
+                                                       ConversationManager conversations,
+                                                       org.springframework.beans.factory.ObjectProvider<ai.mindconnect.filestore.FileStore> fileStore,
+                                                       org.springframework.beans.factory.ObjectProvider<ai.mindconnect.agentrest.service.SessionFileService> sessionFiles) {
+        var backend = new AgentRuntimeBackend(chat, sessions, agents, conversations, userId);
+        var store = fileStore.getIfAvailable();
+        var attach = sessionFiles.getIfAvailable();
+        if (store != null && attach != null) {
+            backend.withFiles(store, (sessionId, stored) -> {
+                var result = attach.attach(sessionId, stored);
+                if (!result.success()) {
+                    throw new IllegalArgumentException(result.message());
+                }
+                return result.message();
+            });
+        }
+        return backend;
     }
 
     @Bean

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/FilesController.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/FilesController.java
@@ -1,0 +1,100 @@
+package ai.mindconnect.agent.responses.controller;
+
+import ai.mindconnect.agent.protocol.StoredFile;
+import ai.mindconnect.agent.protocol.runtime.AgentRuntimeBackend;
+import ai.mindconnect.filestore.FileStore;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * OpenAI's Files API, as far as a Responses client needs it: upload a file
+ * once, then name it by {@code file_id} in an {@code input_file} or
+ * {@code input_image} part of any number of requests. The file lands in the
+ * runtime's file store — the same one the chat's uploads use — and is
+ * attached to a session only when a request references it.
+ */
+@RestController
+@RequestMapping("/v1")
+public class FilesController {
+
+    private final AgentRuntimeBackend backend;
+    private final ObjectProvider<FileStore> fileStore;
+
+    public FilesController(AgentRuntimeBackend backend, ObjectProvider<FileStore> fileStore) {
+        this.backend = backend;
+        this.fileStore = fileStore;
+    }
+
+    /** {@code POST /v1/files} — multipart, {@code file} and {@code purpose}, as the SDKs send it. */
+    @PostMapping(value = "/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> upload(@RequestParam("file") MultipartFile file,
+                                                      @RequestParam(value = "purpose", required = false) String purpose)
+            throws IOException {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("The uploaded file is empty");
+        }
+        String name = file.getOriginalFilename() == null || file.getOriginalFilename().isBlank()
+                ? "upload" : file.getOriginalFilename();
+        StoredFile stored = backend.files().upload(name, file.getContentType(), file.getBytes());
+        return ResponseEntity.ok(toDto(stored, purpose));
+    }
+
+    @GetMapping(value = "/files/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> get(@PathVariable String id) {
+        return backend.files().get(id)
+                .map(f -> ResponseEntity.ok(toDto(f, null)))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(ResponsesController.error("not_found", "No file with id '" + id + "'.")));
+    }
+
+    @GetMapping("/files/{id}/content")
+    public ResponseEntity<?> content(@PathVariable String id) throws IOException {
+        FileStore store = fileStore.getIfAvailable();
+        if (store == null) {
+            throw new IllegalStateException("File support is not wired on this server");
+        }
+        var stored = store.find(id).orElse(null);
+        if (stored == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ResponsesController.error("not_found", "No file with id '" + id + "'."));
+        }
+        MediaType type = MediaType.APPLICATION_OCTET_STREAM;
+        try {
+            if (stored.contentType() != null) type = MediaType.parseMediaType(stored.contentType());
+        } catch (RuntimeException ignore) {
+            // an odd content type on the record; octet-stream will do
+        }
+        return ResponseEntity.ok()
+                .contentType(type)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + stored.name() + "\"")
+                .body(new InputStreamResource(store.content(id)));
+    }
+
+    /** OpenAI's file object: {@code id, object, bytes, created_at, filename, purpose}. */
+    static Map<String, Object> toDto(StoredFile file, String purpose) {
+        Map<String, Object> dto = new LinkedHashMap<>();
+        dto.put("id", file.id());
+        dto.put("object", "file");
+        dto.put("bytes", file.sizeBytes());
+        dto.put("created_at", System.currentTimeMillis() / 1000);
+        dto.put("filename", file.filename());
+        dto.put("purpose", purpose == null || purpose.isBlank() ? "user_data" : purpose);
+        return dto;
+    }
+}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesErrors.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesErrors.java
@@ -42,6 +42,18 @@ public class ResponsesErrors {
     }
 
     /**
+     * The runtime backend refusing the request — an unknown file id, a part
+     * it cannot take, a session it cannot find. The client sent it, the
+     * client can fix it.
+     */
+    @ExceptionHandler(ai.mindconnect.agent.protocol.runtime.RuntimeBackendException.class)
+    public ResponseEntity<Map<String, Object>> backendRefused(
+            ai.mindconnect.agent.protocol.runtime.RuntimeBackendException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(error("invalid_request_error", e.getMessage(), null));
+    }
+
+    /**
      * Anything else. The message is passed on rather than hidden: this API
      * is reached by developers pointing a client at their own server, and a
      * generic "internal error" would cost them the one clue they have.

--- a/agents/server/mc-agent-api-responses-rest/src/test/java/ai/mindconnect/agent/responses/InputPartsTest.java
+++ b/agents/server/mc-agent-api-responses-rest/src/test/java/ai/mindconnect/agent/responses/InputPartsTest.java
@@ -1,0 +1,108 @@
+package ai.mindconnect.agent.responses;
+
+import ai.mindconnect.agent.protocol.item.ContentPart;
+import ai.mindconnect.agent.protocol.item.ConversationItem;
+import ai.mindconnect.agent.protocol.item.Role;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A user message's parts, as OpenAI spells them: text, an image by data URL
+ * or file id, a file by data, id or URL — and nothing else.
+ */
+class InputPartsTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String PNG_B64 = Base64.getEncoder().encodeToString(new byte[]{(byte) 0x89, 'P', 'N', 'G'});
+    private static final String PDF_B64 = Base64.getEncoder().encodeToString("%PDF-1.4".getBytes());
+
+    @Test
+    void textImageAndFilePartsBecomeProtocolParts() throws Exception {
+        var content = JSON.readTree("""
+                [
+                  {"type": "input_text", "text": "What is this?"},
+                  {"type": "input_image", "image_url": "data:image/png;base64,%s", "detail": "high"},
+                  {"type": "input_image", "file_id": "file-7"},
+                  {"type": "input_file", "filename": "spec.pdf", "file_data": "data:application/pdf;base64,%s"},
+                  {"type": "input_file", "file_id": "file-9"}
+                ]
+                """.formatted(PNG_B64, PDF_B64));
+
+        List<ContentPart> parts = InputParts.parse(content);
+
+        assertThat(parts).hasSize(5);
+        assertThat(parts.get(0)).isEqualTo(new ContentPart.Text("What is this?"));
+        assertThat(parts.get(1)).isEqualTo(new ContentPart.Image(
+                new ContentPart.MediaSource.Inline(PNG_B64, "image/png"), ContentPart.Image.Detail.HIGH));
+        assertThat(parts.get(2)).isEqualTo(new ContentPart.Image(
+                new ContentPart.MediaSource.FileId("file-7"), ContentPart.Image.Detail.AUTO));
+        assertThat(parts.get(3)).isEqualTo(new ContentPart.Document(
+                new ContentPart.MediaSource.Inline(PDF_B64, "application/pdf"), "spec.pdf"));
+        assertThat(parts.get(4)).isEqualTo(new ContentPart.Document(
+                new ContentPart.MediaSource.FileId("file-9"), null));
+    }
+
+    @Test
+    void aStringIsOneTextPart_andTheChatCompletionsImageSpellingIsMet() throws Exception {
+        assertThat(InputParts.parse(JSON.readTree("\"hello\""))).containsExactly(new ContentPart.Text("hello"));
+        assertThat(InputParts.parse(null)).isEmpty();
+        var parts = InputParts.parse(JSON.readTree(
+                "[{\"type\":\"input_image\",\"image_url\":{\"url\":\"data:image/jpeg;base64," + PNG_B64 + "\"}}]"));
+        assertThat(parts.get(0)).isEqualTo(new ContentPart.Image(
+                new ContentPart.MediaSource.Inline(PNG_B64, "image/jpeg"), ContentPart.Image.Detail.AUTO));
+    }
+
+    @Test
+    void whatTheServerCannotTakeIsRefused_notDropped() throws Exception {
+        assertThatThrownBy(() -> InputParts.parse(JSON.readTree("[{\"type\":\"input_audio\",\"input_audio\":{}}]")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("input_audio");
+        assertThatThrownBy(() -> InputParts.parse(JSON.readTree("[{\"text\":\"no type\"}]")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("'type'");
+        assertThatThrownBy(() -> InputParts.parse(JSON.readTree("[{\"type\":\"input_file\",\"file_data\":\"data:text/plain;base64,aGk=\"}]")))
+                .as("file_data without a name").isInstanceOf(IllegalArgumentException.class).hasMessageContaining("filename");
+        assertThatThrownBy(() -> InputParts.parse(JSON.readTree("[{\"type\":\"input_image\"}]")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("image_url");
+        assertThatThrownBy(() -> InputParts.parse(JSON.readTree("[{\"type\":\"input_file\",\"filename\":\"a.pdf\",\"file_data\":\"data:application/pdf,notbase64\"}]")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("base64");
+        assertThatThrownBy(() -> InputParts.fetched("ftp://example.com/x.pdf", null))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("http(s)");
+    }
+
+    @Test
+    void theMapperPutsThePartsIntoAUserMessage_andRefusesOtherRoles() throws Exception {
+        var mapper = new ResponsesMapper(JSON);
+        var items = mapper.toItems(JSON.readTree("""
+                [{"role": "user", "content": [
+                    {"type": "input_text", "text": "Read this"},
+                    {"type": "input_file", "filename": "notes.txt", "file_data": "data:text/plain;base64,aGk="}
+                ]}]
+                """));
+        assertThat(items).hasSize(1);
+        var message = (ConversationItem.Message) items.get(0);
+        assertThat(message.role()).isEqualTo(Role.USER);
+        assertThat(message.content()).containsExactly(
+                new ContentPart.Text("Read this"),
+                new ContentPart.Document(new ContentPart.MediaSource.Inline("aGk=", "text/plain"), "notes.txt"));
+
+        assertThatThrownBy(() -> mapper.toItems(JSON.readTree("[{\"role\":\"assistant\",\"content\":\"earlier\"}]")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("previous_response_id");
+        assertThatThrownBy(() -> mapper.toItems(JSON.readTree("[{\"type\":\"input_text\",\"text\":\"bare part\"}]")))
+                .as("a part outside a message").isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void mediaTypesFollowTheName_andADataUrlMayOmitItsType() {
+        assertThat(InputParts.mediaTypeFor("x.PDF")).isEqualTo("application/pdf");
+        assertThat(InputParts.mediaTypeFor("logo.svg")).isEqualTo("image/svg+xml");
+        assertThat(InputParts.mediaTypeFor("noext")).isEqualTo("application/octet-stream");
+        assertThat(InputParts.dataUrl("data:;base64,aGk=")).isEqualTo(new ContentPart.MediaSource.Inline("aGk=", "application/octet-stream"));
+        assertThat(InputParts.nameFrom("https://x.example/docs/spec.pdf?x=1")).isEqualTo("spec.pdf");
+        assertThat(InputParts.nameFrom("https://x.example/")).isEqualTo("download");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <module>agents/server/mc-agent-api-app</module>
         <module>agents/server/mc-agent-chat-ui-rest</module>
         <module>agents/server/mc-agent-admin-ui-rest</module>
+        <module>agents/server/mc-agent-api-responses-rest</module>
         <module>agents/server/mc-agent-admin-ui-app</module>
         <module>agents/client/mc-agent-cli</module>
     </modules>

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -45,6 +45,17 @@ separate process).
 | `POST /v1/responses` | create a response — body as OpenAI defines it: `model`, `input`, `instructions`, `previous_response_id`, `stream`; with `stream: true` (in the body, where the SDKs put it) the answer is the SSE event stream |
 | `GET /v1/responses/{id}` | retrieve a response |
 | `POST /v1/responses/{id}/cancel` | cancel one still running |
+| `POST /v1/files` | upload a file (multipart `file`, `purpose`) and get its `file_id` for `input_file` / `input_image` parts |
+| `GET /v1/files/{id}`, `GET /v1/files/{id}/content` | the file object, and its bytes |
+
+A user message's `content` may be a string or a list of parts, as OpenAI
+defines them: `input_text` (`text`), `input_image` (`image_url` as an
+http(s) or `data:` URL, or `file_id`; optional `detail`) and `input_file`
+(`file_data` as a `data:` URL with `filename`, `file_url`, or `file_id`). A
+URL is fetched by the server. An image or PDF goes to the model with the
+message when its config declares the capability; any other document is
+ingested into the session's store and reached through `vector_search`. A part
+of another type is refused with a 400 rather than dropped.
 
 Two words mean something else here than at OpenAI. The client's **model**
 is an agent or an LLM config: `model: "web-researcher"` has that agent
@@ -56,7 +67,9 @@ session, so `previous_response_id` continues the session that response was
 made in.
 
 Not supported: client-side function tools — this runtime executes tools
-inside the turn instead of handing them back to the caller — and skills.
+inside the turn instead of handing them back to the caller — skills, and
+messages with a role other than `user` in `input` (the session keeps the
+earlier turns; continue with `previous_response_id`).
 
 A browser app on another origin may call this API, like every REST endpoint
 here: `mindconnect.cors.allowed-origins` (default `*`) says which origins.


### PR DESCRIPTION
## What does this PR do?

The Responses API accepted only text. A user message with an `input_image` or `input_file` part — the shape every OpenAI client sends a picture or a document in — had the part dropped without a word, and the model answered a question about a file it never saw ("I can only describe the image if you show it to me again").

Now a user message's `content` may carry the parts as OpenAI defines them: `input_text` (`text`), `input_image` (`image_url` as an http(s) or `data:` URL, or `file_id`; optional `detail`) and `input_file` (`file_data` as a `data:` URL with `filename`, `file_url`, or `file_id`). A URL is fetched by the server and carried inline (http(s) only, 25 MB cap); a data URL is decoded; a file id names an upload. The protocol already had `ContentPart.Image` / `ContentPart.Document` with URL, inline and file-id sources, and `AgentRuntimeBackend` already attached them to the session — what was missing was the parsing at the HTTP edge (`InputParts`) and the wiring of the backend's file support in the Spring configuration (`withFiles(fileStore, SessionFileService::attach)`). So a part lands where a chat upload lands: an image or PDF goes to the model with the message when the config declares the capability, any other document is ingested into the session's store for `vector_search`.

`POST /v1/files` (multipart `file`, `purpose`), `GET /v1/files/{id}` and `GET /v1/files/{id}/content` are OpenAI's Files API as far as a Responses client needs it — upload once, reference by `file_id` in any number of requests — on the runtime's file store.

A part of a type the server cannot take (`input_audio`, for now) is refused with a 400 naming the accepted types, rather than dropped; a message with a role other than `user` is refused too, pointing at `previous_response_id` (the session keeps earlier turns). A refusal from the runtime backend — an unknown file id, a part it cannot attach — is a 400 as well, not a 500.

The one-line root-POM fix from #47 rides along as a cherry-pick so the branch builds from the root; it disappears on rebase once #47 is merged.

Verified with the official Python SDK (`openai` 2.48) against a fresh app backed by LM Studio: `files.create` / `files.retrieve` / `/content` round-trip a PNG; an `input_file` text document (`data:` URL) is answered from its content ("Frau Mertens, 42 000 EUR"); two `input_image` parts on the same conversation, one by `file_id` and one by data URL, are recorded as attachments the model can name; `input_audio` and an unknown `file_id` are refused with 400.

## Affected area

agent runtime (`mc-agent-api-responses-rest`) · docs

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [x] I added/updated tests where it makes sense — `InputPartsTest` covers the parsing, the refusals and the mapper; the end-to-end path was verified with the SDK as described.
- [x] I updated docs/README if behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

## Related issues

Follow-up to #46; carries the fix from #47 until that is merged.
