### PR TITLE
An OpenAI embedding config, and a template form that admits what it cannot save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Added
+
+- **agents:** a bundled `openai-embeddings` LLM config — OpenAI's
+  `text-embedding-3-small` (override with `OPENAI_EMBEDDING_MODEL`) with
+  `OPENAI_API_KEY`, for vector stores and file ingestion when no local
+  embedding server is running. Choose it in a store template or via
+  `mindconnect.vector-store.embedding-config`; the local `embeddings` config
+  stays the default.
+
 ### Fixed
 
 - **agents:** two messages appended at the same moment no longer claim the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
   conversation entire. The history now comes back entire too, in the chat,
   the admin UI's chat, the attached-files list and regenerate.
 
+- **agents:** editing the built-in `default` vector-store template in the Admin
+  UI no longer pretends to save. The built-in template is the
+  `mindconnect.vector-store.*` properties; its edit form now says so and saves
+  the values as a copy under a name of your own, and saving or deleting it
+  under its own name reports why nothing happened instead of staying silent.
+
 ## [0.5.2] - 2026-09-09
 
 ### Added

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/openai-embeddings.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/openai-embeddings.json
@@ -1,0 +1,10 @@
+{
+  "id": "00000001-0000-0000-0000-000000000011",
+  "name": "openai-embeddings",
+  "provider": "OPENAI",
+  "model": "${OPENAI_EMBEDDING_MODEL:text-embedding-3-small}",
+  "baseUrl": "https://api.openai.com",
+  "apiKey": "${OPENAI_API_KEY}",
+  "additionalParams": {},
+  "type": "EMBEDDING"
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
@@ -14,6 +14,7 @@ import ai.mindconnect.ui.model.UiSection;
 import ai.mindconnect.ui.model.UiSectionEntry;
 import ai.mindconnect.ui.model.UiStack;
 import ai.mindconnect.ui.model.UiTable;
+import ai.mindconnect.ui.model.UiToast;
 import ai.mindconnect.ui.model.UiText;
 import ai.mindconnect.ui.model.UiTrigger;
 import ai.mindconnect.vectorstore.VectorStore;
@@ -266,45 +267,59 @@ public class VectorStoreUiController {
 
     @GetMapping("/templates/new")
     public UiPage newTemplate() {
-        return templateForm(null);
+        return templateForm(null, false);
     }
 
+    /**
+     * The built-in template is not a file but the {@code mindconnect.vector-store.*}
+     * properties, so editing it opens its values as an unnamed copy: name the
+     * copy and it becomes a template of its own.
+     */
     @GetMapping("/templates/{name}/edit")
     public UiPage editTemplate(@PathVariable String name) {
-        return templateForm(stores.registry().template(name).orElse(null));
+        if (VectorStores.DEFAULT_TEMPLATE.equals(name)) {
+            return templateForm(stores.template(name).orElse(null), true);
+        }
+        return templateForm(stores.registry().template(name).orElse(null), false);
     }
 
-    private UiPage templateForm(VectorStoreTemplate t) {
-        boolean isNew = t == null;
+    private static final String BUILT_IN_NOTE = "'" + VectorStores.DEFAULT_TEMPLATE
+            + "' is the built-in template: it follows the mindconnect.vector-store.* properties "
+            + "(embedding config: mindconnect.vector-store.embedding-config) and cannot be changed here.";
+
+    private UiPage templateForm(VectorStoreTemplate t, boolean builtIn) {
+        boolean isNew = t == null || builtIn;
         List<UiField.Option> backends = List.of(
                 UiField.Option.of("memory", "memory"), UiField.Option.of("pgvector", "pgvector"));
         List<UiField.Option> embeddingOptions = llmConfigs.findAll().stream()
                 .map(c -> UiField.Option.of(c.name(), c.name())).toList();
-        UiForm form = UiForm.of("vs-template-form", isNew ? "New Template" : "Edit Template: " + t.name())
+        UiForm form = UiForm.of("vs-template-form", builtIn ? "Built-in Template: " + t.name()
+                        : isNew ? "New Template" : "Edit Template: " + t.name())
                 .field(UiField.text("name", "Name", isNew ? null : t.name()).asEditable()
-                        .hint("Unique template name, e.g. knowledge or chat-uploads"))
-                .field(UiField.select("backend", "Backend", isNew ? "memory" : t.backend(), backends)
+                        .hint(builtIn ? BUILT_IN_NOTE + " Give this copy a name to save it as a template of your own."
+                                : "Unique template name, e.g. knowledge or chat-uploads"))
+                .field(UiField.select("backend", "Backend", t == null ? "memory" : t.backend(), backends)
                         .asEditable()
                         // Switching the backend swaps the backend-config group below.
                         .onChange(ai.mindconnect.ui.model.UiTrigger.api("POST",
                                 BASE + "/templates/backend-fields", "vs-template-form")))
                 .field(UiField.select("embeddingConfig", "Embedding Config",
-                        isNew ? "embeddings" : t.embeddingConfig(), embeddingOptions)
+                        t == null ? "embeddings" : t.embeddingConfig(), embeddingOptions)
                         .asEditable()
                         .hint("LlmConfig naming the embedding model — fixed per store at creation; "
                                 + "changing it later never affects existing stores"))
                 .field(UiField.text("ingestionWorkflow", "Ingestion Workflow",
-                        isNew ? "file-ingestion" : t.ingestionWorkflow()).asEditable()
+                        t == null ? "file-ingestion" : t.ingestionWorkflow()).asEditable()
                         .hint("Workflow started by 'Ingest file…' on stores of this template"))
                 .field(UiField.text("description", "Description",
-                        isNew ? null : t.metadata().get("description")).asEditable());
-        form.content(backendConfigGroup(isNew ? "memory" : t.backend(),
-                isNew ? Map.of() : t.backendConfig()));
-        form.action(UiAction.primary("save", "Save").icon("save")
+                        t == null || builtIn ? null : t.metadata().get("description")).asEditable());
+        form.content(backendConfigGroup(t == null ? "memory" : t.backend(),
+                t == null ? Map.of() : t.backendConfig()));
+        form.action(UiAction.primary("save", builtIn ? "Save as new template" : "Save").icon("save")
                         .dispatch("POST", "/admin/vector-stores/templates", "vs-template-form"))
                 .action(UiAction.secondary("cancel", "Cancel").icon("cancel").dispatch("GET", "/admin/vector-stores"))
                 .link(UiLink.of("back", BASE, "← Back to Vector Stores"));
-        return UiPage.of(BASE + (isNew ? "/templates/new" : "/templates/" + t.name() + "/edit"), form);
+        return UiPage.of(BASE + (t == null ? "/templates/new" : "/templates/" + t.name() + "/edit"), form);
     }
 
     /** The backend-specific settings, swapped in place when the dropdown changes. */
