### PR TITLE
A long chat shows its newest messages, and two appends get two numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **agents:** a chat longer than 200 messages no longer hides its newest
+  ones. A session's history was loaded as the *first* 200 messages, so once
+  a conversation passed that the chat kept showing its opening and silently
+  dropped everything after it, the message just sent included. It looked
+  like the message disappearing and the view jumping back a turn, while the
+  agent went on answering it, because the runtime had always read the
+  conversation entire. The history now comes back entire too, in the chat,
+  the admin UI's chat, the attached-files list and regenerate.
+
 ## [0.5.2] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **agents:** two messages appended at the same moment no longer claim the
+  same place in a conversation. The sequence number was read and written in
+  two steps, so a turn finishing several tool calls together could hand the
+  same number to two messages and skip the next, which throws off anything
+  cutting by it: delete-from-here, regenerate, and the tool cards a turn is
+  folded into. Handing out the number is now the store's own doing, in one
+  step: Postgres reserves it in a counter row, the file and in-memory stores
+  take a lock per conversation. `MessageRepository` gains `append` and loses
+  `countByConversationId`, whose only caller this was.
+
 - **agents:** a chat longer than 200 messages no longer hides its newest
   ones. A session's history was loaded as the *first* 200 messages, so once
   a conversation passed that the chat kept showing its opening and silently

