### PR TITLE
The user stream, and one connection per shown stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,34 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **agents:** the user stream. `GET /api/users/{userId}/stream` is the coarse
+  feed across all of a user's sessions — `session_started`,
+  `session_titled`, `turn_started`, `turn_finished`, `approval_requested`
+  and `approval_answered` — for a session list, a badge or a notification,
+  without attaching to any session. Same reconnect story as the session
+  stream: an `attached` frame first, then replay after `afterSeq`, then
+  live. In the admin UI the header's task badge now rides on this stream
+  (`/admin/api/stream`) instead of one of its own, and the chat's history
+  shows which conversations are `running` or `need input` — in every tab,
+  whichever one sent the message.
+
+### Fixed
+
+- **agents:** the admin UI could stop responding once a browser profile held
+  six server-sent event streams to the server — every request stalled in
+  the browser, which looked like a server hang. Two things fed it: the
+  session and task streams did not commit their response until the first
+  event (on a quiet session, the next heartbeat), so for up to 25 s the SPA
+  did not know it held a connection and a second page render opened a
+  second one; and the task badge held a stream per tab beside the chat's.
+  A stream is now committed the moment it attaches, and the badge shares
+  the user stream. The client-side part — a stream is closed when its page
+  is left, a reconnect registers before its request rather than after — is
+  semantic-ui 0.3.1, which this release depends on. The tabs also watch the
+  budget themselves: each one counts the streams it holds, they tell each
+  other, and a notice appears in every tab once the browser is within one
+  connection of that limit, naming the count and the number of tabs.
+
 - **agents:** the Responses API takes images and files. A user message's
   `content` may carry `input_image` (`image_url` as an http(s) or `data:`
   URL, or `file_id`) and `input_file` (`file_data` with `filename`,

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
@@ -428,9 +428,11 @@ public final class AgentRuntimeBuilder {
                 : sql != null ? new ai.mindconnect.agent.adapter.pg.PgLlmCallTraceRepository(sql).initSchema()
                 : new ai.mindconnect.agent.adapter.file.FileLlmCallTraceRepository(dataDir);
         var approvalStore = new ai.mindconnect.agent.service.approval.ToolApprovalStore();
+        var userChannels = new ai.mindconnect.agent.service.stream.UserChannels();
         AgentSessionService sessionService = new AgentSessionService(
                 definitionRepository, sessionRepository, conversationManager,
-                workingMemoryRepository, summaryRepository, todoListRepository, approvalStore);
+                workingMemoryRepository, summaryRepository, todoListRepository, approvalStore,
+                userChannels);
         var sessionChannels = new ai.mindconnect.agent.service.stream.SessionChannels();
         var turnWorker = new ai.mindconnect.agent.service.task.AgentTurnWorker(
                 conversationManager, definitionRepository, sessionService,
@@ -440,7 +442,7 @@ public final class AgentRuntimeBuilder {
         var toolWorker = new ai.mindconnect.agent.service.task.ToolCallWorker(
                 conversationManager, definitionRepository, sessionService,
                 memoryStrategyFactory, toolRegistry, activations, toolExecutor, sessionChannels,
-                approvalStore);
+                approvalStore, userChannels);
         var taskQueue = new ai.mindconnect.taskqueue.local.LocalTaskQueue(
                 new ai.mindconnect.taskqueue.memory.InMemoryTaskStore());
         toolWorker.attach(taskQueue);
@@ -448,7 +450,7 @@ public final class AgentRuntimeBuilder {
         taskQueue.register(ai.mindconnect.agent.service.task.ToolCallWorker.TYPE, toolWorker);
         AgentChatService chatService = new AgentChatService(sessionService, definitionRepository,
                 conversationManager, memoryStrategyFactory, workingMemoryRepository, promptRenderer,
-                statelessRunner, sessionChannels, taskQueue, approvalStore, turnExecutor);
+                statelessRunner, sessionChannels, userChannels, taskQueue, approvalStore, turnExecutor);
 
         // 7. Seed configs, agents, workflows.
         for (LlmConfig config : pendingLlmConfigs) llmConfigRepository.save(config);

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentChatService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentChatService.java
@@ -19,6 +19,7 @@ import ai.mindconnect.agent.port.out.TokenCounter;
 import ai.mindconnect.agent.service.approval.ToolApproval;
 import ai.mindconnect.agent.service.approval.ToolApprovalStore;
 import ai.mindconnect.agent.service.stream.SessionChannels;
+import ai.mindconnect.agent.service.stream.UserEvent;
 import ai.mindconnect.agent.service.stream.SessionEvent;
 import ai.mindconnect.channel.Channel;
 import ai.mindconnect.channel.Subscription;
@@ -76,6 +77,7 @@ public class AgentChatService {
     private final PromptRenderer promptRenderer;
     private final AgentTaskRunner agentTaskRunner;
     private final SessionChannels sessionChannels;
+    private final ai.mindconnect.agent.service.stream.UserChannels userChannels;
     private final TaskQueue queue;
     private final ToolApprovalStore approvalStore;
     private final ExecutorService turnExecutor;
@@ -88,6 +90,7 @@ public class AgentChatService {
                             PromptRenderer promptRenderer,
                             AgentTaskRunner agentTaskRunner,
                             SessionChannels sessionChannels,
+                            ai.mindconnect.agent.service.stream.UserChannels userChannels,
                             TaskQueue queue,
                             ToolApprovalStore approvalStore,
                             ExecutorService turnExecutor) {
@@ -99,6 +102,7 @@ public class AgentChatService {
         this.promptRenderer = promptRenderer;
         this.agentTaskRunner = agentTaskRunner;
         this.sessionChannels = sessionChannels;
+        this.userChannels = userChannels;
         this.queue = queue;
         this.approvalStore = approvalStore;
         this.turnExecutor = turnExecutor;
@@ -166,7 +170,7 @@ public class AgentChatService {
 
         // 2.+3. Listen on the turn's channel, make the turn a task — the queue
         //        is the only registry of running work, nothing is tracked here.
-        return startTurn(sessionId, turnId, 0, eventHandler, response -> {
+        return startTurn(session, turnId, 0, eventHandler, response -> {
             generateTitleIfNeeded(session, isFirstMessage, userMessage, response);
             return response;
         });
@@ -177,17 +181,48 @@ public class AgentChatService {
      * channel, submit the {@code agent.turn} task, wrap the queue's await in
      * the handle's future. Channel cleanup is graceful — the queued tail
      * (Done included) is delivered before detaching.
+     *
+     * <p>The user's stream hears the turn begin and end here — the one place
+     * every top-level turn passes through, whichever client submitted it.
      */
-    private ChatTurnHandle startTurn(UUID sessionId, UUID turnId, int run,
+    private ChatTurnHandle startTurn(AgentSession session, UUID turnId, int run,
                                      Consumer<StreamEvent> eventHandler,
                                      java.util.function.UnaryOperator<String> afterCompletion) {
+        UUID sessionId = session.id();
         var subscription = sessionChannels.subscribeTurn(sessionId, turnId, eventHandler);
         String taskId = queue.submit(AgentTurnWorker.submission(turnId, run, sessionId, 0, null));
+        userChannels.publish(session.userId(), new UserEvent.TurnStarted(sessionId, turnId));
         CompletableFuture<String> future = CompletableFuture
                 .supplyAsync(() -> awaitResult(taskId), turnExecutor)
-                .whenComplete((response, error) -> subscription.close())
+                .whenComplete((response, error) -> {
+                    subscription.close();
+                    userChannels.publish(session.userId(),
+                            new UserEvent.TurnFinished(sessionId, turnId, outcomeOf(error)));
+                })
                 .thenApply(afterCompletion);
         return new LocalChatTurnHandle(turnId, sessionId, future, () -> cancelChat(sessionId));
+    }
+
+    /** How the turn ended, read off the await's failure — or its absence. */
+    private static UserEvent.TurnOutcome outcomeOf(Throwable error) {
+        if (error == null) return UserEvent.TurnOutcome.COMPLETED;
+        Throwable cause = error instanceof java.util.concurrent.CompletionException && error.getCause() != null
+                ? error.getCause() : error;
+        return cause instanceof CancellationException
+                ? UserEvent.TurnOutcome.CANCELLED : UserEvent.TurnOutcome.FAILED;
+    }
+
+    /**
+     * Announces {@code event} on the stream of the user who owns
+     * {@code sessionId}. Best-effort: a session that cannot be read is not
+     * announced, and the operation that raised the event is not affected.
+     */
+    private void announce(UUID sessionId, UserEvent event) {
+        try {
+            userChannels.publish(sessionService.findSession(sessionId).userId(), event);
+        } catch (RuntimeException e) {
+            log.debug("User event {} for session {} not announced: {}", event, sessionId, e.toString());
+        }
     }
 
     /**
@@ -251,6 +286,7 @@ public class AgentChatService {
         }
         log.info("Approval answer for call {} ({}, scope {}) delivered to task {}",
                 callId, approved ? "granted" : "denied", scope, open.toolTaskId());
+        announce(rootSessionId, new UserEvent.ApprovalAnswered(rootSessionId, callId, approved));
         return true;
     }
 
@@ -389,6 +425,7 @@ public class AgentChatService {
             title = userMessage;
         }
         sessionService.updateTitle(session.id(), title);
+        userChannels.publish(session.userId(), new UserEvent.SessionTitled(session.id(), title));
     }
 
     // ── Memory ─────────────────────────────────────────────────────────────

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentSessionService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentSessionService.java
@@ -41,6 +41,7 @@ public class AgentSessionService {
     private final ConversationSummaryRepository summaryRepository;
     private final TodoListRepository todoListRepository;
     private final ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore;
+    private final ai.mindconnect.agent.service.stream.UserChannels userChannels;
 
     public AgentSessionService(AgentDefinitionRepository definitionRepository,
                                 AgentSessionRepository sessionRepository,
@@ -48,7 +49,8 @@ public class AgentSessionService {
                                 WorkingMemoryRepository workingMemoryRepository,
                                 ConversationSummaryRepository summaryRepository,
                                 TodoListRepository todoListRepository,
-                                ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore) {
+                                ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore,
+                                ai.mindconnect.agent.service.stream.UserChannels userChannels) {
         this.definitionRepository = definitionRepository;
         this.sessionRepository = sessionRepository;
         this.conversationManager = conversationManager;
@@ -56,6 +58,7 @@ public class AgentSessionService {
         this.summaryRepository = summaryRepository;
         this.todoListRepository = todoListRepository;
         this.approvalStore = approvalStore;
+        this.userChannels = userChannels;
     }
 
     /**
@@ -105,7 +108,14 @@ public class AgentSessionService {
 
         AgentSession session = AgentSession.startSubAgent(agentDefinitionId, namespace, userId,
                 conversation.id(), parentSessionId, parentTurnId, parentToolCallId);
-        return sessionRepository.save(session);
+        AgentSession saved = sessionRepository.save(session);
+        // A sub-agent's session is the parent turn's business, not news for
+        // the user's session list.
+        if (parentSessionId == null) {
+            userChannels.publish(userId, new ai.mindconnect.agent.service.stream.UserEvent
+                    .SessionStarted(saved.id(), agentDefinitionId));
+        }
+        return saved;
     }
 
     /**
@@ -131,7 +141,10 @@ public class AgentSessionService {
         AgentSession session = AgentSession
                 .start(agent.id(), namespace, userId, conversation.id())
                 .withSessionAgents(List.of(agent));
-        return sessionRepository.save(session);
+        AgentSession saved = sessionRepository.save(session);
+        userChannels.publish(userId, new ai.mindconnect.agent.service.stream.UserEvent
+                .SessionStarted(saved.id(), agent.id()));
+        return saved;
     }
 
     /**

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/stream/UserChannels.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/stream/UserChannels.java
@@ -1,0 +1,75 @@
+package ai.mindconnect.agent.service.stream;
+
+import ai.mindconnect.channel.Channel;
+import ai.mindconnect.channel.ChannelRegistry;
+import ai.mindconnect.channel.Subscription;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+/**
+ * One ring-buffered channel per user, carrying the coarse {@link UserEvent}s
+ * of every session that user owns. The counterpart of {@link SessionChannels}
+ * one level up: a session's stream is what a client attaches to while it
+ * looks at that session; the user's stream is what it keeps attached the
+ * whole time, so it hears about the sessions it is not looking at.
+ *
+ * <p>Same delivery model as the session channels — a monotonic {@code seq}
+ * per user as the reconnect cursor, replay from the buffer, then live — and
+ * the same rule: the channel is delivery, never storage. A missed event
+ * costs a badge update, not data; the persisted sessions and approvals are
+ * the truth a client reloads from. Channels nobody listens to are evicted
+ * after idling {@link #IDLE_EVICTION}.
+ *
+ * <p>Publishing is a fire-and-forget from inside a turn or a session
+ * operation and must never fail that operation: a {@code null} user (a
+ * session without an owner) is simply not announced.
+ */
+public final class UserChannels {
+
+    private static final Duration IDLE_EVICTION = Duration.ofMinutes(10);
+
+    private final ChannelRegistry registry;
+
+    public UserChannels() {
+        this(new ChannelRegistry().withIdleEviction(IDLE_EVICTION));
+    }
+
+    public UserChannels(ChannelRegistry registry) {
+        this.registry = registry;
+    }
+
+    /** Announces {@code event} to every client attached to {@code userId}'s stream. */
+    public void publish(String userId, UserEvent event) {
+        if (userId == null || userId.isBlank() || event == null) return;
+        channel(userId).publish(event);
+    }
+
+    /**
+     * Attach to the user's stream: replay everything after {@code afterSeq}
+     * from the buffer, then continue live. The event's {@code seq} is the
+     * cursor for the next reconnect.
+     */
+    public Subscription subscribe(String userId, long afterSeq,
+                                  Consumer<Channel.Event<UserEvent>> consumer) {
+        return channel(userId).subscribe(afterSeq, consumer);
+    }
+
+    /** The newest sequence the user's stream has seen (0 when nothing happened). */
+    public long lastSeq(String userId) {
+        return channel(userId).lastSeq();
+    }
+
+    /** The oldest sequence still in the buffer — everything before it is gone. */
+    public long earliestBufferedSeq(String userId) {
+        return channel(userId).earliestBufferedSeq();
+    }
+
+    private Channel<UserEvent> channel(String userId) {
+        return registry.channel(id(userId));
+    }
+
+    private static String id(String userId) {
+        return "user_" + userId;
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/stream/UserEvent.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/stream/UserEvent.java
@@ -1,0 +1,49 @@
+package ai.mindconnect.agent.service.stream;
+
+import java.util.UUID;
+
+/**
+ * What a user's clients learn about their sessions without being attached
+ * to any one of them: a session was opened or got its title, a turn began
+ * or ended, a tool waits for an answer. Coarse on purpose — the tokens and
+ * tool calls of a turn stay on the session's own stream
+ * ({@link SessionChannels}); this is the feed a session list, a header badge
+ * or a notification reads, and what lets a second client find out that
+ * something happened in a session it is not looking at.
+ *
+ * <p>Every event names its session. The user is not on the event because the
+ * channel is the user's ({@link UserChannels}); an event never crosses users.
+ */
+public sealed interface UserEvent
+        permits UserEvent.SessionStarted, UserEvent.SessionTitled,
+                UserEvent.TurnStarted, UserEvent.TurnFinished,
+                UserEvent.ApprovalRequested, UserEvent.ApprovalAnswered {
+
+    /** The session this happened in — the root session for a bubbled approval. */
+    UUID sessionId();
+
+    /** How a turn ended, as far as the caller who submitted it can tell. */
+    enum TurnOutcome { COMPLETED, FAILED, CANCELLED }
+
+    /** A top-level session was opened. Sub-agent sessions do not announce themselves. */
+    record SessionStarted(UUID sessionId, UUID agentDefinitionId) implements UserEvent {}
+
+    /** The session got its generated title after the first exchange. */
+    record SessionTitled(UUID sessionId, String title) implements UserEvent {}
+
+    /** A turn was submitted; the session's own stream carries what it does. */
+    record TurnStarted(UUID sessionId, UUID turnId) implements UserEvent {}
+
+    /** The turn's task reached a terminal state, or the wait for it ended. */
+    record TurnFinished(UUID sessionId, UUID turnId, TurnOutcome outcome) implements UserEvent {}
+
+    /**
+     * A tool waits at the approval gate. {@code sessionId} is the ROOT
+     * session — the one whose chat shows the card, even when a sub-agent
+     * asked — so a client can navigate straight to where the answer goes.
+     */
+    record ApprovalRequested(UUID sessionId, String callId, String toolName) implements UserEvent {}
+
+    /** The question was answered (from any client) and the tool's task was told. */
+    record ApprovalAnswered(UUID sessionId, String callId, boolean approved) implements UserEvent {}
+}

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/ToolCallWorker.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/task/ToolCallWorker.java
@@ -80,6 +80,7 @@ public final class ToolCallWorker implements TaskWorker {
     private final DynamicToolActivations dynamicToolActivations;
     private final ToolExecutor toolExecutor;
     private final SessionChannels sessionChannels;
+    private final ai.mindconnect.agent.service.stream.UserChannels userChannels;
     private final ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore;
     private final SubAgentCalls subAgents;
 
@@ -91,7 +92,8 @@ public final class ToolCallWorker implements TaskWorker {
                           DynamicToolActivations dynamicToolActivations,
                           ToolExecutor toolExecutor,
                           SessionChannels sessionChannels,
-                          ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore) {
+                          ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore,
+                          ai.mindconnect.agent.service.stream.UserChannels userChannels) {
         this.conversationManager = conversationManager;
         this.definitionRepository = definitionRepository;
         this.sessionService = sessionService;
@@ -101,6 +103,7 @@ public final class ToolCallWorker implements TaskWorker {
         this.toolExecutor = toolExecutor;
         this.sessionChannels = sessionChannels;
         this.approvalStore = approvalStore;
+        this.userChannels = userChannels;
         this.subAgents = new SubAgentCalls(conversationManager, definitionRepository,
                 sessionService, memoryStrategyFactory, sessionChannels);
     }
@@ -276,6 +279,10 @@ public final class ToolCallWorker implements TaskWorker {
             log.info("Tool '{}' (call {}) waits at the approval gate — card registered for root session {}",
                     toolName, callId, root.id());
             publishApprovalCard(root, entry, arguments);
+            // The user's own stream too, so a client that is not looking at
+            // this chat — a session list, another tab — learns someone waits.
+            userChannels.publish(root.userId(), new ai.mindconnect.agent.service.stream.UserEvent
+                    .ApprovalRequested(root.id(), callId, toolName));
         }
         return Gate.WAIT;
     }

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/stream/UserChannelsTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/stream/UserChannelsTest.java
@@ -1,0 +1,64 @@
+package ai.mindconnect.agent.service.stream;
+
+import ai.mindconnect.channel.Channel;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserChannelsTest {
+
+    private final UserChannels channels = new UserChannels();
+    private final UUID session = UUID.randomUUID();
+    private final UUID turn = UUID.randomUUID();
+
+    @Test
+    void eventsReachOnlyTheirUsersStream() {
+        List<Channel.Event<UserEvent>> alice = new CopyOnWriteArrayList<>();
+        List<Channel.Event<UserEvent>> bob = new CopyOnWriteArrayList<>();
+        channels.subscribe("alice", 0, alice::add);
+        channels.subscribe("bob", 0, bob::add);
+
+        channels.publish("alice", new UserEvent.TurnStarted(session, turn));
+        channels.publish("alice", new UserEvent.TurnFinished(session, turn, UserEvent.TurnOutcome.COMPLETED));
+
+        awaitSize(alice, 2);
+        assertThat(alice.get(0).value()).isInstanceOf(UserEvent.TurnStarted.class);
+        assertThat(alice.get(1).value()).isInstanceOf(UserEvent.TurnFinished.class);
+        assertThat(alice.get(1).seq()).isGreaterThan(alice.get(0).seq());
+        assertThat(bob).isEmpty();
+    }
+
+    @Test
+    void afterSeqReplaysTheBufferedTailThenContinuesLive() {
+        channels.publish("alice", new UserEvent.SessionStarted(session, UUID.randomUUID()));
+        channels.publish("alice", new UserEvent.TurnStarted(session, turn));
+        long cursor = channels.lastSeq("alice") - 1;   // "I saw the session start"
+
+        List<Channel.Event<UserEvent>> seen = new CopyOnWriteArrayList<>();
+        channels.subscribe("alice", cursor, seen::add);
+        channels.publish("alice", new UserEvent.SessionTitled(session, "Hello"));
+
+        awaitSize(seen, 2);
+        assertThat(seen.get(0).value()).isInstanceOf(UserEvent.TurnStarted.class);
+        assertThat(seen.get(1).value()).isEqualTo(new UserEvent.SessionTitled(session, "Hello"));
+    }
+
+    @Test
+    void aSessionWithoutAnOwnerIsNotAnnounced() {
+        channels.publish(null, new UserEvent.TurnStarted(session, turn));
+        channels.publish("", new UserEvent.TurnStarted(session, turn));
+        assertThat(channels.lastSeq("")).isZero();
+    }
+
+    private static void awaitSize(List<?> list, int size) {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (list.size() < size && System.currentTimeMillis() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertThat(list).hasSize(size);
+    }
+}

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/config/DefaultAgentRuntimeConfig.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/config/DefaultAgentRuntimeConfig.java
@@ -18,6 +18,7 @@ import ai.mindconnect.agent.tools.toolsearch.DynamicToolActivations;
 import ai.mindconnect.agent.tools.workspace.WorkspaceStore;
 import ai.mindconnect.agent.service.AgentChatService;
 import ai.mindconnect.agent.service.stream.SessionChannels;
+import ai.mindconnect.agent.service.stream.UserChannels;
 import ai.mindconnect.agent.service.task.AgentTurnWorker;
 import ai.mindconnect.agent.service.task.ToolCallWorker;
 import ai.mindconnect.taskqueue.local.LocalTaskQueue;
@@ -330,10 +331,11 @@ public class DefaultAgentRuntimeConfig {
                                              WorkingMemoryRepository workingMemoryRepository,
                                              ConversationSummaryRepository conversationSummaryRepository,
                                              TodoListRepository todoListRepository,
-                                             ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore) {
+                                             ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore,
+                                             UserChannels userChannels) {
         return new AgentSessionService(definitionRepository, sessionRepository,
                 conversationManager, workingMemoryRepository, conversationSummaryRepository,
-                todoListRepository, approvalStore);
+                todoListRepository, approvalStore, userChannels);
     }
 
     /**
@@ -388,10 +390,11 @@ public class DefaultAgentRuntimeConfig {
                                   DynamicToolActivations dynamicToolActivations,
                                   ToolExecutor toolExecutor,
                                   SessionChannels sessionChannels,
-                                  ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore) {
+                                  ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore,
+                                  UserChannels userChannels) {
         return new ToolCallWorker(conversationManager, definitionRepository, sessionService,
                 memoryStrategyFactory, toolRegistry, dynamicToolActivations, toolExecutor,
-                sessionChannels, approvalStore);
+                sessionChannels, approvalStore, userChannels);
     }
 
     @Bean
@@ -403,12 +406,13 @@ public class DefaultAgentRuntimeConfig {
                                        PromptRenderer promptRenderer,
                                        AgentTaskRunner agentTaskRunner,
                                        SessionChannels sessionChannels,
+                                       UserChannels userChannels,
                                        LocalTaskQueue taskQueue,
                                        ai.mindconnect.agent.service.approval.ToolApprovalStore approvalStore,
                                        ExecutorService turnExecutor) {
         return new AgentChatService(sessionService, definitionRepository, conversationManager,
                 memoryStrategyFactory, workingMemoryRepository, promptRenderer,
-                agentTaskRunner, sessionChannels, taskQueue, approvalStore, turnExecutor);
+                agentTaskRunner, sessionChannels, userChannels, taskQueue, approvalStore, turnExecutor);
     }
 
     /**
@@ -419,5 +423,16 @@ public class DefaultAgentRuntimeConfig {
     @Bean
     public SessionChannels sessionChannels() {
         return new SessionChannels();
+    }
+
+    /**
+     * The users' streams — the coarse feed (session opened, turn started
+     * and finished, approval pending) a client keeps attached while it is
+     * not looking at any particular session. A bean of its own for the same
+     * reason as the session channels: SSE adapters subscribe by user id.
+     */
+    @Bean
+    public UserChannels userChannels() {
+        return new UserChannels();
     }
 }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/TaskMonitor.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/TaskMonitor.java
@@ -1,6 +1,5 @@
 package ai.mindconnect.adminui.service;
 
-import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
 import ai.mindconnect.agent.domain.AgentDefinition;
 import ai.mindconnect.agent.domain.AgentSession;
 import ai.mindconnect.agent.port.out.AgentDefinitionRepository;
@@ -14,13 +13,10 @@ import ai.mindconnect.taskqueue.TaskListener;
 import ai.mindconnect.taskqueue.TaskRecord;
 import ai.mindconnect.taskqueue.TaskStatus;
 import ai.mindconnect.taskqueue.local.LocalTaskQueue;
-import ai.mindconnect.ui.model.UiPatch;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -30,12 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 /**
  * The task manager behind the header's task badge: what the task queue is
@@ -47,12 +43,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *   <li><b>Observation.</b> A {@link TaskListener} on the queue. Every
  *       transition marks the view dirty; a short debounce turns a burst of
  *       events (a turn dispatching five tool calls) into one snapshot.</li>
- *   <li><b>Delivery.</b> Snapshots go onto a {@link Channel}, and every
- *       browser tab that opened the {@code /sse} endpoint is a subscriber
- *       with its own bounded queue — a slow tab never slows the queue, and
- *       the listener callback itself only flips a flag. Each subscriber is
- *       rendered for <em>its</em> user, because whether a Cancel button
- *       appears depends on who is looking.</li>
+ *   <li><b>Delivery.</b> Snapshots go onto a {@link Channel}; every
+ *       browser tab is a subscriber with its own bounded queue — a slow tab
+ *       never slows the queue, and the listener callback itself only flips
+ *       a flag. The wire side — the SSE connection, rendering each snapshot
+ *       for the user who is looking — is {@link UserStream}'s: the board
+ *       shares the user's stream instead of holding a connection of its
+ *       own.</li>
  *   <li><b>Ownership.</b> A task belongs to whoever owns the session it runs
  *       for ({@code payload.sessionId} → {@link AgentSession#userId()}); a
  *       sub-agent's session inherits its parent's user, so a whole task tree
@@ -64,18 +61,11 @@ public class TaskMonitor implements TaskListener {
 
     private static final Logger log = LoggerFactory.getLogger(TaskMonitor.class);
 
-    /**
-     * Stream channel id AND the DOM id of the header badge. The SPA keeps a
-     * stream attached only while an element with the channel's id is
-     * mounted; the badge is on every admin page, so the stream survives
-     * navigation and is never opened twice.
-     */
+    /** The board's channel in the registry — and the DOM id of the header badge. */
     public static final String CHANNEL_ID = "task-monitor";
 
     /** Events within this window collapse into one snapshot. */
     static final long DEBOUNCE_MS = 250;
-    /** SSE comment keeping idle connections alive through proxies. */
-    private static final long HEARTBEAT_SECONDS = 20;
     /** Finished tasks shown under the live ones — a glance at what just happened. */
     static final int RECENT_LIMIT = 15;
     private static final int QUERY_LIMIT = 1000;
@@ -115,10 +105,8 @@ public class TaskMonitor implements TaskListener {
     private final LocalTaskQueue queue;
     private final AgentSessionRepository sessions;
     private final AgentDefinitionRepository definitions;
-    private final ObjectMapper objectMapper;
 
     private final Channel<Snapshot> channel = new ChannelRegistry().channel(CHANNEL_ID);
-    private final Map<SseEmitter, Subscription> subscriptions = new ConcurrentHashMap<>();
     private final AtomicBoolean pending = new AtomicBoolean();
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
         Thread t = new Thread(r, "task-monitor");
@@ -128,27 +116,15 @@ public class TaskMonitor implements TaskListener {
 
     public TaskMonitor(LocalTaskQueue queue,
                        AgentSessionRepository sessions,
-                       AgentDefinitionRepository definitions,
-                       ObjectMapper objectMapper) {
+                       AgentDefinitionRepository definitions) {
         this.queue = queue;
         this.sessions = sessions;
         this.definitions = definitions;
-        this.objectMapper = objectMapper;
         queue.addListener(this);
-        scheduler.scheduleWithFixedDelay(this::heartbeat, HEARTBEAT_SECONDS, HEARTBEAT_SECONDS, TimeUnit.SECONDS);
     }
 
     @PreDestroy
     void shutdown() {
-        for (var entry : subscriptions.entrySet()) {
-            entry.getValue().close();
-            try {
-                entry.getKey().complete();
-            } catch (Exception ignore) {
-                // already gone
-            }
-        }
-        subscriptions.clear();
         scheduler.shutdownNow();
     }
 
@@ -311,45 +287,11 @@ public class TaskMonitor implements TaskListener {
     // ── delivery ────────────────────────────────────────────────────────────
 
     /**
-     * Subscribes a browser tab, live only: the page that opened the stream
-     * already shows the current board, so there is nothing to replay. Every
-     * snapshot from here on is rendered for {@code userId} and written as
-     * one {@code patch} frame.
+     * Every snapshot from now on, live only: whoever subscribes already
+     * shows the current board, so there is nothing to replay. The event's
+     * {@code seq} is the board's own sequence.
      */
-    public void attach(SseEmitter emitter, String userId) {
-        Subscription subscription = channel.subscribe(channel.lastSeq(),
-                event -> send(emitter, event.seq(), event.value(), userId));
-        Subscription previous = subscriptions.put(emitter, subscription);
-        if (previous != null) previous.close();
-    }
-
-    public void detach(SseEmitter emitter) {
-        Subscription subscription = subscriptions.remove(emitter);
-        if (subscription != null) subscription.close();
-    }
-
-    private void send(SseEmitter emitter, long seq, Snapshot snapshot, String userId) {
-        try {
-            UiPatch patch = TaskMonitorComponent.livePatch(snapshot, userId);
-            emitter.send(SseEmitter.event()
-                    .id(Long.toString(seq))
-                    .name("patch")
-                    .data(objectMapper.writeValueAsString(patch)));
-        } catch (Exception e) {
-            // The client went away, or the socket is broken. The heartbeat
-            // reaps it; the channel must not see the exception.
-            detach(emitter);
-        }
-    }
-
-    /** Keeps idle connections open and notices the ones that are gone. */
-    private void heartbeat() {
-        for (SseEmitter emitter : subscriptions.keySet()) {
-            try {
-                emitter.send(SseEmitter.event().comment("hb"));
-            } catch (Exception e) {
-                detach(emitter);
-            }
-        }
+    public Subscription subscribe(Consumer<Channel.Event<Snapshot>> consumer) {
+        return channel.subscribe(channel.lastSeq(), consumer);
     }
 }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/UserStream.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/UserStream.java
@@ -1,0 +1,171 @@
+package ai.mindconnect.adminui.service;
+
+import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
+import ai.mindconnect.agent.service.stream.UserChannels;
+import ai.mindconnect.agentrest.dto.UserEventFrame;
+import ai.mindconnect.channel.Subscription;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The one stream every admin page keeps attached: the user's own feed. Two
+ * sources share the connection —
+ * <ul>
+ *   <li>the {@link TaskMonitor}'s board, as {@code patch} frames that keep
+ *       the header badge and the task dialog current, rendered for the user
+ *       on this connection (whether a Cancel appears depends on who looks);</li>
+ *   <li>the user's {@link UserChannels} stream, as {@code user} frames — a
+ *       session opened or titled, a turn started or finished, a tool waiting
+ *       for an answer — so a tab learns what happens in the sessions it is
+ *       not looking at.</li>
+ * </ul>
+ *
+ * <p>One connection rather than one per source because a browser allows six
+ * per host, shared by all its tabs: every stream a page holds is a slot a
+ * second tab cannot have. The task badge used to be a stream of its own.
+ *
+ * <p>Live only. The page that attaches already shows the current board and
+ * the current session list; what it needs is what changes from here on.
+ * The heartbeat is also the liveness check: a write that fails drops that
+ * subscriber.
+ */
+@Component
+public class UserStream {
+
+    private static final Logger log = LoggerFactory.getLogger(UserStream.class);
+
+    /**
+     * The stream's channel id AND the DOM id of the header element the SPA
+     * looks for: it keeps a stream attached only while an element with the
+     * channel's id is mounted. {@code AdminLayout} renders that element on
+     * every page, so the stream survives navigation and is opened once.
+     */
+    public static final String CHANNEL_ID = "user-stream";
+    public static final String STREAM_URL = "/admin/api/stream";
+
+    /** SSE comment keeping idle connections alive through proxies. */
+    private static final long HEARTBEAT_SECONDS = 20;
+
+    private record Attached(Subscription tasks, Subscription events) {
+        void close() {
+            if (tasks != null) tasks.close();
+            events.close();
+        }
+    }
+
+    /** Absent when the host runs no task queue; the stream then carries user events only. */
+    private final TaskMonitor taskMonitor;
+    private final UserChannels userChannels;
+    private final ObjectMapper objectMapper;
+    private final Map<SseEmitter, Attached> attached = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService pulse = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "user-stream-heartbeat");
+        t.setDaemon(true);
+        return t;
+    });
+
+    public UserStream(Optional<TaskMonitor> taskMonitor, UserChannels userChannels, ObjectMapper objectMapper) {
+        this.taskMonitor = taskMonitor.orElse(null);
+        this.userChannels = userChannels;
+        this.objectMapper = objectMapper;
+        pulse.scheduleWithFixedDelay(this::heartbeat, HEARTBEAT_SECONDS, HEARTBEAT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        pulse.shutdownNow();
+        for (var entry : attached.entrySet()) {
+            entry.getValue().close();
+            try {
+                entry.getKey().complete();
+            } catch (Exception ignore) {
+                // already gone
+            }
+        }
+        attached.clear();
+    }
+
+    /**
+     * Subscribes a browser tab for {@code userId}. The first thing written
+     * is a comment: Spring commits an SseEmitter's headers with its first
+     * write, and until then the browser's {@code fetch()} has not resolved
+     * — the SPA does not know it holds this connection and a second page
+     * render opens another. On a quiet server the first real frame could
+     * be the heartbeat, 20 seconds away.
+     */
+    public void attach(SseEmitter emitter, String userId) {
+        try {
+            emitter.send(SseEmitter.event().comment("attached"));
+        } catch (Exception e) {
+            log.debug("User stream for {} could not be opened: {}", userId, e.toString());
+            return;
+        }
+        Subscription tasks = taskMonitor == null ? null : taskMonitor.subscribe(event -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .id(Long.toString(event.seq()))
+                        .name("patch")
+                        .data(json(TaskMonitorComponent.livePatch(event.value(), userId))));
+            } catch (Exception e) {
+                detach(emitter);
+            }
+        });
+        Subscription events = userChannels.subscribe(userId, userChannels.lastSeq(userId), event -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("user")
+                        .data(json(UserEventFrame.of(event.seq(), event.value()))));
+            } catch (Exception e) {
+                detach(emitter);
+            }
+        });
+        Attached previous = attached.put(emitter, new Attached(tasks, events));
+        if (previous != null) previous.close();
+        log.debug("User stream attached for {} — {} open", userId, attached.size());
+    }
+
+    public void detach(SseEmitter emitter) {
+        Attached subscriptions = attached.remove(emitter);
+        if (subscriptions != null) {
+            subscriptions.close();
+            log.debug("User stream detached — {} open", attached.size());
+        }
+    }
+
+    /** How many tabs are attached right now — for tests and logs. */
+    public int subscriberCount() {
+        return attached.size();
+    }
+
+    private String json(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** Keeps idle connections open and notices the ones that are gone. */
+    private void heartbeat() {
+        for (SseEmitter emitter : attached.keySet()) {
+            try {
+                emitter.send(SseEmitter.event().comment("hb"));
+            } catch (Exception e) {
+                detach(emitter);
+            }
+        }
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
@@ -7,6 +7,7 @@ import ai.mindconnect.ui.model.UiMenu;
 import ai.mindconnect.ui.model.UiMenuItem;
 import ai.mindconnect.ui.model.UiNode;
 import ai.mindconnect.ui.model.UiPage;
+import ai.mindconnect.ui.model.UiStack;
 import ai.mindconnect.ui.model.UiTrigger;
 
 import java.util.ArrayList;
@@ -45,8 +46,9 @@ public final class AdminLayout {
     /**
      * @param taskBadge  the task-queue badge for the header, or null when the
      *                   host has no task monitor
-     * @param taskStream the live feed behind the badge; put on every page so
-     *                   the SPA attaches once and keeps it across navigation
+     * @param taskStream the user's live feed — the badge's patches and the
+     *                   session events; put on every page so the SPA attaches
+     *                   once and keeps it across navigation
      */
     public AdminLayout(String userName, boolean authEnabled, String versionLabel,
                        UiNode taskBadge, UiPage.ActiveStream taskStream) {
@@ -102,7 +104,16 @@ public final class AdminLayout {
         // is DOING right now, beside who is using it. A click opens the task
         // manager. What the server IS — its version — lives at the foot of
         // the sidebar (see buildMenu), where it is out of the way.
-        if (taskBadge != null) {
+        if (taskStream != null) {
+            // The element the SPA looks for to keep the user's stream
+            // attached across navigation: its id is the stream's channel
+            // id, and it is here on every page, badge or no badge.
+            UiStack live = UiStack.of(taskStream.getChannelId())
+                    .direction(UiStack.Direction.HORIZONTAL).gap(0);
+            live.withCssClass("user-stream-anchor");
+            if (taskBadge != null) live.child(taskBadge);
+            header.extra(live);
+        } else if (taskBadge != null) {
             header.extra(taskBadge);
         }
         if (authEnabled) {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.adminui.ui;
 
 import ai.mindconnect.adminui.service.TaskMonitor;
+import ai.mindconnect.adminui.service.UserStream;
 import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
 import ai.mindconnect.ui.model.UiPage;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,15 +36,16 @@ public class AdminLayoutFactory {
         this.taskMonitor = taskMonitor.orElse(null);
     }
 
-    /** Layout for the user currently in the {@link SecurityContextHolder}. */
+    /**
+     * Layout for the user currently in the {@link SecurityContextHolder}.
+     * Every page names the user's stream, badge or no badge: the stream
+     * carries the session events even where there is no task queue to show.
+     */
     public AdminLayout current() {
-        if (taskMonitor == null) {
-            return new AdminLayout(currentUserName(), authEnabled, buildInfo.label());
-        }
         return new AdminLayout(currentUserName(), authEnabled, buildInfo.label(),
-                TaskMonitorComponent.badge(taskMonitor.counts()),
-                UiPage.ActiveStream.of(TaskMonitor.CHANNEL_ID, TaskMonitorComponent.STREAM_URL,
-                        "Task queue", "/admin/agents"));
+                taskMonitor == null ? null : TaskMonitorComponent.badge(taskMonitor.counts()),
+                UiPage.ActiveStream.of(UserStream.CHANNEL_ID, UserStream.STREAM_URL,
+                        "Live updates", "/admin/agents"));
     }
 
     private String currentUserName() {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/TaskMonitorComponent.java
@@ -35,14 +35,13 @@ import java.util.Map;
  */
 public final class TaskMonitorComponent {
 
-    /** The badge's DOM id — equal to the stream channel id, see {@link TaskMonitor#CHANNEL_ID}. */
+    /** The badge's DOM id — the live patch's target, see {@link TaskMonitor#CHANNEL_ID}. */
     public static final String BADGE_ID = TaskMonitor.CHANNEL_ID;
     public static final String DIALOG_ID = "task-monitor-dialog";
     public static final String BODY_ID = "task-monitor-body";
 
     public static final String OPEN_URL = "/admin/api/tasks";
     public static final String CLOSE_URL = "/admin/api/tasks/close";
-    public static final String STREAM_URL = "/admin/api/tasks/sse";
 
     private TaskMonitorComponent() { }
 
@@ -50,9 +49,8 @@ public final class TaskMonitorComponent {
 
     /**
      * The header badge: an activity icon and "3 running" (or "idle"). The
-     * outer stack carries the stream channel id, which is what keeps the
-     * stream attached across navigation, and a class that says whether
-     * anything is going on so the stylesheet can light it up.
+     * outer stack carries the id the live patch replaces, and a class that
+     * says whether anything is going on so the stylesheet can light it up.
      *
      * <p>The count is deliberately a sibling of the button, not its label.
      * The button keeps focus after the click that opens the dialog, and the
@@ -96,7 +94,7 @@ public final class TaskMonitorComponent {
         return body;
     }
 
-    /** One stream frame: badge on every page, dialog body when it is open. */
+    /** One {@code patch} frame of the user stream: badge on every page, dialog body when it is open. */
     public static UiPatch livePatch(Snapshot snapshot, String userId) {
         return UiPatch.of()
                 .patch(UiPatch.Operation.replace(BADGE_ID, badge(snapshot)))

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/TaskMonitorUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/TaskMonitorUiController.java
@@ -5,9 +5,6 @@ import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
 import ai.mindconnect.ui.model.UiDialog;
 import ai.mindconnect.ui.model.UiPatch;
 import ai.mindconnect.ui.model.UiToast;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,13 +12,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
  * The task manager behind the header's task badge. The dialog opens and
  * closes as patches on the body-level dialog host, like About; while it is
- * open the stream every page carries ({@code /sse}) keeps it current, so
- * there is no refresh button and nothing to poll.
+ * open the user stream every page carries ({@code UserStream}) keeps it
+ * current, so there is no refresh button and nothing to poll.
  */
 @RestController
 @RequestMapping(TaskMonitorComponent.OPEN_URL)
@@ -64,26 +60,6 @@ public class TaskMonitorUiController {
             case UNKNOWN -> UiToast.error("No such task — it may have been cleared.");
         };
         return UiPatch.of().toast(toast);
-    }
-
-    /**
-     * The live feed the SPA attaches to from every admin page (see
-     * {@code AdminLayout}): one {@code patch} frame per change of the board,
-     * rendered for the user on this connection. Live only — the page that
-     * opened it already shows the current state.
-     */
-    @GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> stream(@AuthenticationPrincipal OidcUser user) {
-        SseEmitter emitter = new SseEmitter(0L);
-        monitor.attach(emitter, userId(user));
-        emitter.onCompletion(() -> monitor.detach(emitter));
-        emitter.onError(t -> monitor.detach(emitter));
-        emitter.onTimeout(() -> monitor.detach(emitter));
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Sui-Stream-Channel", TaskMonitor.CHANNEL_ID);
-        headers.add("Sui-Stream-Label", "Task queue");
-        return ResponseEntity.ok().headers(headers).body(emitter);
     }
 
     private static String userId(OidcUser user) {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/UserStreamController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/UserStreamController.java
@@ -1,0 +1,47 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.adminui.service.UserStream;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * The live feed the SPA attaches to from every admin page (see
+ * {@code AdminLayout}): the task board as {@code patch} frames and the
+ * user's own session events as {@code user} frames, on one connection.
+ */
+@RestController
+public class UserStreamController {
+
+    private final UserStream userStream;
+
+    public UserStreamController(UserStream userStream) {
+        this.userStream = userStream;
+    }
+
+    @GetMapping(value = UserStream.STREAM_URL, produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> stream(@AuthenticationPrincipal OidcUser user) {
+        // Long-lived: it outlives every turn and every navigation. Idle time
+        // is covered by the heartbeat.
+        SseEmitter emitter = new SseEmitter(0L);
+        userStream.attach(emitter, userId(user));
+        emitter.onCompletion(() -> userStream.detach(emitter));
+        emitter.onError(t -> userStream.detach(emitter));
+        emitter.onTimeout(() -> userStream.detach(emitter));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Sui-Stream-Channel", UserStream.CHANNEL_ID);
+        headers.add("Sui-Stream-Label", "Live updates");
+        return ResponseEntity.ok().headers(headers).body(emitter);
+    }
+
+    /** The same identity the chat and the task manager use — the fixed dev user with auth off. */
+    private static String userId(OidcUser user) {
+        return user == null ? "mc_user" : user.getPreferredUsername();
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -8,6 +8,7 @@ import { bffFetch }                            from "/sui/bff.js";
 import { install as installJsonViewer } from "/sui-ext/jsonviewer/extension.js";
 import { install as installMarkdown }   from "/sui-ext/markdown/extension.js";
 import { install as installDiagram }    from "/sui-ext/diagram/extension.js";
+import { watchConnectionBudget }        from "/js/connection-budget.js";
 
 // ── Renderer + extensions ────────────────────────────────────────────────────
 
@@ -54,9 +55,22 @@ bus.setFetcher(bffFetch)
    .setOnUnauthenticated(handle401)
    // App-defined SSE event: chat errors come over the same stream as patches.
    .onStreamEvent("error", (msg) => showStreamError(msg))
+   // The user's own feed, on every page: a session opened or titled, a turn
+   // started or finished, a tool waiting for an answer. The bus only carries
+   // it; the chat's history (chat-ui.js) is what reacts, so it is re-raised
+   // as a DOM event for whoever owns the elements it concerns.
+   .onStreamEvent("user", (data) => {
+       let event;
+       try { event = JSON.parse(data); } catch { return; }
+       document.dispatchEvent(new CustomEvent("mc-user-event", { detail: event }));
+   })
    // The framework tells us when a stream's state changes; what to do about
    // a lost one is our call.
    .onStreamStateChange(noticeLostStream);
+
+// Too many tabs: each holds a stream or two, and a browser allows six per
+// site. The tabs count each other and warn before the seventh stalls them all.
+watchConnectionBudget(bus);
 
 // ── "Connection lost" notice ─────────────────────────────────────────────────
 

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -72,6 +72,19 @@ bus.setFetcher(bffFetch)
 // site. The tabs count each other and warn before the seventh stalls them all.
 watchConnectionBudget(bus);
 
+// Console hook. `mc.streams()` lists the server-sent streams this tab holds
+// (a chat page should show `user-stream` and one `msg-list-…`, nothing
+// else); `mc.bus` is the event bus itself. The bus lives in this module's
+// scope, so without this nothing of it is reachable from DevTools.
+let heldStreams = [];
+bus.onStreamStateChange((list) => { heldStreams = list; });
+window.mc = {
+    bus,
+    streams: () => heldStreams.map((h) => ({
+        channel: h.channelId, state: h.state, attached: h.pageAttached, buffered: h.bufferedEvents.length,
+    })),
+};
+
 // ── "Connection lost" notice ─────────────────────────────────────────────────
 
 /**

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/connection-budget.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/connection-budget.js
@@ -1,0 +1,123 @@
+// Warns when this browser holds too many live server-sent event streams to
+// this app across its tabs.
+//
+// Over HTTP/1.1 a browser keeps at most six connections open per host, per
+// profile. Every stream the app holds — the user stream on every page, the
+// session stream on a chat — is one of them, and they never end while their
+// page is mounted. So a person with a few chats open in a few tabs reaches
+// the limit without doing anything wrong, and from then on every request in
+// every tab queues behind the streams: pages stop loading, nothing says why.
+//
+// The tabs tell each other what they hold over a BroadcastChannel (same
+// origin, same profile — exactly the scope of the limit) and each one warns
+// when the sum comes within one of the limit. Message handlers run in hidden
+// tabs too, unlike timers, so a background tab is counted at once; the
+// periodic re-announcement only covers a tab that died without saying
+// goodbye. HTTP/2 multiplexes streams over one connection and has no such
+// limit, so a page served that way stays quiet.
+
+const LIMIT = 6;
+const WARN_AT = LIMIT - 1;
+const ANNOUNCE_EVERY_MS = 30_000;
+const FORGET_AFTER_MS = 4 * ANNOUNCE_EVERY_MS;   // hidden tabs get one timer a minute
+const BANNER_ID = "connection-budget-banner";
+
+/**
+ * Wires the watch to the bus. Call once per page; harmless where
+ * BroadcastChannel is missing (nothing is counted, nothing is shown).
+ */
+export function watchConnectionBudget(bus) {
+    if (typeof BroadcastChannel !== "function" || !limitApplies()) return;
+
+    const me = Math.random().toString(36).slice(2);
+    const peers = new Map();            // tab id → { streams, seen }
+    let mine = 0;
+    let dismissedAt = 0;                // the total the person waved off
+    const channel = new BroadcastChannel("mc-connection-budget");
+
+    const post = (type) => channel.postMessage({ type, id: me, streams: mine });
+
+    channel.addEventListener("message", ({ data }) => {
+        if (!data || data.id === me) return;
+        if (data.type === "bye") {
+            peers.delete(data.id);
+        } else {
+            peers.set(data.id, { streams: data.streams | 0, seen: Date.now() });
+            if (data.type === "hello") post("state");   // a newcomer asks who is here
+        }
+        review();
+    });
+
+    bus.onStreamStateChange(streams => {
+        const open = streams.filter(s => s.state === "idle" || s.state === "running").length;
+        if (open === mine) return;
+        mine = open;
+        post("state");
+        review();
+    });
+
+    window.addEventListener("pagehide", () => post("bye"));
+    setInterval(() => { forgetSilent(); post("state"); review(); }, ANNOUNCE_EVERY_MS);
+    post("hello");
+
+    function forgetSilent() {
+        const cutoff = Date.now() - FORGET_AFTER_MS;
+        for (const [id, peer] of peers) if (peer.seen < cutoff) peers.delete(id);
+    }
+
+    function review() {
+        let total = mine;
+        for (const peer of peers.values()) total += peer.streams;
+        const tabs = peers.size + 1;
+        if (total < WARN_AT) {
+            dismissedAt = 0;
+            document.getElementById(BANNER_ID)?.remove();
+            return;
+        }
+        // Waving the notice off means "I know" for this count; it comes back
+        // only when the count grows further.
+        if (dismissedAt && total <= dismissedAt) return;
+        showBanner(total, tabs, () => { dismissedAt = total; });
+    }
+}
+
+/** Only HTTP/1.1 rations connections per host; a page served over h2/h3 is safe. */
+function limitApplies() {
+    const nav = performance.getEntriesByType?.("navigation")?.[0];
+    const protocol = nav?.nextHopProtocol || "";
+    return !/^h[23]/.test(protocol);
+}
+
+function showBanner(total, tabs, onDismiss) {
+    let banner = document.getElementById(BANNER_ID);
+    if (!banner) {
+        banner = document.createElement("div");
+        banner.id = BANNER_ID;
+        banner.setAttribute("role", "alert");
+        banner.style.cssText = "position:fixed;top:16px;right:16px;max-width:480px;z-index:9999;"
+            + "display:flex;align-items:center;gap:12px;padding:10px 14px;"
+            + "background:#fef3c7;color:#92400e;border:1px solid #fcd34d;border-radius:6px;"
+            + "box-shadow:0 4px 12px rgba(0,0,0,.1);font-size:13px;line-height:1.4;";
+
+        const text = document.createElement("span");
+        text.className = "text";
+        banner.appendChild(text);
+
+        const close = document.createElement("button");
+        close.type = "button";
+        close.setAttribute("aria-label", "Dismiss");
+        close.textContent = "×";
+        close.style.cssText = "font:inherit;font-size:16px;line-height:1;padding:0 4px;border:none;"
+            + "background:none;color:inherit;cursor:pointer;";
+        close.addEventListener("click", () => { onDismiss(); banner.remove(); });
+        banner.appendChild(close);
+
+        document.body.appendChild(banner);
+    }
+    const where = tabs === 1 ? "in this tab" : `across ${tabs} browser tabs`;
+    const verdict = total >= LIMIT
+        ? "That is the browser's limit per site: pages will stop loading until some are closed."
+        : `The browser allows ${LIMIT} per site; one more and pages stop loading.`;
+    banner.querySelector(".text").textContent =
+        `⚠ ${total} live connections to this app are open ${where}. ${verdict} Close the tabs you no longer need.`;
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/TaskMonitorTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/TaskMonitorTest.java
@@ -15,11 +15,9 @@ import ai.mindconnect.taskqueue.TaskOutcome;
 import ai.mindconnect.taskqueue.TaskStatus;
 import ai.mindconnect.taskqueue.TaskSubmission;
 import ai.mindconnect.taskqueue.local.LocalTaskQueue;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -35,9 +33,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * The monitor against a real {@link LocalTaskQueue}: a task that runs for
  * someone shows up under their name, only they may cancel it, and the
- * cancel reaches the worker. The stream side is exercised through a
- * capturing emitter — a transition on the queue ends as one patch frame on
- * every attached connection.
+ * cancel reaches the worker. A transition on the queue ends as one snapshot
+ * for every subscriber; the wire side of that is {@link UserStreamTest}'s.
  */
 class TaskMonitorTest {
 
@@ -76,7 +73,7 @@ class TaskMonitorTest {
                 "Alice asks", SessionStatus.ACTIVE, Instant.now(), null,
                 null, null, null, null, null, null, null));
 
-        monitor = new TaskMonitor(queue, sessions, definitions, new ObjectMapper());
+        monitor = new TaskMonitor(queue, sessions, definitions);
     }
 
     @AfterEach
@@ -125,33 +122,21 @@ class TaskMonitorTest {
     }
 
     @Test
-    void aTransitionBecomesOnePatchFrameOnEveryAttachedStream() throws Exception {
-        var frames = new CopyOnWriteArrayList<String>();
+    void aTransitionBecomesOneSnapshotForEverySubscriber() throws Exception {
+        var snapshots = new CopyOnWriteArrayList<Snapshot>();
         var arrived = new CountDownLatch(1);
-        SseEmitter emitter = new SseEmitter(0L) {
-            @Override
-            public void send(SseEventBuilder builder) {
-                // The builder's data parts are the JSON; join them into one frame.
-                frames.add(builder.build().stream()
-                        .map(part -> String.valueOf(part.getData()))
-                        .collect(java.util.stream.Collectors.joining()));
-                arrived.countDown();
-            }
-        };
-        monitor.attach(emitter, "alice");
+        var subscription = monitor.subscribe(event -> {
+            snapshots.add(event.value());
+            arrived.countDown();
+        });
 
         String id = submitTurn();
         assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
         assertThat(arrived.await(5, TimeUnit.SECONDS))
-                .as("the submit/start burst is debounced into a frame")
+                .as("the submit/start burst is debounced into a snapshot")
                 .isTrue();
 
-        String frame = frames.get(0);
-        assertThat(frame).contains("\"targetId\":\"" + TaskMonitor.CHANNEL_ID + "\"");
-        assertThat(frame).contains("task-" + id);
-        // rendered for alice: her task carries its Cancel
-        assertThat(frame).contains("/admin/api/tasks/" + id + "/cancel");
-
-        monitor.detach(emitter);
+        assertThat(snapshots.get(0).active()).extracting(TaskView::id).containsExactly(id);
+        subscription.close();
     }
 }

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/UserStreamTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/UserStreamTest.java
@@ -1,0 +1,153 @@
+package ai.mindconnect.adminui.service;
+
+import ai.mindconnect.agent.adapter.repo.memory.InMemoryAgentDefinitionRepository;
+import ai.mindconnect.agent.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.domain.AgentDefinition;
+import ai.mindconnect.agent.domain.AgentDefinitionStatus;
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.domain.SessionStatus;
+import ai.mindconnect.agent.service.stream.UserChannels;
+import ai.mindconnect.agent.service.stream.UserEvent;
+import ai.mindconnect.agent.service.task.AgentTurnWorker;
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.taskqueue.TaskOutcome;
+import ai.mindconnect.taskqueue.TaskSubmission;
+import ai.mindconnect.taskqueue.local.LocalTaskQueue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The wire side of the user's stream, through a capturing emitter: the
+ * connection is committed before anything happens, a task transition lands
+ * as a {@code patch} frame rendered for the attached user, and a user event
+ * lands as a {@code user} frame — on that user's connection only.
+ */
+class UserStreamTest {
+
+    private static final Namespace NS = new Namespace("local");
+    private static final UUID AGENT_ID = UUID.randomUUID();
+    private static final UUID ALICE_SESSION = UUID.randomUUID();
+
+    private LocalTaskQueue queue;
+    private TaskMonitor monitor;
+    private UserChannels userChannels;
+    private UserStream stream;
+    private final CountDownLatch started = new CountDownLatch(1);
+    private final CountDownLatch release = new CountDownLatch(1);
+
+    /** Records every write as the SSE text it would put on the wire. */
+    private static final class CapturingEmitter extends SseEmitter {
+        final List<String> frames = new CopyOnWriteArrayList<>();
+        final CountDownLatch patchArrived = new CountDownLatch(1);
+        final CountDownLatch userArrived = new CountDownLatch(1);
+
+        CapturingEmitter() { super(0L); }
+
+        @Override
+        public void send(SseEventBuilder builder) {
+            String frame = builder.build().stream()
+                    .map(part -> String.valueOf(part.getData()))
+                    .collect(java.util.stream.Collectors.joining());
+            frames.add(frame);
+            if (frame.contains("event:patch")) patchArrived.countDown();
+            if (frame.contains("event:user")) userArrived.countDown();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        queue = new LocalTaskQueue(new ai.mindconnect.taskqueue.memory.InMemoryTaskStore());
+        queue.register(AgentTurnWorker.TYPE, ctx -> {
+            started.countDown();
+            try {
+                while (!ctx.cancelRequested() && !release.await(20, TimeUnit.MILLISECONDS)) {
+                    // spin on the cooperative flag
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return TaskOutcome.done("ok");
+        });
+        var definitions = new InMemoryAgentDefinitionRepository();
+        definitions.save(new AgentDefinition(AGENT_ID, NS, "Scout", "A test agent",
+                "assistants", "bot", "prompt", null, "cfg", 5, null,
+                AgentDefinitionStatus.ACTIVE, List.of(), List.of(), null, null, null, null));
+        var sessions = new InMemoryAgentSessionRepository();
+        sessions.save(new AgentSession(ALICE_SESSION, AGENT_ID, NS, "alice", UUID.randomUUID(),
+                "Alice asks", SessionStatus.ACTIVE, Instant.now(), null,
+                null, null, null, null, null, null, null));
+        monitor = new TaskMonitor(queue, sessions, definitions);
+        userChannels = new UserChannels();
+        stream = new UserStream(Optional.of(monitor), userChannels, new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() {
+        release.countDown();
+        stream.shutdown();
+        monitor.shutdown();
+        queue.close();
+    }
+
+    @Test
+    void theConnectionIsCommittedBeforeAnythingHappens() {
+        var emitter = new CapturingEmitter();
+        stream.attach(emitter, "alice");
+
+        assertThat(emitter.frames).hasSize(1);
+        assertThat(emitter.frames.get(0)).startsWith(":attached");
+        assertThat(stream.subscriberCount()).isEqualTo(1);
+
+        stream.detach(emitter);
+        assertThat(stream.subscriberCount()).isZero();
+    }
+
+    @Test
+    void aTaskTransitionBecomesAPatchFrameRenderedForTheAttachedUser() throws Exception {
+        var emitter = new CapturingEmitter();
+        stream.attach(emitter, "alice");
+
+        String id = queue.submit(TaskSubmission.of(AgentTurnWorker.TYPE,
+                Map.of(AgentTurnWorker.SESSION_ID, ALICE_SESSION.toString(), AgentTurnWorker.DEPTH, 0)));
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(emitter.patchArrived.await(5, TimeUnit.SECONDS)).isTrue();
+
+        String frame = emitter.frames.stream().filter(f -> f.contains("event:patch")).findFirst().orElseThrow();
+        assertThat(frame).contains("\"targetId\":\"" + TaskMonitor.CHANNEL_ID + "\"");
+        assertThat(frame).contains("task-" + id);
+        // rendered for alice: her task carries its Cancel
+        assertThat(frame).contains("/admin/api/tasks/" + id + "/cancel");
+    }
+
+    @Test
+    void aUserEventBecomesAUserFrameOnThatUsersConnectionOnly() throws Exception {
+        var alice = new CapturingEmitter();
+        var bob = new CapturingEmitter();
+        stream.attach(alice, "alice");
+        stream.attach(bob, "bob");
+
+        UUID turn = UUID.randomUUID();
+        userChannels.publish("alice", new UserEvent.TurnStarted(ALICE_SESSION, turn));
+        assertThat(alice.userArrived.await(5, TimeUnit.SECONDS)).isTrue();
+
+        String frame = alice.frames.stream().filter(f -> f.contains("event:user")).findFirst().orElseThrow();
+        assertThat(frame).contains("\"type\":\"turn_started\"");
+        assertThat(frame).contains("\"sessionId\":\"" + ALICE_SESSION + "\"");
+        assertThat(frame).contains("\"turnId\":\"" + turn + "\"");
+        assertThat(bob.frames).noneMatch(f -> f.contains("event:user"));
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
@@ -16,6 +16,7 @@ import ai.mindconnect.agentrest.dto.CreateAgentRequest;
 import ai.mindconnect.agentrest.dto.StartSessionRequest;
 import ai.mindconnect.agentrest.dto.AttachedFrame;
 import ai.mindconnect.agentrest.dto.SessionStreamFrame;
+import ai.mindconnect.agentrest.dto.UserEventFrame;
 import ai.mindconnect.agentrest.dto.StreamEventFrame;
 import ai.mindconnect.agentrest.dto.UpdateToolsRequest;
 import ai.mindconnect.common.Namespace;
@@ -49,17 +50,20 @@ public class AgentApiController {
     private final AgentSessionService sessionService;
     private final AgentChatService chatService;
     private final ai.mindconnect.filestore.FileStore fileStore;
+    private final ai.mindconnect.agent.service.stream.UserChannels userChannels;
     private final ObjectMapper compactMapper;
 
     public AgentApiController(AgentRegistryService registryService,
                             AgentSessionService sessionService,
                             AgentChatService chatService,
                             ai.mindconnect.filestore.FileStore fileStore,
+                            ai.mindconnect.agent.service.stream.UserChannels userChannels,
                             ObjectMapper objectMapper) {
         this.registryService = registryService;
         this.sessionService = sessionService;
         this.chatService = chatService;
         this.fileStore = fileStore;
+        this.userChannels = userChannels;
         this.compactMapper = objectMapper.copy().disable(
                 com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT);
     }
@@ -288,6 +292,52 @@ public class AgentApiController {
             }
         });
 
+        return emitter;
+    }
+
+    @Operation(tags = "Sessions", summary = "Attach to a user's event stream",
+            description = "The coarse feed across all of a user's sessions: session_started, "
+                    + "session_titled, turn_started, turn_finished, approval_requested and "
+                    + "approval_answered — what a session list or a notification needs, "
+                    + "without attaching to any session. Same reconnect story as the session "
+                    + "stream: the first frame is {type:'attached'} with the buffer bounds, "
+                    + "then every buffered event after afterSeq replays and the stream "
+                    + "continues live; each frame carries seq, the cursor for the next "
+                    + "reconnect. The tokens of a turn are not here — attach to the session's "
+                    + "own stream for those.")
+    @GetMapping(value = "/users/{userId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter userStream(@PathVariable String userId,
+                                 @RequestParam(defaultValue = "0") long afterSeq) {
+        log.info("GET /api/users/{}/stream afterSeq={}", userId, afterSeq);
+        SseEmitter emitter = new SseEmitter(120_000L);
+
+        var attachedSent = new java.util.concurrent.CountDownLatch(1);
+        ai.mindconnect.channel.Subscription subscription = userChannels.subscribe(userId, afterSeq, event -> {
+            try {
+                attachedSent.await();
+                emitter.send(SseEmitter.event().data(
+                        compactMapper.writeValueAsString(
+                                UserEventFrame.of(event.seq(), event.value())),
+                        MediaType.APPLICATION_JSON));
+            } catch (Exception e) {
+                emitter.completeWithError(e);
+            }
+        });
+        try {
+            emitter.send(SseEmitter.event().data(
+                    compactMapper.writeValueAsString(UserEventFrame.Attached.of(
+                            userChannels.earliestBufferedSeq(userId), userChannels.lastSeq(userId))),
+                    MediaType.APPLICATION_JSON));
+        } catch (Exception e) {
+            subscription.close();
+            emitter.completeWithError(e);
+            return emitter;
+        } finally {
+            attachedSent.countDown();
+        }
+        emitter.onCompletion(subscription::close);
+        emitter.onTimeout(subscription::close);
+        emitter.onError(error -> subscription.close());
         return emitter;
     }
 

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/UserEventFrame.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/UserEventFrame.java
@@ -1,0 +1,56 @@
+package ai.mindconnect.agentrest.dto;
+
+import ai.mindconnect.agent.service.stream.UserEvent;
+
+import java.util.UUID;
+
+/**
+ * One frame of the user stream ({@code GET /api/users/{userId}/stream}): a
+ * {@link UserEvent} on the wire, flat, with a {@code type} discriminator and
+ * only the fields that event carries. {@code seq} is the cursor a client
+ * hands back as {@code afterSeq} on reconnect.
+ *
+ * <table>
+ *   <tr><th>type</th><th>fields</th></tr>
+ *   <tr><td>{@code session_started}</td><td>{@code sessionId}, {@code agentDefinitionId}</td></tr>
+ *   <tr><td>{@code session_titled}</td><td>{@code sessionId}, {@code title}</td></tr>
+ *   <tr><td>{@code turn_started}</td><td>{@code sessionId}, {@code turnId}</td></tr>
+ *   <tr><td>{@code turn_finished}</td><td>{@code sessionId}, {@code turnId}, {@code outcome}</td></tr>
+ *   <tr><td>{@code approval_requested}</td><td>{@code sessionId} (the root), {@code callId}, {@code toolName}</td></tr>
+ *   <tr><td>{@code approval_answered}</td><td>{@code sessionId}, {@code callId}, {@code approved}</td></tr>
+ * </table>
+ */
+public record UserEventFrame(long seq, String type, String sessionId, String turnId, String outcome,
+                             String callId, String toolName, Boolean approved, String title,
+                             String agentDefinitionId) {
+
+    /** The first frame of every user stream: what the buffer still holds. */
+    public record Attached(String type, long firstBufferedSeq, long latestSeq) {
+        public static Attached of(long firstBufferedSeq, long latestSeq) {
+            return new Attached("attached", firstBufferedSeq, latestSeq);
+        }
+    }
+
+    public static UserEventFrame of(long seq, UserEvent event) {
+        String session = str(event.sessionId());
+        return switch (event) {
+            case UserEvent.SessionStarted e -> new UserEventFrame(seq, "session_started", session,
+                    null, null, null, null, null, null, str(e.agentDefinitionId()));
+            case UserEvent.SessionTitled e -> new UserEventFrame(seq, "session_titled", session,
+                    null, null, null, null, null, e.title(), null);
+            case UserEvent.TurnStarted e -> new UserEventFrame(seq, "turn_started", session,
+                    str(e.turnId()), null, null, null, null, null, null);
+            case UserEvent.TurnFinished e -> new UserEventFrame(seq, "turn_finished", session,
+                    str(e.turnId()), e.outcome().name().toLowerCase(java.util.Locale.ROOT),
+                    null, null, null, null, null);
+            case UserEvent.ApprovalRequested e -> new UserEventFrame(seq, "approval_requested", session,
+                    null, null, e.callId(), e.toolName(), null, null, null);
+            case UserEvent.ApprovalAnswered e -> new UserEventFrame(seq, "approval_answered", session,
+                    null, null, e.callId(), null, e.approved(), null, null);
+        };
+    }
+
+    private static String str(UUID id) {
+        return id == null ? null : id.toString();
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatShellComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatShellComponent.java
@@ -39,6 +39,8 @@ public final class ChatShellComponent implements UiComponent {
     private final String agentName;
     private final UiNode content;
     private final java.util.Map<UUID, String> agentIcons;
+    private java.util.Set<UUID> running = java.util.Set.of();
+    private java.util.Set<UUID> waiting = java.util.Set.of();
 
     public ChatShellComponent(List<? extends AgentSessionHeader> sessions, AgentSession active,
                               String agentName, UiNode content) {
@@ -61,6 +63,24 @@ public final class ChatShellComponent implements UiComponent {
         this.content = content;
         this.agentIcons = agentIcons == null ? java.util.Map.of() : agentIcons;
     }
+
+    /**
+     * Which conversations are busy right now, so their rows say so instead
+     * of showing their age: {@code running} has a turn in flight,
+     * {@code waiting} has a tool stopped at the approval gate. The server
+     * renders the current state; the user stream keeps it current after
+     * that (see chat-ui.js).
+     */
+    public ChatShellComponent withActivity(java.util.Set<UUID> running, java.util.Set<UUID> waiting) {
+        this.running = running == null ? java.util.Set.of() : running;
+        this.waiting = waiting == null ? java.util.Set.of() : waiting;
+        return this;
+    }
+
+    /** The row badge of a chat that waits for an answer — the words chat-ui.js keys off. */
+    public static final String BADGE_NEEDS_INPUT = "needs input";
+    /** The row badge of a chat with a turn in flight. */
+    public static final String BADGE_RUNNING = "running";
 
     @Override
     public String id() {
@@ -104,9 +124,12 @@ public final class ChatShellComponent implements UiComponent {
         UUID activeId = active == null ? null : active.id();
         for (AgentSessionHeader s : sessions) {
             String label = s.title() != null && !s.title().isBlank() ? s.title() : "New chat";
+            String badge = waiting.contains(s.id()) ? BADGE_NEEDS_INPUT
+                    : running.contains(s.id()) ? BADGE_RUNNING
+                    : ago(s.startedAt());
             menu.item(UiMenuItem.link("chat-" + s.id(), label, "/chat/sessions/" + s.id())
                     .icon(iconFor(s))
-                    .badge(ago(s.startedAt()))
+                    .badge(badge)
                     .selected(s.id().equals(activeId)));
         }
         return menu;

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -339,7 +339,9 @@ public class ChatUiController {
         var agent = agentResolver.resolve(session);
         var chat = buildChatPage(session, agent);
         var appShell = new ai.mindconnect.chatui.ui.component.ChatShellComponent(
-                sessions, session, agent.name(), chat.renderContent(), agentIcons()).render();
+                sessions, session, agent.name(), chat.renderContent(), agentIcons())
+                .withActivity(runningSessions(sessions), waitingSessions(sessions))
+                .render();
         var page = UiPage.of("/chat/sessions/" + session.id(), appShell);
         // A reload during a live turn reattaches instead of showing a dead form.
         if (!chat.activeStreams().isEmpty()) {
@@ -637,6 +639,24 @@ public class ChatUiController {
                         "/chat/sessions/" + session.id(),
                         returnLabel)));
         return page;
+    }
+
+    /** The sessions with a turn in flight — the stream registry is the truth, as for the Stop button. */
+    private java.util.Set<UUID> runningSessions(List<? extends ai.mindconnect.agent.domain.view.AgentSessionHeader> sessions) {
+        java.util.Set<UUID> running = new java.util.HashSet<>();
+        for (var s : sessions) {
+            if (activeStreams.findHandle("msg-list-" + s.id()).isPresent()) running.add(s.id());
+        }
+        return running;
+    }
+
+    /** The sessions with a tool stopped at the approval gate — the store is the truth, as for the cards. */
+    private java.util.Set<UUID> waitingSessions(List<? extends ai.mindconnect.agent.domain.view.AgentSessionHeader> sessions) {
+        java.util.Set<UUID> waiting = new java.util.HashSet<>();
+        for (var s : sessions) {
+            if (!approvalStore.openForRoot(s.id()).isEmpty()) waiting.add(s.id());
+        }
+        return waiting;
     }
 
     /**

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/StreamController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/StreamController.java
@@ -112,6 +112,20 @@ public class StreamController {
         // outlives them. Idle time is covered by the heartbeat.
         var emitter = new SseEmitter(0L);
 
+        // Commit the response before anything else. Spring writes the headers
+        // of an SseEmitter with its first event, and on a quiet session that
+        // is the next heartbeat — up to 25 s in which the browser's fetch()
+        // has not resolved and the SPA does not yet know it holds this
+        // connection. A second page render inside that window opened a
+        // second stream to the same session, and the first one leaked. A
+        // comment is invisible to every handler and closes the window.
+        try {
+            emitter.send(SseEmitter.event().comment("attached"));
+        } catch (java.io.IOException e) {
+            emitter.completeWithError(e);
+            return ResponseEntity.ok().body(emitter);
+        }
+
         // A client that arrives mid-turn has no streaming bubble in its DOM,
         // so every cumulative token REPLACE would land nowhere. The catch-up
         // frames create it and fill it with the reply so far.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
@@ -310,6 +310,17 @@
     opacity: 1;
 }
 
+/* A chat that is busy says so where its age would be (chat-ui.js keeps the
+   class in step with the badge as the user stream reports changes). */
+#chat-menu li.sui-menu-item.is-running .sui-menu-badge {
+    color: var(--sui-accent, #2563eb);
+    font-weight: 600;
+}
+#chat-menu li.sui-menu-item.needs-input .sui-menu-badge {
+    color: var(--sui-warning, #b45309);
+    font-weight: 600;
+}
+
 /* The row's own badge steps aside so the two never overlap. */
 #chat-menu li.sui-menu-item:hover .sui-menu-badge,
 #chat-menu li.sui-menu-item:focus-within .sui-menu-badge {

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/js/chat-ui.js
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/js/chat-ui.js
@@ -93,6 +93,68 @@
         head.appendChild(button);
     }
 
+    /* ── What the rows say about their chats ──────────────────────────────
+     * The server renders a busy chat's row with "running" or "needs input"
+     * in place of its age (see ChatShellComponent); the user stream carries
+     * the changes after that. The menu renderer has no slot for a class on
+     * the row, so the state is read off the badge and turned into one here
+     * — that is what the stylesheet colours.
+     */
+    const BADGE_RUNNING = "running";
+    const BADGE_NEEDS_INPUT = "needs input";
+
+    function markRow(row) {
+        const badge = row.querySelector(".sui-menu-badge");
+        const text = badge ? badge.textContent.trim() : "";
+        row.classList.toggle("is-running", text === BADGE_RUNNING);
+        row.classList.toggle("needs-input", text === BADGE_NEEDS_INPUT);
+    }
+
+    function setBadge(row, text) {
+        let badge = row.querySelector(".sui-menu-badge");
+        if (!badge) {
+            badge = document.createElement("span");
+            badge.className = "sui-menu-badge";
+            const link = row.querySelector(".sui-menu-link");
+            (link || row).appendChild(badge);
+        }
+        badge.textContent = text;
+        markRow(row);
+    }
+
+    /** One event of the user's stream, applied to the row it concerns. */
+    function applyUserEvent(event) {
+        if (!event || !event.sessionId) return;
+        const row = document.getElementById("chat-" + event.sessionId);
+        if (!row) return;
+        switch (event.type) {
+            case "turn_started":
+                setBadge(row, BADGE_RUNNING);
+                break;
+            case "approval_requested":
+                setBadge(row, BADGE_NEEDS_INPUT);
+                break;
+            case "approval_answered":
+                // The turn goes on; the card is gone.
+                if (row.classList.contains("needs-input")) setBadge(row, BADGE_RUNNING);
+                break;
+            case "turn_finished":
+                setBadge(row, "now");
+                break;
+            case "session_titled": {
+                const label = row.querySelector(".sui-menu-label");
+                if (label && event.title) label.textContent = event.title;
+                const tip = row.querySelector(".sui-menu-tip");
+                if (tip && event.title) tip.textContent = event.title;
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    document.addEventListener("mc-user-event", (e) => applyUserEvent(e.detail));
+
     /** Gives every history row its menu; runs again after each patch. */
     function decorateRows() {
         const menu = document.getElementById(MENU_ID);
@@ -100,6 +162,7 @@
         menu.querySelectorAll("li.sui-menu-item").forEach((row) => {
             const id = (row.dataset.id || "");
             if (!id.startsWith("chat-") || id === "chat-new") return;
+            markRow(row);
             if (row.querySelector(".chat-row-menu")) return;
             row.classList.add("chat-row");
             row.appendChild(buildRowMenu(id.slice("chat-".length)));

--- a/mc-java-parent/pom.xml
+++ b/mc-java-parent/pom.xml
@@ -46,7 +46,7 @@
         <changelist>-SNAPSHOT</changelist>
         <!-- Version of the published semantic-ui artifacts (their own repo:
              mindconnect-ai/mc-semantic-ui) consumed across the monorepo. -->
-        <semantic-ui.version>0.3.0</semantic-ui.version>
+        <semantic-ui.version>0.3.1</semantic-ui.version>
         <java.version>21</java.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/website/docs/agents/admin-ui/index.md
+++ b/website/docs/agents/admin-ui/index.md
@@ -117,10 +117,26 @@ The navigation has seven top-level entries:
 ## The task manager
 
 The header carries a small badge that says what the task queue is doing right
-now — `3 running · 2 waiting`, or `idle`. It is live: the page attaches to a
-server-sent event stream (`/admin/api/tasks/sse`) once, and the stream stays
-attached while you navigate, so the count is current on every page without
-polling.
+now — `3 running · 2 waiting`, or `idle`. It is live: the page attaches to the
+user's own server-sent event stream (`/admin/api/stream`) once, and the stream
+stays attached while you navigate, so the count is current on every page
+without polling.
+
+The same stream carries what happens in your sessions while you are not
+looking at them: a turn started or finished, a tool waiting for your answer, a
+chat that got its title. The chat's history reflects it — a conversation with
+a turn in flight says `running` where its age would be, one with an approval
+card open says `needs input` — and it does so in every tab, whichever one
+sent the message.
+
+One thing to know about tabs: over HTTP/1.1 a browser keeps at most six
+connections open per site, and every stream the app holds is one of them —
+the user stream on every page, plus the session stream on a chat. A few chats
+in a few tabs reach that limit, and from then on every request queues behind
+the streams and pages stop loading. The tabs count their streams together and
+warn you once the sum comes within one of the limit; close the tabs you no
+longer need and the notice goes away. Served over HTTP/2 there is no such
+limit and no notice.
 
 A click on the badge opens the task queue, the admin UI's Task Manager:
 

--- a/website/docs/agents/admin-ui/index.md
+++ b/website/docs/agents/admin-ui/index.md
@@ -136,7 +136,9 @@ in a few tabs reach that limit, and from then on every request queues behind
 the streams and pages stop loading. The tabs count their streams together and
 warn you once the sum comes within one of the limit; close the tabs you no
 longer need and the notice goes away. Served over HTTP/2 there is no such
-limit and no notice.
+limit and no notice. To see what one tab holds, type `console.table(mc.streams())`
+into the browser console: a chat page lists `user-stream` and one
+`msg-list-…`, any other page only `user-stream`.
 
 A click on the badge opens the task queue, the admin UI's Task Manager:
 

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -160,6 +160,38 @@ session's, so it spans turns; it stays open across them until you disconnect
 or the emitter times out. Reattaching with the last seen `seq` is the intended
 loop, not an error path.
 
+## The user stream
+
+A session's stream tells you everything about one session, and nothing about
+the others. A client that shows a list of sessions — or wants to notify
+someone that an agent is waiting for them — needs the opposite: little about
+every session, without attaching to any of them. That is the user stream:
+
+```bash
+curl -N "http://localhost:8080/api/users/$USER/stream?afterSeq=0"
+```
+
+The first frame is the `attached` frame with the buffer bounds
+(`firstBufferedSeq`, `latestSeq`); then the buffered events after `afterSeq`
+replay and the stream continues live. Every frame is one JSON object with a
+`seq` and a `type`, and the `sessionId` it is about:
+
+| type | carries |
+|---|---|
+| `session_started` | `agentDefinitionId` — a top-level session was opened (sub-agent sessions do not announce themselves) |
+| `session_titled` | `title` — the session got its generated title after the first exchange |
+| `turn_started` | `turnId` |
+| `turn_finished` | `turnId`, `outcome` — `completed`, `failed` or `cancelled` |
+| `approval_requested` | `callId`, `toolName` — a tool waits for a human; `sessionId` is the **root** session whose chat shows the card, even when a sub-agent asked |
+| `approval_answered` | `callId`, `approved` — the question was answered, from whichever client |
+
+The tokens of a turn are not here. A client that sees `turn_started` for a
+session it is showing attaches to that session's stream for the rest; one
+that is not showing it updates a badge. The reconnect rules are the session
+stream's: remember `seq`, check `firstBufferedSeq` for a gap (the truth to
+reload from is `GET /api/sessions` and `GET /api/sessions/{id}/approvals`),
+and reattach with the last seen `seq` when the connection drops.
+
 ## Approvals
 
 A tool marked "needs approval" suspends its task and the turn stops, waiting


### PR DESCRIPTION
## What

A user's sessions share one coarse feed. `GET /api/users/{userId}/stream` carries `session_started`, `session_titled`, `turn_started`, `turn_finished`, `approval_requested` and `approval_answered` across all of that user's sessions, with the same contract as the session stream: an `attached` frame first, replay after `afterSeq`, then live. In the admin UI it is served at `/admin/api/stream`; the header's task badge rides on it instead of a stream of its own, and the chat history shows which conversations are running or need input, in every tab.

## Why

Chrome grants six HTTP/1.1 connections per host, and the admin UI could spend all of them on server-sent event streams. Once it did, every request stalled in the browser, which looked like a server hang. Three things fed it:

- the session and task streams did not commit their response until the first event, so on a quiet session a second page render within the heartbeat window opened a second connection the SPA did not know about;
- the task badge held a stream per tab beside the chat's;
- on the client, a stream stayed open after its page was left, and a reconnect registered only after its request returned.

## How

- Streams commit the moment they attach (`StreamController`, `TaskMonitorUiController`).
- The badge shares the user stream (`UserStream`, `UserStreamController`, `AdminLayout`).
- `UserChannels` fans events out per user in the runtime core; `AgentChatService`, `AgentSessionService` and `ToolCallWorker` publish them.
- The client side is [mc-semantic-ui 0.3.1](https://github.com/mindconnect-ai/mc-semantic-ui/pull/34): a stream is closed when its page no longer names it, running or not, and a reconnect registers before its request. `mc-java-parent` pins that version.
- As a safety net, `connection-budget.js` counts the streams each tab holds over a `BroadcastChannel` and shows a notice once the browser is within one connection of the limit, naming the count and the number of tabs. It stays quiet on HTTP/2.

## Verified

- `UserChannelsTest`, `UserStreamTest`, `TaskMonitorTest` green.
- Against the released 0.3.1 from Central: switching through four chats and to the Agents page leaves exactly `user-stream` plus the current session's `msg-list`; the server logs `Closed idle session stream` for each one left behind.

## Docs

`CHANGELOG.md` (Added and Fixed), `website/docs/agents/rest-api.md`, `website/docs/agents/admin-ui/index.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