@@ -342,8 +357,9 @@ public class VectorStoreUiController {
     public UiPage saveTemplate(@RequestBody Map<String, Object> raw) {
         var body = new FormBody(raw);
         String name = body.str("name");
-        if (name == null || name.isBlank() || VectorStores.DEFAULT_TEMPLATE.equals(name)) {
-            return list("templates");
+        String refusal = saveRefusal(name);
+        if (refusal != null) {
+            return list("templates").toast(UiToast.error(refusal));
         }
         Map<String, String> backendConfig = new LinkedHashMap<>();
         putIfPresent(backendConfig, "url", body.str("url"));
@@ -357,11 +373,25 @@ public class VectorStoreUiController {
                 backendConfig,
                 body.str("embeddingConfig") == null ? "embeddings" : body.str("embeddingConfig"),
                 body.str("ingestionWorkflow"), metadata));
-        return list("templates");
+        return list("templates").toast(UiToast.success("Template '" + name.trim() + "' saved."));
+    }
+
+    /** Why a template of this name cannot be saved — {@code null} when it can. */
+    static String saveRefusal(String name) {
+        if (name == null || name.isBlank()) {
+            return "The template needs a name — nothing was saved.";
+        }
+        if (VectorStores.DEFAULT_TEMPLATE.equals(name.trim())) {
+            return BUILT_IN_NOTE + " Save the copy under another name — nothing was saved.";
+        }
+        return null;
     }
 
     @DeleteMapping("/templates/{name}")
     public UiPage deleteTemplate(@PathVariable String name) {
+        if (VectorStores.DEFAULT_TEMPLATE.equals(name)) {
+            return list("templates").toast(UiToast.error(BUILT_IN_NOTE));
+        }
         stores.registry().deleteTemplate(name);
         return list("templates");
     }

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiControllerTemplatesTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiControllerTemplatesTest.java
@@ -1,0 +1,27 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.vectorstore.tools.VectorStores;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The built-in template is the {@code mindconnect.vector-store.*} properties,
+ * not a file: saving under its name, or under none, is refused with a
+ * reason instead of quietly doing nothing.
+ */
+class VectorStoreUiControllerTemplatesTest {
+
+    @Test
+    void theBuiltInNameAndNoNameAreRefusedWithAReason() {
+        assertThat(VectorStoreUiController.saveRefusal(VectorStores.DEFAULT_TEMPLATE))
+                .contains("built-in template")
+                .contains("mindconnect.vector-store.embedding-config")
+                .endsWith("nothing was saved.");
+        assertThat(VectorStoreUiController.saveRefusal(" " + VectorStores.DEFAULT_TEMPLATE + " "))
+                .as("surrounding blanks do not slip past").contains("built-in template");
+        assertThat(VectorStoreUiController.saveRefusal(null)).isEqualTo("The template needs a name — nothing was saved.");
+        assertThat(VectorStoreUiController.saveRefusal("   ")).isEqualTo("The template needs a name — nothing was saved.");
+        assertThat(VectorStoreUiController.saveRefusal("chat-uploads")).isNull();
+    }
+}

--- a/website/docs/agents/environment-variables.md
+++ b/website/docs/agents/environment-variables.md
@@ -56,14 +56,17 @@ as an env var in `SCREAMING_SNAKE` form (e.g. `MINDCONNECT_DATA_BASE_DIR`).
 | `CLAUDE_HAIKU_MODEL` | `claude-haiku-default` | Override model id (default `claude-haiku-4-5`) |
 | `OPENAI_API_KEY` | `openai-default` | OpenAI API key |
 | `OPENAI_MODEL` | `openai-default` | Override model id (default `gpt-5.4-mini`) |
+| `OPENAI_EMBEDDING_MODEL` | `openai-embeddings` | Override the embedding model (default `text-embedding-3-small`; `OPENAI_API_KEY` is the key) |
+| `EMBEDDING_BASE_URL` | `embeddings` | Local embedding server (default `http://localhost:1234`, LM Studio) |
+| `EMBEDDING_MODEL` | `embeddings` | Override the local embedding model (default `text-embedding-nomic-embed-text-v1.5`) |
 | `AZURE_OPENAI_API_KEY` | `azure-openai-default` | Azure OpenAI key |
 | `AZURE_OPENAI_ENDPOINT` | `azure-openai-default` | Azure resource endpoint URL |
 | `AZURE_OPENAI_DEPLOYMENT` | `azure-openai-default` | Deployment name (default `gpt-4o`) |
 | `GEMINI_API_KEY` | `gemini-default` | Google Gemini key |
 | `GEMINI_MODEL` | `gemini-default` | Override model id (default `gemini-2.0-flash`) |
 
-Local providers (`lm-studio-default`, `agent-default`) need **no** key — they
-talk to LM Studio at `http://localhost:1234`.
+Local providers (`lm-studio-default`, `agent-default`, `embeddings`) need **no**
+key — they talk to LM Studio at `http://localhost:1234`.
 
 ## Tools
 

--- a/website/docs/agents/llm-configs-reference.md
+++ b/website/docs/agents/llm-configs-reference.md
@@ -29,6 +29,8 @@ resolve from environment variables), see
 | `gemini-default` | Google Gemini | `gemini-2.0-flash` | `GEMINI_API_KEY` |
 | `lm-studio-default` | LM Studio (local) | `openai/gpt-oss-120b` | none — local server at `http://localhost:1234` |
 | `agent-default` | LM Studio (local) | `openai/gpt-oss-120b` | none — the default most agents use |