--- a/agents/adapter/postgres/mc-message-repository-pg/src/main/java/ai/mindconnect/message/adapter/pg/PgMessageRepository.java
+++ b/agents/adapter/postgres/mc-message-repository-pg/src/main/java/ai/mindconnect/message/adapter/pg/PgMessageRepository.java
@@ -10,6 +10,7 @@ import javax.sql.DataSource;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.IntFunction;
 
 /**
  * {@link MessageRepository} on Postgres. One row of {@code mc_message} per
@@ -23,7 +24,28 @@ import java.util.UUID;
  */
 public final class PgMessageRepository implements MessageRepository {
 
+    /**
+     * One row per conversation holding the last number handed out. The
+     * upsert below takes that row's lock, so two appenders queue up on it
+     * and leave with different numbers; without it both would read the
+     * same highest {@code seq} and write it twice. The row seeds itself
+     * from the messages already stored, so a conversation that predates
+     * this table carries on where it left off.
+     */
+    private static final String SEQUENCE_TABLE = """
+            CREATE TABLE IF NOT EXISTS mc_message_seq (
+                conversation_id UUID PRIMARY KEY,
+                last_seq        INTEGER NOT NULL
+            )""";
+
+    private static final String NEXT_SEQUENCE = """
+            INSERT INTO mc_message_seq (conversation_id, last_seq)
+            VALUES (?, (SELECT coalesce(max(seq), 0) + 1 FROM mc_message WHERE conversation_id = ?))
+            ON CONFLICT (conversation_id) DO UPDATE SET last_seq = mc_message_seq.last_seq + 1
+            RETURNING last_seq""";
+
     private final DocumentTable<Message> messages;
+    private final Sql sql;
 
     public PgMessageRepository(DataSource dataSource) {
         this(Sql.of(dataSource));
@@ -31,6 +53,7 @@ public final class PgMessageRepository implements MessageRepository {
 
     /** Share a {@link Sql} — and with it the application's JSON mapper — with the other stores. */
     public PgMessageRepository(Sql sql) {
+        this.sql = sql;
         this.messages = DocumentTable.of(Message.class)
                 .table("mc_message")
                 .id("id", "UUID", Message::id)
@@ -43,6 +66,7 @@ public final class PgMessageRepository implements MessageRepository {
     /** Runs the idempotent DDL ({@code CREATE TABLE IF NOT EXISTS …}). */
     public PgMessageRepository initSchema() {
         messages.createSchema();
+        sql.execute(SEQUENCE_TABLE);
         return this;
     }
 
@@ -62,9 +86,15 @@ public final class PgMessageRepository implements MessageRepository {
         return messages.findOne("WHERE id = ? AND conversation_id = ?", messageId, conversationId);
     }
 
+    /**
+     * The number comes from the counter row, in one statement, before the
+     * message is written. Nothing is retried and nothing is locked in
+     * Java: the row lock the upsert takes is what serialises two appenders.
+     */
     @Override
-    public int countByConversationId(UUID conversationId) {
-        return messages.count("WHERE conversation_id = ?", conversationId);
+    public Message append(UUID conversationId, IntFunction<Message> create) {
+        int next = sql.scalar(NEXT_SEQUENCE, Integer.class, conversationId, conversationId);
+        return messages.save(create.apply(next));
     }
 
     @Override

--- a/agents/adapter/postgres/mc-message-repository-pg/src/test/java/ai/mindconnect/message/adapter/pg/PgMessageRepositoryTest.java
+++ b/agents/adapter/postgres/mc-message-repository-pg/src/test/java/ai/mindconnect/message/adapter/pg/PgMessageRepositoryTest.java
@@ -27,6 +27,7 @@ class PgMessageRepositoryTest {
     void setUp() {
         Sql sql = Sql.of(TestDb.requirePostgres());
         sql.execute("DROP TABLE IF EXISTS mc_message");
+        sql.execute("DROP TABLE IF EXISTS mc_message_seq");
         repo = new PgMessageRepository(sql).initSchema();
     }
 
@@ -68,7 +69,7 @@ class PgMessageRepositoryTest {
         Message compressed = m.withCompressed("[summary]", 5);
         repo.save(compressed);
 
-        assertThat(repo.countByConversationId(conversation)).isEqualTo(1);
+        assertThat(repo.findByConversationId(conversation, PageRequest.DEFAULT)).hasSize(1);
         assertThat(repo.findById(conversation, m.id())).contains(compressed);
         assertThat(repo.findById(conversation, m.id())).get()
                 .extracting(Message::compressed, Message::compressedContent).containsExactly(true, "[summary]");
@@ -83,8 +84,8 @@ class PgMessageRepositoryTest {
                 .extracting(Message::sequenceNum).containsExactly(1, 2, 3);
         assertThat(repo.findByConversationId(conversation, new PageRequest(1, 3)))
                 .extracting(Message::sequenceNum).containsExactly(4, 5);
-        assertThat(repo.countByConversationId(conversation)).isEqualTo(5);
-        assertThat(repo.countByConversationId(UUID.randomUUID())).isZero();
+        assertThat(repo.findByConversationId(conversation, PageRequest.DEFAULT)).hasSize(5);
+        assertThat(repo.findByConversationId(UUID.randomUUID(), PageRequest.DEFAULT)).isEmpty();
     }
 
     @Test
@@ -97,7 +98,56 @@ class PgMessageRepositoryTest {
 
         assertThat(repo.findByConversationId(conversation, PageRequest.DEFAULT))
                 .extracting(Message::sequenceNum).containsExactly(1, 5, 6);
-        assertThat(repo.countByConversationId(other)).isEqualTo(1);
+        assertThat(repo.findByConversationId(other, PageRequest.DEFAULT)).hasSize(1);
         repo.deleteBySequenceRange(conversation, 100, 200); // nothing there is not an error
+    }
+
+    @Test
+    void appendNumbersTheMessagesAndPicksUpFromWhatIsAlreadyStored() {
+        repo.append(conversation, seq -> message(seq));
+        repo.append(conversation, seq -> message(seq));
+
+        assertThat(repo.findByConversationId(conversation, PageRequest.DEFAULT))
+                .extracting(Message::sequenceNum).containsExactly(1, 2);
+
+        // A conversation written before the counter existed: the first
+        // append reads where it got to instead of starting over at 1.
+        UUID older = UUID.randomUUID();
+        IntStream.rangeClosed(1, 7).forEach(seq ->
+                repo.save(Message.of(older, sender, ParticipantType.USER, MessageType.CHAT, "m" + seq, seq)));
+
+        assertThat(repo.append(older, seq -> Message.of(older, sender, ParticipantType.USER,
+                MessageType.CHAT, "next", seq)).sequenceNum()).isEqualTo(8);
+    }
+
+    @Test
+    void twentyThreadsAppendingAtOnceGetTwentyDifferentNumbers() throws Exception {
+        int writers = 20;
+        var start = new java.util.concurrent.CountDownLatch(1);
+        var done = new java.util.concurrent.CountDownLatch(writers);
+        var failures = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
+        try (var pool = java.util.concurrent.Executors.newFixedThreadPool(writers)) {
+            for (int i = 0; i < writers; i++) {
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        repo.append(conversation, seq -> message(seq));
+                    } catch (Throwable t) {
+                        failures.add(t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertThat(done.await(60, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+        }
+
+        assertThat(failures).isEmpty();
+        assertThat(repo.findByConversationId(conversation, new PageRequest(0, 100)))
+                .extracting(Message::sequenceNum)
+                .as("every appender left with a number of its own")
+                .containsExactlyInAnyOrderElementsOf(
+                        IntStream.rangeClosed(1, writers).boxed().toList());
     }
 }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentSessionService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/service/AgentSessionService.java
@@ -34,6 +34,9 @@ public class AgentSessionService {
 
     private static final Logger log = LoggerFactory.getLogger(AgentSessionService.class);
 
+    /** No paging: {@link #loadHistory} returns the conversation entire. */
+    private static final int LOAD_ALL = Integer.MAX_VALUE;
+
     private final AgentDefinitionRepository definitionRepository;
     private final AgentSessionRepository sessionRepository;
     private final ConversationManager conversationManager;
@@ -179,9 +182,17 @@ public class AgentSessionService {
                 .orElseThrow(() -> DomainException.notFound("AgentSession", sessionId.toString()));
     }
 
+    /**
+     * The session's whole conversation, oldest first. Not a page: this is
+     * what the chat shows, and a cap here cuts away the newest messages,
+     * not the oldest. A conversation past the cap kept displaying its
+     * opening and silently dropped everything after it, the message just
+     * sent included. The runtime has always read the conversation entire;
+     * the display now agrees with it.
+     */
     public List<Message> loadHistory(UUID sessionId) {
         AgentSession session = findSession(sessionId);
-        return conversationManager.loadHistory(session.conversationId(), new PageRequest(0, 200));
+        return conversationManager.loadHistory(session.conversationId(), new PageRequest(0, LOAD_ALL));
     }
 
     /**

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/SessionHistoryTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/service/SessionHistoryTest.java
@@ -1,0 +1,123 @@
+package ai.mindconnect.agent.service;
+
+import ai.mindconnect.agent.domain.AgentSession;
+import ai.mindconnect.agent.port.out.AgentSessionRepository;
+import ai.mindconnect.common.Namespace;
+import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.domain.Conversation;
+import ai.mindconnect.message.domain.ConversationHistory;
+import ai.mindconnect.message.domain.ConversationType;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.Participant;
+import ai.mindconnect.message.domain.ParticipantType;
+import ai.mindconnect.message.port.in.ConversationManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * What a session's history hands back is the whole conversation. It used to
+ * be the first 200 messages, so a long chat kept showing its opening and
+ * dropped everything after it — the message just sent included, while the
+ * runtime itself went on reading all of them.
+ */
+class SessionHistoryTest {
+
+    private final UUID conversationId = UUID.randomUUID();
+
+    @Test
+    void aConversationPastTheOldCapComesBackEntire() {
+        Conversations conversations = new Conversations(conversationId);
+        for (int i = 1; i <= 315; i++) {
+            conversations.append("message " + i);
+        }
+        AgentSession session = AgentSession.start(UUID.randomUUID(), new Namespace("default"),
+                "mc_user", conversationId);
+        AgentSessionService service = serviceFor(session, conversations);
+
+        List<Message> history = service.loadHistory(session.id());
+
+        assertThat(history).hasSize(315);
+        assertThat(history.get(history.size() - 1).content()).isEqualTo("message 315");
+        assertThat(conversations.requested.page()).isZero();
+        assertThat(conversations.requested.size()).as("one page, big enough for any chat")
+                .isGreaterThanOrEqualTo(315);
+    }
+
+    private AgentSessionService serviceFor(AgentSession session, ConversationManager conversations) {
+        AgentSessionRepository sessions = new AgentSessionRepository() {
+            @Override public AgentSession save(AgentSession s) { return s; }
+            @Override public Optional<AgentSession> findById(UUID id) {
+                return session.id().equals(id) ? Optional.of(session) : Optional.empty();
+            }
+            @Override public List<AgentSession> findByAgentDefinitionId(UUID a, Namespace n, String u) {
+                return List.of();
+            }
+            @Override public List<AgentSession> findByUser(Namespace n, String u) { return List.of(); }
+            @Override public List<AgentSession> findByParentSessionId(UUID parent) { return List.of(); }
+            @Override public void deleteById(UUID id) { }
+        };
+        return new AgentSessionService(null, sessions, conversations, null, null, null, null, null);
+    }
+
+    /** Only what {@code loadHistory} touches; the page it was asked for is kept. */
+    private static final class Conversations implements ConversationManager {
+        private final UUID conversationId;
+        private final List<Message> messages = new ArrayList<>();
+        private PageRequest requested;
+        private int seq;
+
+        private Conversations(UUID conversationId) {
+            this.conversationId = conversationId;
+        }
+
+        void append(String content) {
+            messages.add(Message.of(conversationId, UUID.randomUUID(), ParticipantType.USER,
+                    MessageType.CHAT, content, ++seq));
+        }
+
+        @Override public List<Message> loadHistory(UUID id, PageRequest page) {
+            this.requested = page;
+            return messages.stream().skip(page.offset()).limit(page.size()).toList();
+        }
+
+        @Override public ConversationHistory loadCompleteHistory(UUID id) {
+            return ConversationHistory.of(id, List.copyOf(messages));
+        }
+
+        @Override public Conversation createConversation(Namespace namespace, String title,
+                ConversationType type, List<Participant> participants) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public Optional<Conversation> findById(UUID id) { return Optional.empty(); }
+        @Override public List<Conversation> listByNamespace(Namespace namespace, PageRequest page) {
+            return List.of();
+        }
+        @Override public Message addMessageToConversation(UUID id, UUID senderId,
+                ParticipantType senderType, MessageType type, String content, UUID turnId) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public Message addMessageToConversation(UUID id, UUID senderId,
+                ParticipantType senderType, MessageType type, String content, UUID turnId,
+                Integer run, Map<String, Object> metadata) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public Message addMessageToConversation(UUID id, UUID senderId,
+                ParticipantType senderType, MessageType type,
+                List<ai.mindconnect.message.domain.ContentPart> parts, UUID turnId,
+                Integer run, Map<String, Object> metadata) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void compressMessage(UUID id, UUID messageId, String stub, Integer tokens) { }
+        @Override public void updateTokenCount(UUID id, UUID messageId, int tokenCount) { }
+        @Override public void updateDurationMs(UUID id, UUID messageId, long durationMs) { }
+        @Override public int deleteMessages(UUID id, int fromSeq, int toSeq) { return 0; }
+    }
+}

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/port/out/MessageRepository.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/port/out/MessageRepository.java
@@ -6,6 +6,7 @@ import ai.mindconnect.message.domain.Message;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.IntFunction;
 
 public interface MessageRepository {
 
@@ -19,7 +20,23 @@ public interface MessageRepository {
 
     Optional<Message> findById(UUID conversationId, UUID messageId);
 
-    int countByConversationId(UUID conversationId);
+    /**
+     * Appends a message with the next free sequence number of its
+     * conversation, and gives back what was stored.
+     *
+     * <p>The number is the adapter's to hand out, because only the adapter
+     * knows how to reserve one without a second writer getting the same:
+     * the store-backed ones take a lock per conversation, the SQL one lets
+     * the database count. Reading the highest number and writing a row are
+     * one step here; apart, two turns appending at the same moment (two
+     * tool results arriving together, say) both read the same number and
+     * the conversation ends up with two messages claiming it.
+     *
+     * <p>{@code create} is handed the reserved number and returns the
+     * message to store. It is called while the reservation is held, so it
+     * should do nothing but build the message.
+     */
+    Message append(UUID conversationId, IntFunction<Message> create);
 
     /** Deletes all messages whose sequenceNum is in [fromSeq, toSeq] inclusive. */
     void deleteBySequenceRange(UUID conversationId, int fromSeq, int toSeq);

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/service/ConversationService.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/service/ConversationService.java
@@ -64,17 +64,20 @@ public class ConversationService implements ConversationManager {
                 turnId, run, metadata);
     }
 
-    /** The shared tail: the conversation must exist, the sequence is the next free one. */
+    /**
+     * The shared tail: the conversation must exist, and the store hands out
+     * the sequence number as it writes. Counting the messages here and
+     * writing afterwards is what used to give two messages the same number
+     * whenever a turn appended twice at once.
+     */
     private Message append(UUID conversationId, java.util.function.IntFunction<Message> create,
                            UUID turnId, Integer run, java.util.Map<String, Object> metadata) {
         conversationRepository.findById(conversationId)
                 .orElseThrow(() -> DomainException.notFound("Conversation", conversationId.toString()));
-        int seq = messageRepository.countByConversationId(conversationId) + 1;
-        Message message = create.apply(seq)
-                .withTurnId(turnId)
-                .withMetadata(metadata);
-        if (run != null) message = message.withRun(run);
-        return messageRepository.save(message);
+        return messageRepository.append(conversationId, seq -> {
+            Message message = create.apply(seq).withTurnId(turnId).withMetadata(metadata);
+            return run != null ? message.withRun(run) : message;
+        });
     }
 
     @Override

--- a/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/service/ConversationServiceTest.java
+++ b/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/service/ConversationServiceTest.java
@@ -197,8 +197,12 @@ class ConversationServiceTest {
         }
 
         @Override
-        public int countByConversationId(UUID id) {
-            return (int) store.stream().filter(m -> m.conversationId().equals(id)).count();
+        public synchronized Message append(UUID id, java.util.function.IntFunction<Message> create) {
+            int next = store.stream()
+                    .filter(m -> m.conversationId().equals(id))
+                    .mapToInt(Message::sequenceNum)
+                    .max().orElse(0) + 1;
+            return save(create.apply(next));
         }
 
         @Override

--- a/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileMessageRepository.java
+++ b/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileMessageRepository.java
@@ -12,7 +12,10 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.IntFunction;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 import java.nio.file.PathMatcher;
 
 /**
@@ -24,6 +27,21 @@ import java.nio.file.PathMatcher;
 public class FileMessageRepository implements MessageRepository {
 
     private static final Logger log = Logger.getLogger(FileMessageRepository.class.getName());
+
+    /**
+     * Locks for {@link #append}, one bucket per conversation by hash. A
+     * fixed set rather than one per conversation: nothing to create, and
+     * nothing that grows for as long as the process lives. Two
+     * conversations sharing a bucket wait for each other now and then,
+     * which costs a moment and breaks nothing.
+     *
+     * <p>Process-wide, which is what a directory of files is: two JVMs
+     * writing into the same store would still hand out the same number.
+     */
+    private static final int APPEND_LOCKS = 64;
+
+    private final ReentrantLock[] appendLocks = Stream.generate(ReentrantLock::new)
+            .limit(APPEND_LOCKS).toArray(ReentrantLock[]::new);
 
     private final Path baseDir;
     private final ObjectMapper objectMapper;
@@ -100,13 +118,42 @@ public class FileMessageRepository implements MessageRepository {
     }
 
     @Override
-    public int countByConversationId(UUID conversationId) {
+    public Message append(UUID conversationId, IntFunction<Message> create) {
+        ReentrantLock lock = appendLocks[Math.floorMod(conversationId.hashCode(), APPEND_LOCKS)];
+        lock.lock();
+        try {
+            return save(create.apply(maxSequenceNum(conversationId) + 1));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * The highest number in the conversation, 0 when it has no messages.
+     * Read from the file names, which carry it zero-padded in front, so
+     * this costs a directory listing and opens nothing.
+     */
+    private int maxSequenceNum(UUID conversationId) {
         Path dir = messagesDir(conversationId);
         if (!Files.exists(dir)) return 0;
         try (var stream = Files.list(dir)) {
-            return (int) stream.filter(p -> p.toString().endsWith(".json")).count();
+            return stream.filter(p -> p.toString().endsWith(".json"))
+                    .mapToInt(p -> seqOf(p.getFileName().toString()))
+                    .filter(seq -> seq >= 0)
+                    .max().orElse(0);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    /** The leading digits of "0000000012_<uuid>.json"; -1 for a name of another shape. */
+    private static int seqOf(String fileName) {
+        int underscore = fileName.indexOf('_');
+        if (underscore < 1) return -1;
+        try {
+            return Integer.parseInt(fileName.substring(0, underscore));
+        } catch (NumberFormatException e) {
+            return -1;
         }
     }
 
@@ -117,18 +164,14 @@ public class FileMessageRepository implements MessageRepository {
         try (var stream = Files.list(dir)) {
             stream.filter(p -> p.toString().endsWith(".json"))
                     .forEach(p -> {
-                        // filename format: 0000000012_<uuid>.json — extract leading digits
-                        String name = p.getFileName().toString();
-                        try {
-                            int seq = Integer.parseInt(name.substring(0, name.indexOf('_')));
-                            if (seq >= fromSeq && seq <= toSeq) {
+                        int seq = seqOf(p.getFileName().toString());
+                        if (seq >= 0 && seq >= fromSeq && seq <= toSeq) {
+                            try {
                                 Files.delete(p);
                                 log.fine("Deleted message file: " + p.getFileName());
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
                             }
-                        } catch (NumberFormatException ignored) {
-                            // skip files that don't match naming convention
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
                         }
                     });
         } catch (IOException e) {

--- a/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/memory/InMemoryMessageRepository.java
+++ b/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/memory/InMemoryMessageRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.IntFunction;
 
 /** In-memory {@link MessageRepository} — process-lifetime storage, no persistence. */
 public class InMemoryMessageRepository implements MessageRepository {
@@ -44,9 +45,18 @@ public class InMemoryMessageRepository implements MessageRepository {
                 .findFirst();
     }
 
+    /**
+     * One appender at a time, so two of them cannot read the same highest
+     * number. The list itself is thread-safe; handing out a number is not,
+     * and that is what needs guarding.
+     */
     @Override
-    public int countByConversationId(UUID conversationId) {
-        return (int) store.stream().filter(m -> m.conversationId().equals(conversationId)).count();
+    public synchronized Message append(UUID conversationId, IntFunction<Message> create) {
+        int next = store.stream()
+                .filter(m -> m.conversationId().equals(conversationId))
+                .mapToInt(Message::sequenceNum)
+                .max().orElse(0) + 1;
+        return save(create.apply(next));
     }
 
     @Override

--- a/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/AppendGivesEachMessageItsOwnNumberTest.java
+++ b/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/AppendGivesEachMessageItsOwnNumberTest.java
@@ -1,0 +1,102 @@
+package ai.mindconnect.message.adapter;
+
+import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.adapter.file.FileMessageRepository;
+import ai.mindconnect.message.adapter.memory.InMemoryMessageRepository;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import ai.mindconnect.message.port.out.MessageRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Handing out a sequence number is the store's job, and no two appenders
+ * may leave with the same one. Both stores that live in this module are
+ * held to it: the numbers run 1, 2, 3 …, a store with messages already in
+ * it carries on from the highest, and twenty threads appending at the same
+ * moment produce twenty different numbers. Reading the highest number and
+ * writing the row apart is what used to give a busy turn two messages
+ * claiming the same place in the conversation.
+ */
+class AppendGivesEachMessageItsOwnNumberTest {
+
+    @TempDir
+    static Path dir;
+
+    private static final UUID CONVERSATION = UUID.randomUUID();
+    private static final UUID SENDER = UUID.randomUUID();
+
+    static List<MessageRepository> stores() {
+        return List.of(new InMemoryMessageRepository(),
+                new FileMessageRepository(dir.resolve(UUID.randomUUID().toString()),
+                        new ObjectMapper().registerModule(new JavaTimeModule())));
+    }
+
+    private static Message message(UUID conversation, int seq) {
+        return Message.of(conversation, SENDER, ParticipantType.USER, MessageType.CHAT, "m" + seq, seq);
+    }
+
+    @ParameterizedTest
+    @MethodSource("stores")
+    void theNumbersRunFromOne_andAStoreWithMessagesCarriesOn(MessageRepository store) {
+        UUID conversation = UUID.randomUUID();
+
+        assertThat(store.append(conversation, seq -> message(conversation, seq)).sequenceNum()).isEqualTo(1);
+        assertThat(store.append(conversation, seq -> message(conversation, seq)).sequenceNum()).isEqualTo(2);
+
+        UUID older = UUID.randomUUID();
+        IntStream.rangeClosed(1, 7).forEach(seq -> store.save(message(older, seq)));
+        assertThat(store.append(older, seq -> message(older, seq)).sequenceNum())
+                .as("picks up above what is already stored").isEqualTo(8);
+
+        assertThat(store.append(UUID.randomUUID(), s -> message(UUID.randomUUID(), s)).sequenceNum())
+                .as("each conversation counts on its own").isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("stores")
+    void twentyThreadsAppendingAtOnceGetTwentyDifferentNumbers(MessageRepository store) throws Exception {
+        int writers = 20;
+        UUID conversation = UUID.randomUUID();
+        var start = new CountDownLatch(1);
+        var done = new CountDownLatch(writers);
+        var failures = new CopyOnWriteArrayList<Throwable>();
+
+        try (var pool = Executors.newFixedThreadPool(writers)) {
+            for (int i = 0; i < writers; i++) {
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        store.append(conversation, seq -> message(conversation, seq));
+                    } catch (Throwable t) {
+                        failures.add(t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+        }
+
+        assertThat(failures).isEmpty();
+        assertThat(store.findByConversationId(conversation, new PageRequest(0, 100)))
+                .extracting(Message::sequenceNum)
+                .containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(1, writers).boxed().toList());
+    }
+}


### PR DESCRIPTION
Two bugs in the same area, both found while using the chat: a long
conversation stopped showing what was newest, and a busy turn could give
two messages the same place in the conversation.

## A long chat shows its newest messages

`AgentSessionService.loadHistory` read the *first* 200 messages of the
session's conversation. Past that, the chat kept rendering the opening of
the chat and dropped everything after it. The message you had just sent
vanished from the view, which fell back to the previous turn, while the
agent answered it regardless: the runtime reads the conversation entire,
so the model saw a message the display did not.

Observed on a 315-message conversation. The last chat message inside the
window was number 198, and that is exactly where the rendered page ended.

The display now reads the conversation entire too, which also covers the
admin UI's chat, the attached-files list, sub-agent history and
regenerate.

## Two messages appended at once get two numbers

A message's sequence number came from `countByConversationId() + 1`,
written as a second step. Two appends at the same moment, which is what a
turn does when several tool calls come back together, read the same count
and stored the same number; the following number was then skipped. In the
conversation above, five numbers were held by two messages and one by
three, with six numbers missing.

Nothing crashes from it, but everything that cuts a conversation by
sequence is then cutting in the wrong place: delete-from-here,
regenerate, and the window a turn's tool cards are collected from.

Reserving the number is now the store's own doing, in one step, because
only the store can make it one step:

- **Postgres** keeps a counter row per conversation in a new
  `mc_message_seq` table and reserves through an upsert, whose row lock
  serialises the appenders. The row seeds itself from the messages
  already stored, so conversations written before this carry on where
  they left off, with no migration.
- **File and in-memory** stores take a lock per conversation. Both are
  single-process by nature, which is what that covers.

`MessageRepository` gains `append(conversationId, create)` and loses
`countByConversationId`, whose only caller this was.

## Not in here

The unique index on `(conversation_id, seq)` that would have the database
refuse a duplicate outright. Schemas are created at startup, and any
database written before this fix holds duplicates, so adding the index
now would stop the app from coming up. It wants a repair step first,
which is worth its own PR.

## Verification

Full suite green (884 tests, 25 skipped). The Postgres tests ran against
a real database rather than being skipped.

Both concurrency tests were checked for teeth by removing the guard they
test: without the counter row the Postgres test fails, without the lock
the file-store test fails. Twenty threads append to one conversation at
the same moment and must come away with twenty different numbers.