+| `embeddings` | LM Studio (local), `EMBEDDING` | `text-embedding-nomic-embed-text-v1.5` | none — `EMBEDDING_BASE_URL`, `EMBEDDING_MODEL` to override |
+| `openai-embeddings` | OpenAI, `EMBEDDING` | `text-embedding-3-small` | `OPENAI_API_KEY`, `OPENAI_EMBEDDING_MODEL` |
 
 :::info `agent-default` is the default
 Most bundled agents reference **`agent-default`**, which points at a local

--- a/website/docs/agents/vector-store.md
+++ b/website/docs/agents/vector-store.md
@@ -60,10 +60,19 @@ Embedding happens **inside the tools** through the gateway's `LlmEmbeddings`
 port. It needs an [LLM config](./llm-config-json.md) of `type: EMBEDDING` —
 by default one named **`embeddings`** (`mindconnect.vector-store.embedding-config`).
 
-:::warning No embedding config is bundled
-None of the bundled LLM configs is an embedding config, so the knowledge tools
-report themselves unavailable until you create one (e.g. an OpenAI
-`text-embedding-3-small` config named `embeddings`).
+:::info Two embedding configs are bundled
+`embeddings` points at a local LM Studio server (`text-embedding-nomic-embed-text-v1.5`
+at `http://localhost:1234`), `openai-embeddings` at OpenAI's
+`text-embedding-3-small` with `OPENAI_API_KEY`. Stores are created with the
+`embeddings` config; to use OpenAI instead, pick `openai-embeddings` in the
+store template (Admin UI → Vector Stores → the `chat-uploads` template) or set
+`mindconnect.vector-store.embedding-config`.
+
+There is no dimension to configure: a store takes the dimension of the first
+vectors written to it and rejects others afterwards. Switching a template's
+embedding config therefore only affects stores created from then on — a store
+filled with 768-dimensional nomic vectors will not accept 1536-dimensional
+OpenAI ones, so delete and re-ingest it when you switch.
 :::
 
 ## The knowledge tools


### PR DESCRIPTION
An embedding config for OpenAI, and the vector-store template form saying
what it can and cannot do.

## An OpenAI embedding config comes bundled

The only bundled embedding config pointed at a local LM Studio server, so
file ingestion and the knowledge tools were down whenever that server was
not running: a document sent to a chat, or through the Responses API, came
back as `Embeddings call to http://localhost:1234 failed`.

`openai-embeddings` is a second one: OpenAI's `text-embedding-3-small`,
keyed by `OPENAI_API_KEY` like `openai-default`, with
`OPENAI_EMBEDDING_MODEL` to override the model. The local `embeddings`
config stays the default; a store template can point at either.

There is no dimension to configure, and the vector-store docs now say so:
a store takes the dimension of the first vectors written to it and refuses
others afterwards, so switching a template's embedding config only affects
stores created from then on.

## The built-in vector-store template says it cannot be edited

`default` is not a row in the registry, it is the
`mindconnect.vector-store.*` properties. Its **Edit** button opened a form
whose **Save** was then dropped on the floor, silently, with the list
re-rendered as if something had happened. Changing the embedding config
there looked like it worked and did nothing.

Editing it now opens its values as an unnamed copy with that explanation
in the form, and **Save** reads *Save as new template*. Saving or deleting
under the reserved name, or saving with no name at all, comes back as an
error toast naming the property to change instead of staying quiet. A
successful save says so too.

## Docs

`vector-store.md` claimed no embedding config was bundled at all, which
stopped being true some releases ago. It now names both and explains what
switching one means for stores that already hold vectors.
