### PR TITLE
Speech to text: a Whisper config, and a microphone in the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,35 @@ fresh empty one, so nothing has to be moved by hand at release time.
   switches exhaustively over `StreamEvent`, needs the extra argument and the
   extra arm. `StreamEvent.Done` is unchanged.
 
+- **agents:** speech to text — a Whisper model as a normal LLM config, and a
+  microphone in the chat. A config's type can now be `SPEECH_TO_TEXT` next to
+  `CHAT` and `EMBEDDING`, with the same provider, key, encryption and admin
+  form as every other model. `LlmTranscription` is the port callers use: they
+  name a config and get a transcript, so an alias is followed exactly as it is
+  for a chat model — point `speech-to-text` at whichever config should serve
+  and swap it later without touching a caller. Behind it,
+  `OpenAiTranscriptionGateway` calls the OpenAI-compatible
+  `/v1/audio/transcriptions` endpoint, so OpenAI, Groq and a local Whisper
+  server all work by pointing the base URL at them; language, prompt and
+  response format are provider parameters on the config, and the LM Studio
+  model picker says it serves no transcription models rather than offering
+  chat ones.
+
+  In the chat, the composer's new microphone records in the browser and puts
+  the transcript into the input, after anything already typed — nothing is
+  sent without the person who spoke it pressing Send. Dictating while a turn
+  is still streaming brings the words back as a sticky toast, since there is
+  no input to fill at that moment. The admin UI tests a
+  speech config the same way: drop an audio file into the test dialog, or
+  press **Record**, speak and press **Stop**. Both need a microphone and a
+  secure context (`localhost` or HTTPS); where the browser refuses, uploading
+  a file still works.
+
+  A new installation is seeded with a `speech-to-text` config (`whisper-1`
+  behind `${OPENAI_API_KEY}`, overridable through `SPEECH_TO_TEXT_MODEL` and
+  `SPEECH_TO_TEXT_BASE_URL`); an existing one gets it on the next start, since
+  seeding checks each entry by id.
+
 ### Fixed
 
 - **agents:** the Responses API reports what a turn cost. `usage` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,17 @@ fresh empty one, so nothing has to be moved by hand at release time.
   and the recording's length; `?wait=` holds the request until the job ends,
   for a caller who wants the synchronous feel without a loop.
   `GET /api/transcriptions/{id}/events` is Server-Sent Events from the job's
-  channel — queued, running, completed — opening with the state as it is now,
+  channel — queued, running, the transcript as it forms in `delta` events,
+  then completed with the whole text — opening with the state as it is now,
   so a late arrival is told what it missed, and `?afterSeq=` resumes a dropped
   connection without a gap. The queue retries a provider hiccup, and `model`
   names an LLM config whose alias is followed. The recording stays in the file
   store, so a transcript keeps the audio behind it: its id and URL come back
   with the job, and `DELETE /api/files/{id}` disposes of it when the caller
-  says so.
+  says so. Whether the text arrives word by word depends on the model —
+  OpenAI's transcribe models stream it, `whisper-1` answers in one piece and
+  sends one delta — and the events are the same either way, so a client does
+  not branch on the model.
 
 - **agents:** speech to text — a Whisper model as a normal LLM config, and a
   microphone in the chat. A config's type can now be `SPEECH_TO_TEXT` next to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,21 @@ fresh empty one, so nothing has to be moved by hand at release time.
   `mindconnect.vector-store.embedding-config`; the local `embeddings` config
   stays the default.
 
-### Changed
-
-- **agents:** `AgentLoop.run` takes the tokens spent by earlier attempts as a
-  further argument, and `StreamEvent` has a new `TurnUsage` variant. Code
-  embedding `mc-agent-runtime-core` that calls `run` directly, or that
-  switches exhaustively over `StreamEvent`, needs the extra argument and the
-  extra arm. `StreamEvent.Done` is unchanged.
+- **agents:** transcription over the REST API, as a job.
+  `POST /api/transcriptions` takes a recording as multipart, stores it, queues
+  the work on the task queue and answers `202` with the job id plus both URLs
+  to follow it: one to poll, one to stream. `GET /api/transcriptions/{id}`
+  reports the status and, once done, the transcript with the detected language
+  and the recording's length; `?wait=` holds the request until the job ends,
+  for a caller who wants the synchronous feel without a loop.
+  `GET /api/transcriptions/{id}/events` is Server-Sent Events from the job's
+  channel — queued, running, completed — opening with the state as it is now,
+  so a late arrival is told what it missed, and `?afterSeq=` resumes a dropped
+  connection without a gap. The queue retries a provider hiccup, and `model`
+  names an LLM config whose alias is followed. The recording stays in the file
+  store, so a transcript keeps the audio behind it: its id and URL come back
+  with the job, and `DELETE /api/files/{id}` disposes of it when the caller
+  says so.
 
 - **agents:** speech to text — a Whisper model as a normal LLM config, and a
   microphone in the chat. A config's type can now be `SPEECH_TO_TEXT` next to
@@ -68,6 +76,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
   behind `${OPENAI_API_KEY}`, overridable through `SPEECH_TO_TEXT_MODEL` and
   `SPEECH_TO_TEXT_BASE_URL`); an existing one gets it on the next start, since
   seeding checks each entry by id.
+
+### Changed
+
+- **agents:** `AgentLoop.run` takes the tokens spent by earlier attempts as a
+  further argument, and `StreamEvent` has a new `TurnUsage` variant. Code
+  embedding `mc-agent-runtime-core` that calls `run` directly, or that
+  switches exhaustively over `StreamEvent`, needs the extra argument and the
+  extra arm. `StreamEvent.Done` is unchanged.
 
 ### Fixed
 

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
@@ -49,10 +49,11 @@ public record LlmConfig(
          */
         RateLimitConfig rateLimit,
         /**
-         * What the model does — {@link LlmConfigType#CHAT} (default) or
-         * {@link LlmConfigType#EMBEDDING}. Embedding models turn text into
-         * vectors and have no sampling settings — temperature, output tokens,
-         * thinking etc. don't apply.
+         * What the model does — {@link LlmConfigType#CHAT} (default),
+         * {@link LlmConfigType#EMBEDDING} or
+         * {@link LlmConfigType#SPEECH_TO_TEXT}. Only chat models have sampling
+         * settings; temperature, output tokens, thinking etc. don't apply to
+         * the others, and each type is reached through its own port.
          */
         LlmConfigType type,
         /**
@@ -108,6 +109,12 @@ public record LlmConfig(
     @com.fasterxml.jackson.annotation.JsonIgnore
     public boolean isEmbedding() {
         return type == LlmConfigType.EMBEDDING;
+    }
+
+    /** Convenience: is this a speech-to-text model? */
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    public boolean isSpeechToText() {
+        return type == LlmConfigType.SPEECH_TO_TEXT;
     }
 
     /** Jackson deserialisation — trailing fields default for old persisted configs. */
@@ -203,6 +210,23 @@ public record LlmConfig(
     public static LlmConfig googleGemini(String name, String model, String apiKey) {
         return new LlmConfig(UUID.randomUUID(), name, LlmProvider.GOOGLE_GEMINI,
                 model, "https://generativelanguage.googleapis.com", apiKey, 0.7, 8192, Map.of(), 1_000_000, false, null, null, null, null, null);
+    }
+
+    /**
+     * A speech-to-text config for the OpenAI-compatible transcription
+     * endpoint: OpenAI itself, Groq, or a local Whisper server behind its own
+     * base URL. Sampling settings and the context window stay empty — they do
+     * not apply to a transcription call.
+     *
+     * @param model   e.g. {@code whisper-1} or {@code gpt-4o-mini-transcribe}
+     * @param baseUrl the provider root, without the {@code /v1/…} path
+     * @param apiKey  the key, or {@code null} for a keyless local server
+     */
+    public static LlmConfig speechToText(String name, LlmProvider provider, String model,
+                                         String baseUrl, String apiKey) {
+        return new LlmConfig(UUID.randomUUID(), name, provider, model, baseUrl, apiKey,
+                0.0, 0, Map.of(), null, false, null, null, null,
+                LlmConfigType.SPEECH_TO_TEXT, null);
     }
 
     /** Guards against runaway / circular alias chains. */

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfigType.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfigType.java
@@ -2,12 +2,20 @@ package ai.mindconnect.llm.domain;
 
 /**
  * What a config's model does. One {@link LlmConfig} shape serves all types —
- * the type decides which settings apply (sampling knobs are chat-only) and
- * what a "test" means (chat turn vs text → vector).
+ * the type decides which settings apply (sampling knobs are chat-only), which
+ * port reaches the model, and what a "test" means (chat turn vs text → vector
+ * vs audio → text).
  */
 public enum LlmConfigType {
     /** Conversational / completion model — the default. */
     CHAT,
     /** Embedding model: turns text into vectors (vector stores, semantic search). */
-    EMBEDDING
+    EMBEDDING,
+    /**
+     * Speech-to-text model: turns recorded audio into text (Whisper and the
+     * OpenAI-compatible transcription endpoint). Reached through
+     * {@link ai.mindconnect.llm.port.in.LlmTranscription}; sampling settings
+     * and the context window do not apply.
+     */
+    SPEECH_TO_TEXT
 }

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
@@ -93,6 +93,13 @@ public enum LlmProvider {
                         "Context that steers spelling, e.g. product or people names that occur "
                                 + "in the recordings.",
                         LlmConfigType.SPEECH_TO_TEXT),
+                AdditionalParamSpec.select("stream", "Stream the transcript",
+                        List.of("auto", "off"),
+                        "'auto' asks the endpoint to send the text as it forms — models that "
+                                + "cannot simply answer in one piece, and callers see no "
+                                + "difference. 'off' is for a server that rejects fields it does "
+                                + "not know.",
+                        LlmConfigType.SPEECH_TO_TEXT),
                 AdditionalParamSpec.select("response_format", "Response Format",
                         List.of("json", "verbose_json", "text", "srt", "vtt"),
                         "How the endpoint answers. Leave empty for 'json', which every model "

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
@@ -13,9 +13,10 @@ import java.util.Set;
  */
 public enum LlmProvider {
     LM_STUDIO(Set.of(LlmCapability.TOOL_CALLING)),
-    OPENAI(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS)),
+    OPENAI(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS),
+            SpeechParams.TRANSCRIPTION),
     AZURE_OPENAI(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION)),
-    GROQ(Set.of(LlmCapability.TOOL_CALLING)),
+    GROQ(Set.of(LlmCapability.TOOL_CALLING), SpeechParams.TRANSCRIPTION),
     ANTHROPIC(Set.of(LlmCapability.TOOL_CALLING, LlmCapability.VISION, LlmCapability.DOCUMENTS), List.of(
             AdditionalParamSpec.select("thinking", "Thinking",
                     List.of("adaptive", "disabled"),
@@ -71,5 +72,34 @@ public enum LlmProvider {
     /** The specs that apply to a config of the given type. */
     public List<AdditionalParamSpec> additionalParams(LlmConfigType type) {
         return additionalParams.stream().filter(spec -> spec.appliesTo(type)).toList();
+    }
+
+    /**
+     * Holder for the shared parameter lists. An enum constant cannot read a
+     * static field of its own enum — the constants are built first — so the
+     * lists live in a nested class the constructors may reference.
+     */
+    private static final class SpeechParams {
+        /**
+         * The knobs the OpenAI-compatible transcription endpoint understands.
+         * Every provider that speaks it shares this list.
+         */
+        static final List<AdditionalParamSpec> TRANSCRIPTION = List.of(
+                AdditionalParamSpec.text("language", "Language",
+                        "ISO-639-1 code of the spoken language (de, en, fr). Leave empty to let "
+                                + "the model detect it — naming it is faster and more accurate.",
+                        LlmConfigType.SPEECH_TO_TEXT),
+                AdditionalParamSpec.text("prompt", "Prompt",
+                        "Context that steers spelling, e.g. product or people names that occur "
+                                + "in the recordings.",
+                        LlmConfigType.SPEECH_TO_TEXT),
+                AdditionalParamSpec.select("response_format", "Response Format",
+                        List.of("json", "verbose_json", "text", "srt", "vtt"),
+                        "How the endpoint answers. 'verbose_json' adds language and duration; "
+                                + "'srt'/'vtt' return subtitles as plain text.",
+                        LlmConfigType.SPEECH_TO_TEXT));
+
+        private SpeechParams() {
+        }
     }
 }

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmProvider.java
@@ -95,8 +95,10 @@ public enum LlmProvider {
                         LlmConfigType.SPEECH_TO_TEXT),
                 AdditionalParamSpec.select("response_format", "Response Format",
                         List.of("json", "verbose_json", "text", "srt", "vtt"),
-                        "How the endpoint answers. 'verbose_json' adds language and duration; "
-                                + "'srt'/'vtt' return subtitles as plain text.",
+                        "How the endpoint answers. Leave empty for 'json', which every model "
+                                + "takes. 'verbose_json' adds language and duration, and "
+                                + "'srt'/'vtt' return subtitles — whisper-1 only; the "
+                                + "gpt-4o transcribe models refuse them.",
                         LlmConfigType.SPEECH_TO_TEXT));
 
         private SpeechParams() {

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/TranscriptionRequest.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/TranscriptionRequest.java
@@ -1,0 +1,47 @@
+package ai.mindconnect.llm.domain;
+
+/**
+ * One recording to turn into text. The audio travels as the bytes of an
+ * encoded file — what a browser's recorder or an upload hands over (WebM/Opus,
+ * WAV, MP3, M4A, FLAC) — and the provider sniffs the container, so the
+ * {@link #filename} matters: its extension is what most endpoints look at.
+ *
+ * @param audio       the encoded audio file's bytes; never empty
+ * @param filename    file name including the extension, e.g. {@code speech.webm}
+ * @param contentType the media type when known, e.g. {@code audio/webm};
+ *                    {@code null} lets the adapter fall back to a generic one
+ * @param language    ISO-639-1 code of the spoken language ({@code de}, {@code en}).
+ *                    {@code null} leaves it to the model, which detects it.
+ * @param prompt      optional context that steers spelling of names and terms
+ */
+public record TranscriptionRequest(
+        byte[] audio,
+        String filename,
+        String contentType,
+        String language,
+        String prompt
+) {
+    public TranscriptionRequest {
+        if (audio == null || audio.length == 0) {
+            throw new IllegalArgumentException("audio must not be empty");
+        }
+        if (filename == null || filename.isBlank()) {
+            throw new IllegalArgumentException("filename must not be blank");
+        }
+    }
+
+    /** A recording with no language hint and no prompt — the common case. */
+    public static TranscriptionRequest of(byte[] audio, String filename, String contentType) {
+        return new TranscriptionRequest(audio, filename, contentType, null, null);
+    }
+
+    /** The same recording, transcribed as the given language. */
+    public TranscriptionRequest withLanguage(String language) {
+        return new TranscriptionRequest(audio, filename, contentType, language, prompt);
+    }
+
+    /** The same recording, with context that steers spelling. */
+    public TranscriptionRequest withPrompt(String prompt) {
+        return new TranscriptionRequest(audio, filename, contentType, language, prompt);
+    }
+}

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/TranscriptionResult.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/TranscriptionResult.java
@@ -1,0 +1,25 @@
+package ai.mindconnect.llm.domain;
+
+/**
+ * What a speech-to-text model heard. Only {@link #text} is guaranteed —
+ * language, duration and token counts are reported by some models and
+ * endpoints and left empty by others.
+ *
+ * @param text            the transcript
+ * @param language        the language the model detected, or {@code null}
+ * @param durationSeconds length of the recording, or {@code null}
+ * @param inputTokens     tokens billed for the audio, 0 when not reported
+ * @param outputTokens    tokens billed for the transcript, 0 when not reported
+ */
+public record TranscriptionResult(
+        String text,
+        String language,
+        Double durationSeconds,
+        int inputTokens,
+        int outputTokens
+) {
+    /** Just a transcript — what an endpoint returning plain text gives. */
+    public static TranscriptionResult of(String text) {
+        return new TranscriptionResult(text, null, null, 0, 0);
+    }
+}

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/in/LlmTranscription.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/in/LlmTranscription.java
@@ -1,0 +1,29 @@
+package ai.mindconnect.llm.port.in;
+
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+
+/**
+ * Turns recorded speech into text. The counterpart of {@link LlmChat} for
+ * audio: the caller names a config of type
+ * {@link ai.mindconnect.llm.domain.LlmConfigType#SPEECH_TO_TEXT} and gets one
+ * transcript back — no streaming, no conversation. Routing by name means an
+ * alias works here as it does for chat models: point {@code speech-to-text}
+ * at whichever config should serve it and callers stay unchanged.
+ *
+ * <p>An application provides an implementation as a bean; hosts that offer no
+ * speech input simply have none, and callers check for its absence.
+ */
+public interface LlmTranscription {
+
+    /**
+     * Transcribes one recording with the named config.
+     *
+     * @param configName the config's name, or the name of an alias pointing at it
+     * @throws ai.mindconnect.common.DomainException if no config has that name
+     * @throws IllegalStateException                           if the config is not a
+     *                                                         speech-to-text config, or
+     *                                                         the provider call fails
+     */
+    TranscriptionResult transcribe(String configName, TranscriptionRequest request);
+}

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/in/LlmTranscription.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/in/LlmTranscription.java
@@ -26,4 +26,22 @@ public interface LlmTranscription {
      *                                                         the provider call fails
      */
     TranscriptionResult transcribe(String configName, TranscriptionRequest request);
+
+    /**
+     * The same call, with the transcript handed over as it forms — for a
+     * caller that shows it while it arrives. {@code onDelta} receives
+     * fragments in order; their concatenation is the returned text, which
+     * stays the authority.
+     *
+     * <p>A model that answers in one piece calls the consumer once at the
+     * end. Nothing about the caller's code changes with the model.
+     */
+    default TranscriptionResult transcribe(String configName, TranscriptionRequest request,
+                                           java.util.function.Consumer<String> onDelta) {
+        TranscriptionResult result = transcribe(configName, request);
+        if (onDelta != null && result.text() != null && !result.text().isEmpty()) {
+            onDelta.accept(result.text());
+        }
+        return result;
+    }
 }

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/out/TranscriptionGateway.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/out/TranscriptionGateway.java
@@ -20,4 +20,24 @@ public interface TranscriptionGateway {
      *                               with an error status
      */
     TranscriptionResult transcribe(LlmConfig config, TranscriptionRequest request);
+
+    /**
+     * The same call, with the transcript handed over as it forms.
+     * {@code onDelta} receives fragments in order; concatenated they are the
+     * returned text, which is always the authority.
+     *
+     * <p>Whether anything actually arrives piecewise is the model's business.
+     * A provider or model that answers in one piece calls the consumer once
+     * at the end, so a caller's handling is the same either way — the default
+     * implementation here does exactly that for a gateway that cannot stream
+     * at all.
+     */
+    default TranscriptionResult transcribe(LlmConfig config, TranscriptionRequest request,
+                                           java.util.function.Consumer<String> onDelta) {
+        TranscriptionResult result = transcribe(config, request);
+        if (onDelta != null && result.text() != null && !result.text().isEmpty()) {
+            onDelta.accept(result.text());
+        }
+        return result;
+    }
 }

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/out/TranscriptionGateway.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/port/out/TranscriptionGateway.java
@@ -1,0 +1,23 @@
+package ai.mindconnect.llm.port.out;
+
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+
+/**
+ * Adapter port to a provider's speech-to-text endpoint — what
+ * {@link ai.mindconnect.llm.port.in.LlmTranscription} routes to once the
+ * config behind a name is known. The config is concrete here: aliases are
+ * already followed, the API key is still encrypted or an environment
+ * placeholder, and resolving it is the adapter's job.
+ */
+public interface TranscriptionGateway {
+
+    /**
+     * Transcribes one recording.
+     *
+     * @throws IllegalStateException when the provider call fails or answers
+     *                               with an error status
+     */
+    TranscriptionResult transcribe(LlmConfig config, TranscriptionRequest request);
+}

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModel.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/lmstudio/LmStudioModel.java
@@ -62,11 +62,17 @@ public record LmStudioModel(
         return loadedContextLength != null ? loadedContextLength : maxContextLength;
     }
 
-    /** Whether this model fits a config of the given type. */
+    /**
+     * Whether this model fits a config of the given type. LM Studio serves no
+     * transcription models — it reports only LLM, VLM and embedding kinds — so
+     * a speech-to-text config finds nothing here and points elsewhere.
+     */
     public boolean appliesTo(LlmConfigType type) {
-        return type == LlmConfigType.EMBEDDING
-                ? kind == Kind.EMBEDDING
-                : kind == Kind.LLM || kind == Kind.VLM;
+        return switch (type) {
+            case EMBEDDING -> kind == Kind.EMBEDDING;
+            case SPEECH_TO_TEXT -> false;
+            case CHAT -> kind == Kind.LLM || kind == Kind.VLM;
+        };
     }
 
     /** The capabilities LM Studio's metadata vouches for. */

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGateway.java
@@ -16,9 +16,11 @@ import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Speech-to-text against the OpenAI-compatible transcription endpoint,
@@ -53,28 +55,47 @@ public final class OpenAiTranscriptionGateway implements TranscriptionGateway {
 
     @Override
     public TranscriptionResult transcribe(LlmConfig config, TranscriptionRequest request) {
+        return transcribe(config, request, null);
+    }
+
+    /**
+     * Transcribes, and hands over the text as it forms when the model can do
+     * that. Asking costs nothing: the {@code stream} field is added only when
+     * somebody is listening, a model that cannot stream ignores it and
+     * answers with plain JSON, and the answer's content type says which of
+     * the two arrived. A config can opt out with {@code stream=off} for a
+     * server that refuses fields it does not know.
+     */
+    @Override
+    public TranscriptionResult transcribe(LlmConfig config, TranscriptionRequest request,
+                                          Consumer<String> onDelta) {
         LlmConfig cfg = config.resolved(encryption);
         String responseFormat = param(cfg, "response_format", "json");
+        String stream = param(cfg, "stream", "auto");
+        boolean askForStream = onDelta != null
+                && !"off".equalsIgnoreCase(stream) && !"false".equalsIgnoreCase(stream);
 
         long start = System.currentTimeMillis();
         Request.Builder http = new Request.Builder()
                 .url(cfg.baseUrl() + "/v1/audio/transcriptions")
-                .post(multipartBody(cfg, request, responseFormat));
+                .post(multipartBody(cfg, request, responseFormat, askForStream));
         // A local server usually takes no key; sending an empty bearer breaks some of them.
         if (cfg.apiKey() != null && !cfg.apiKey().isBlank()) {
             http.header("Authorization", "Bearer " + cfg.apiKey());
         }
 
         try (Response response = httpClient.newCall(http.build()).execute()) {
-            String payload = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
+                String payload = response.body() != null ? response.body().string() : "";
                 throw new IllegalStateException("Transcription call failed (" + response.code()
                         + "): " + truncate(payload));
             }
-            TranscriptionResult result = parse(payload, responseFormat);
-            log.debug("Transcribed {} bytes with {} in {} ms ({} characters)",
+            TranscriptionResult result = streamed(response)
+                    ? readStream(response, onDelta)
+                    : readWhole(response, responseFormat, onDelta);
+            log.debug("Transcribed {} bytes with {} in {} ms ({} characters{})",
                     request.audio().length, cfg.model(), System.currentTimeMillis() - start,
-                    result.text().length());
+                    result.text().length(), streamed(response) ? ", streamed" : "");
             return result;
         } catch (IOException e) {
             throw new IllegalStateException("Transcription call to " + cfg.baseUrl() + " failed: "
@@ -83,9 +104,12 @@ public final class OpenAiTranscriptionGateway implements TranscriptionGateway {
     }
 
     /** The request body. Package-private so a test can read the parts back. */
-    MultipartBody multipartBody(LlmConfig cfg, TranscriptionRequest request, String responseFormat) {
+    MultipartBody multipartBody(LlmConfig cfg, TranscriptionRequest request, String responseFormat,
+                                boolean askForStream) {
         MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
-        formFields(cfg, request, responseFormat).forEach(builder::addFormDataPart);
+        Map<String, String> fields = formFields(cfg, request, responseFormat);
+        if (askForStream) fields.put("stream", "true");
+        fields.forEach(builder::addFormDataPart);
         MediaType mediaType = request.contentType() == null ? OCTET_STREAM
                 : MediaType.parse(request.contentType());
         builder.addFormDataPart("file", request.filename(),
@@ -126,6 +150,63 @@ public final class OpenAiTranscriptionGateway implements TranscriptionGateway {
     private static String firstNonBlank(String first, String second) {
         if (first != null && !first.isBlank()) return first;
         return second != null && !second.isBlank() ? second : null;
+    }
+
+    /** Did the provider answer with an event stream rather than one document? */
+    private static boolean streamed(Response response) {
+        String type = response.header("content-type");
+        return type != null && type.toLowerCase(java.util.Locale.ROOT).startsWith("text/event-stream");
+    }
+
+    /**
+     * One document: parsed as before, and handed to a listening caller in a
+     * single piece so its handling does not depend on the model.
+     */
+    private TranscriptionResult readWhole(Response response, String responseFormat,
+                                          Consumer<String> onDelta) throws IOException {
+        String payload = response.body() != null ? response.body().string() : "";
+        TranscriptionResult result = parse(payload, responseFormat);
+        if (onDelta != null && result.text() != null && !result.text().isEmpty()) {
+            onDelta.accept(result.text());
+        }
+        return result;
+    }
+
+    /**
+     * The event stream: {@code transcript.text.delta} frames as the words
+     * form, {@code transcript.text.done} with the whole text and the usage.
+     * The done frame is the authority; the deltas are what a caller shows
+     * while waiting for it.
+     */
+    private TranscriptionResult readStream(Response response, Consumer<String> onDelta)
+            throws IOException {
+        StringBuilder assembled = new StringBuilder();
+        TranscriptionResult done = null;
+        try (BufferedReader reader = new BufferedReader(response.body().charStream())) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.startsWith("data:")) continue;
+                String data = line.substring("data:".length()).trim();
+                if (data.isEmpty() || "[DONE]".equals(data)) continue;
+
+                JsonNode frame = objectMapper.readTree(data);
+                String type = frame.path("type").asText("");
+                if ("transcript.text.delta".equals(type)) {
+                    String delta = frame.path("delta").asText("");
+                    if (delta.isEmpty()) continue;
+                    assembled.append(delta);
+                    if (onDelta != null) onDelta.accept(delta);
+                } else if ("transcript.text.done".equals(type)) {
+                    JsonNode usage = frame.path("usage");
+                    done = new TranscriptionResult(frame.path("text").asText(""), null, null,
+                            usage.path("input_tokens").asInt(0),
+                            usage.path("output_tokens").asInt(0));
+                }
+            }
+        }
+        // No done frame — the stream broke off. What arrived is still a
+        // transcript, and saying so beats throwing away the words.
+        return done != null ? done : TranscriptionResult.of(assembled.toString());
     }
 
     private TranscriptionResult parse(String payload, String responseFormat) {

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGateway.java
@@ -1,0 +1,153 @@
+package ai.mindconnect.llm.adapter.openai;
+
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import ai.mindconnect.llm.port.out.TranscriptionGateway;
+import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Speech-to-text against the OpenAI-compatible transcription endpoint,
+ * {@code POST {baseUrl}/v1/audio/transcriptions} as {@code multipart/form-data}.
+ * Works for OpenAI's own Whisper and transcribe models, for Groq, and for a
+ * local faster-whisper server — the base URL decides.
+ *
+ * <p>The audio is forwarded as the uploaded file's bytes; the provider sniffs
+ * the container from the file name, which is why
+ * {@link TranscriptionRequest#filename()} carries an extension.
+ *
+ * <p>Extras travel in {@link LlmConfig#additionalParams()}: {@code language},
+ * {@code prompt}, {@code temperature} and {@code response_format}. Values on
+ * the request win over the config's.
+ */
+public final class OpenAiTranscriptionGateway implements TranscriptionGateway {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenAiTranscriptionGateway.class);
+    private static final MediaType OCTET_STREAM = MediaType.get("application/octet-stream");
+    private static final int MAX_ERROR_BODY = 500;
+
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final EncryptionHelper encryption;
+
+    public OpenAiTranscriptionGateway(OkHttpClient httpClient, ObjectMapper objectMapper,
+                                      EncryptionHelper encryption) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.encryption = encryption;
+    }
+
+    @Override
+    public TranscriptionResult transcribe(LlmConfig config, TranscriptionRequest request) {
+        LlmConfig cfg = config.resolved(encryption);
+        String responseFormat = param(cfg, "response_format", "json");
+
+        long start = System.currentTimeMillis();
+        Request.Builder http = new Request.Builder()
+                .url(cfg.baseUrl() + "/v1/audio/transcriptions")
+                .post(multipartBody(cfg, request, responseFormat));
+        // A local server usually takes no key; sending an empty bearer breaks some of them.
+        if (cfg.apiKey() != null && !cfg.apiKey().isBlank()) {
+            http.header("Authorization", "Bearer " + cfg.apiKey());
+        }
+
+        try (Response response = httpClient.newCall(http.build()).execute()) {
+            String payload = response.body() != null ? response.body().string() : "";
+            if (!response.isSuccessful()) {
+                throw new IllegalStateException("Transcription call failed (" + response.code()
+                        + "): " + truncate(payload));
+            }
+            TranscriptionResult result = parse(payload, responseFormat);
+            log.debug("Transcribed {} bytes with {} in {} ms ({} characters)",
+                    request.audio().length, cfg.model(), System.currentTimeMillis() - start,
+                    result.text().length());
+            return result;
+        } catch (IOException e) {
+            throw new IllegalStateException("Transcription call to " + cfg.baseUrl() + " failed: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    /** The request body. Package-private so a test can read the parts back. */
+    MultipartBody multipartBody(LlmConfig cfg, TranscriptionRequest request, String responseFormat) {
+        MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+        formFields(cfg, request, responseFormat).forEach(builder::addFormDataPart);
+        MediaType mediaType = request.contentType() == null ? OCTET_STREAM
+                : MediaType.parse(request.contentType());
+        builder.addFormDataPart("file", request.filename(),
+                RequestBody.create(request.audio(), mediaType == null ? OCTET_STREAM : mediaType));
+        return builder.build();
+    }
+
+    /**
+     * The non-file form fields, in a stable order. The request's language and
+     * prompt win over the config's defaults; both are omitted when neither
+     * says anything, which lets the model detect the language itself.
+     */
+    Map<String, String> formFields(LlmConfig cfg, TranscriptionRequest request, String responseFormat) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("model", cfg.model());
+        fields.put("response_format", responseFormat);
+
+        String language = firstNonBlank(request.language(), param(cfg, "language", null));
+        if (language != null) fields.put("language", language);
+
+        String prompt = firstNonBlank(request.prompt(), param(cfg, "prompt", null));
+        if (prompt != null) fields.put("prompt", prompt);
+
+        String temperature = param(cfg, "temperature", null);
+        if (temperature != null) fields.put("temperature", temperature);
+
+        return fields;
+    }
+
+    /** Reads a string from the config's additional parameters, or {@code fallback}. */
+    private static String param(LlmConfig cfg, String key, String fallback) {
+        Object value = cfg.additionalParams() == null ? null : cfg.additionalParams().get(key);
+        if (value == null) return fallback;
+        String text = String.valueOf(value);
+        return text.isBlank() ? fallback : text;
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) return first;
+        return second != null && !second.isBlank() ? second : null;
+    }
+
+    private TranscriptionResult parse(String payload, String responseFormat) {
+        // text / srt / vtt answer with a bare body, not with JSON.
+        if (!"json".equals(responseFormat) && !"verbose_json".equals(responseFormat)) {
+            return TranscriptionResult.of(payload.trim());
+        }
+        try {
+            JsonNode root = objectMapper.readTree(payload);
+            String text = root.path("text").asText("");
+            String language = root.hasNonNull("language") ? root.path("language").asText() : null;
+            Double duration = root.hasNonNull("duration") ? root.path("duration").asDouble() : null;
+            JsonNode usage = root.path("usage");
+            return new TranscriptionResult(text, language, duration,
+                    usage.path("input_tokens").asInt(0), usage.path("output_tokens").asInt(0));
+        } catch (IOException e) {
+            log.warn("Could not parse the transcription response as JSON; using the raw body");
+            return TranscriptionResult.of(payload.trim());
+        }
+    }
+
+    private static String truncate(String text) {
+        return text.length() > MAX_ERROR_BODY ? text.substring(0, MAX_ERROR_BODY) + "…" : text;
+    }
+}

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/service/RoutingLlmTranscriptionService.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/service/RoutingLlmTranscriptionService.java
@@ -31,6 +31,12 @@ public class RoutingLlmTranscriptionService implements LlmTranscription {
         return gateway.transcribe(resolveConfig(configName), request);
     }
 
+    @Override
+    public TranscriptionResult transcribe(String configName, TranscriptionRequest request,
+                                          java.util.function.Consumer<String> onDelta) {
+        return gateway.transcribe(resolveConfig(configName), request, onDelta);
+    }
+
     /**
      * The config behind the name, aliases followed. A config of the wrong type
      * is refused here rather than at the provider: sending a chat model to the

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/service/RoutingLlmTranscriptionService.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/service/RoutingLlmTranscriptionService.java
@@ -1,0 +1,49 @@
+package ai.mindconnect.llm.service;
+
+import ai.mindconnect.common.DomainException;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigType;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import ai.mindconnect.llm.port.in.LlmTranscription;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import ai.mindconnect.llm.port.out.TranscriptionGateway;
+
+/**
+ * Routes a transcription by config name, the way
+ * {@link RoutingLlmChatService} routes a chat: look the name up, follow an
+ * alias to the config behind it, hand the call to the gateway. Callers name
+ * {@code speech-to-text} and an operator decides what that is.
+ */
+public class RoutingLlmTranscriptionService implements LlmTranscription {
+
+    private final LlmConfigRepository configRepository;
+    private final TranscriptionGateway gateway;
+
+    public RoutingLlmTranscriptionService(LlmConfigRepository configRepository,
+                                          TranscriptionGateway gateway) {
+        this.configRepository = configRepository;
+        this.gateway = gateway;
+    }
+
+    @Override
+    public TranscriptionResult transcribe(String configName, TranscriptionRequest request) {
+        return gateway.transcribe(resolveConfig(configName), request);
+    }
+
+    /**
+     * The config behind the name, aliases followed. A config of the wrong type
+     * is refused here rather than at the provider: sending a chat model to the
+     * transcription endpoint fails with a message about the endpoint, which
+     * says nothing about the actual mistake.
+     */
+    private LlmConfig resolveConfig(String configName) {
+        LlmConfig config = configRepository.findResolvedByName(configName)
+                .orElseThrow(() -> DomainException.notFound("LlmConfig", configName));
+        if (config.type() != LlmConfigType.SPEECH_TO_TEXT) {
+            throw new IllegalStateException("LLM config '" + configName + "' is a "
+                    + config.type() + " config, not a speech-to-text one");
+        }
+        return config;
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/RoutingLlmTranscriptionServiceTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/RoutingLlmTranscriptionServiceTest.java
@@ -1,0 +1,83 @@
+package ai.mindconnect.llm;
+
+import ai.mindconnect.common.DomainException;
+import ai.mindconnect.llm.adapter.memory.InMemoryLlmConfigRepository;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmProvider;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import ai.mindconnect.llm.port.out.TranscriptionGateway;
+import ai.mindconnect.llm.service.RoutingLlmTranscriptionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Routing a transcription by config name: the alias a caller may name, the
+ * config it lands on, and the two ways a name can be wrong.
+ */
+class RoutingLlmTranscriptionServiceTest {
+
+    private static final TranscriptionRequest RECORDING = TranscriptionRequest.of(
+            "audio".getBytes(StandardCharsets.UTF_8), "speech.webm", "audio/webm");
+
+    private LlmConfigRepository repository;
+    private RoutingLlmTranscriptionService service;
+    private final AtomicReference<LlmConfig> used = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryLlmConfigRepository();
+        repository.save(LlmConfig.speechToText("whisper", LlmProvider.OPENAI, "whisper-1",
+                "https://api.openai.com", "key"));
+
+        TranscriptionGateway gateway = (config, request) -> {
+            used.set(config);
+            return TranscriptionResult.of("what the model heard");
+        };
+        service = new RoutingLlmTranscriptionService(repository, gateway);
+    }
+
+    @Test
+    void theNamedConfigReachesTheGateway() {
+        TranscriptionResult result = service.transcribe("whisper", RECORDING);
+
+        assertThat(result.text()).isEqualTo("what the model heard");
+        assertThat(used.get().model()).isEqualTo("whisper-1");
+    }
+
+    @Test
+    void anAliasIsFollowedToTheConfigBehindIt() {
+        repository.save(LlmConfig.alias("speech-to-text", "whisper"));
+
+        service.transcribe("speech-to-text", RECORDING);
+
+        // The alias carries no provider or model — what arrives at the
+        // gateway has to be the config it points at.
+        assertThat(used.get().name()).isEqualTo("whisper");
+        assertThat(used.get().model()).isEqualTo("whisper-1");
+    }
+
+    @Test
+    void anUnknownNameIsNotFound() {
+        assertThatThrownBy(() -> service.transcribe("nobody", RECORDING))
+                .isInstanceOf(DomainException.class)
+                .hasMessageContaining("nobody");
+    }
+
+    @Test
+    void aChatConfigIsRefusedBeforeTheCall() {
+        repository.save(LlmConfig.lmStudio("local", "gpt-oss", "http://localhost:1234"));
+
+        assertThatThrownBy(() -> service.transcribe("local", RECORDING))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not a speech-to-text one");
+        assertThat(used.get()).as("nothing reached the gateway").isNull();
+    }
+}

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGatewayTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGatewayTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,6 +38,7 @@ class OpenAiTranscriptionGatewayTest {
     private final AtomicReference<String> lastAuth = new AtomicReference<>();
     private volatile String responseBody = "{\"text\":\"hello\"}";
     private volatile int responseCode = 200;
+    private volatile String responseType = "application/json";
 
     @BeforeEach
     void startServer() throws Exception {
@@ -44,6 +47,7 @@ class OpenAiTranscriptionGatewayTest {
             lastAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
             lastBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", responseType);
             exchange.sendResponseHeaders(responseCode, bytes.length);
             try (OutputStream out = exchange.getResponseBody()) {
                 out.write(bytes);
@@ -153,6 +157,65 @@ class OpenAiTranscriptionGatewayTest {
         gateway().transcribe(local, recording());
 
         assertThat(lastAuth.get()).isNull();
+    }
+
+    @Test
+    void anEventStreamArrivesAsDeltasAndOneFinalText() {
+        responseType = "text/event-stream";
+        responseBody = """
+                data: {"type":"transcript.text.delta","delta":"Guten"}
+
+                data: {"type":"transcript.text.delta","delta":" Tag"}
+
+                data: {"type":"transcript.text.done","text":"Guten Tag",\
+                "usage":{"input_tokens":49,"output_tokens":21}}
+
+                data: [DONE]
+                """;
+        List<String> deltas = new ArrayList<>();
+
+        TranscriptionResult result = gateway().transcribe(config(), recording(), deltas::add);
+
+        assertThat(deltas).containsExactly("Guten", " Tag");
+        assertThat(result.text()).as("the done frame is the authority").isEqualTo("Guten Tag");
+        assertThat(result.inputTokens()).isEqualTo(49);
+        assertThat(lastBody.get()).contains("name=\"stream\"");
+    }
+
+    @Test
+    void aModelThatCannotStreamStillCallsTheConsumerOnce() {
+        responseBody = "{\"text\":\"one piece\"}";
+        List<String> deltas = new ArrayList<>();
+
+        TranscriptionResult result = gateway().transcribe(config(), recording(), deltas::add);
+
+        // whisper-1 ignores the stream field and answers with JSON — the
+        // caller's handling must not depend on which model served.
+        assertThat(deltas).containsExactly("one piece");
+        assertThat(result.text()).isEqualTo("one piece");
+    }
+
+    @Test
+    void withoutAConsumerNothingAsksForAStream() {
+        gateway().transcribe(config(), recording());
+
+        assertThat(lastBody.get()).doesNotContain("name=\"stream\"");
+    }
+
+    @Test
+    void aBrokenStreamKeepsTheWordsThatArrived() {
+        responseType = "text/event-stream";
+        responseBody = """
+                data: {"type":"transcript.text.delta","delta":"half a"}
+
+                data: {"type":"transcript.text.delta","delta":" sentence"}
+                """;
+        List<String> deltas = new ArrayList<>();
+
+        TranscriptionResult result = gateway().transcribe(config(), recording(), deltas::add);
+
+        assertThat(result.text()).isEqualTo("half a sentence");
+        assertThat(deltas).hasSize(2);
     }
 
     @Test

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGatewayTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGatewayTest.java
@@ -1,0 +1,164 @@
+package ai.mindconnect.llm.adapter.openai;
+
+import ai.mindconnect.common.util.encryption.EncryptionHelper;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmProvider;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The OpenAI-compatible transcription adapter: what it puts into the
+ * multipart body, how it reads the two answer shapes (JSON and plain text),
+ * and that a provider error arrives readable.
+ */
+class OpenAiTranscriptionGatewayTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final byte[] AUDIO = "not really audio".getBytes(StandardCharsets.UTF_8);
+
+    private HttpServer server;
+    private final AtomicReference<String> lastBody = new AtomicReference<>();
+    private final AtomicReference<String> lastAuth = new AtomicReference<>();
+    private volatile String responseBody = "{\"text\":\"hello\"}";
+    private volatile int responseCode = 200;
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/audio/transcriptions", exchange -> {
+            lastAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            lastBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(responseCode, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private LlmConfig config() {
+        return LlmConfig.speechToText("whisper", LlmProvider.OPENAI, "whisper-1",
+                "http://localhost:" + server.getAddress().getPort(), "test-key");
+    }
+
+    private OpenAiTranscriptionGateway gateway() {
+        return new OpenAiTranscriptionGateway(new OkHttpClient(), MAPPER, new EncryptionHelper(null));
+    }
+
+    private static TranscriptionRequest recording() {
+        return TranscriptionRequest.of(AUDIO, "speech.webm", "audio/webm");
+    }
+
+    @Test
+    void theRecordingTravelsAsAFilePartNamedLikeTheUpload() {
+        TranscriptionResult result = gateway().transcribe(config(), recording());
+
+        assertThat(result.text()).isEqualTo("hello");
+        assertThat(lastAuth.get()).isEqualTo("Bearer test-key");
+        assertThat(lastBody.get())
+                .contains("name=\"model\"").contains("whisper-1")
+                .contains("name=\"response_format\"").contains("json")
+                .contains("name=\"file\"").contains("filename=\"speech.webm\"")
+                .contains("not really audio");
+    }
+
+    @Test
+    void aRequestLanguageWinsOverTheConfigsDefault() {
+        LlmConfig withDefaults = new LlmConfig(config().id(), "whisper", LlmProvider.OPENAI,
+                "whisper-1", config().baseUrl(), "test-key", 0.0, 0,
+                Map.of("language", "en", "prompt", "Mindconnect", "temperature", "0.2"),
+                null, false, null, null, null,
+                ai.mindconnect.llm.domain.LlmConfigType.SPEECH_TO_TEXT, null);
+
+        Map<String, String> fields = gateway()
+                .formFields(withDefaults, recording().withLanguage("de"), "json");
+
+        assertThat(fields).containsEntry("language", "de")
+                .containsEntry("prompt", "Mindconnect")
+                .containsEntry("temperature", "0.2");
+    }
+
+    @Test
+    void withoutALanguageAnywhereTheFieldIsOmittedSoTheModelDetectsIt() {
+        Map<String, String> fields = gateway().formFields(config(), recording(), "json");
+
+        assertThat(fields).doesNotContainKey("language").doesNotContainKey("prompt");
+    }
+
+    @Test
+    void verboseJsonCarriesLanguageAndDuration() {
+        responseBody = "{\"text\":\"Guten Tag\",\"language\":\"german\",\"duration\":2.5,"
+                + "\"usage\":{\"input_tokens\":14,\"output_tokens\":3}}";
+
+        TranscriptionResult result = gateway().transcribe(config(), recording());
+
+        assertThat(result.text()).isEqualTo("Guten Tag");
+        assertThat(result.language()).isEqualTo("german");
+        assertThat(result.durationSeconds()).isEqualTo(2.5);
+        assertThat(result.inputTokens()).isEqualTo(14);
+        assertThat(result.outputTokens()).isEqualTo(3);
+    }
+
+    @Test
+    void aTextResponseFormatIsTakenAsTheTranscriptItself() {
+        responseBody = "  Plain spoken words.\n";
+        LlmConfig asText = new LlmConfig(config().id(), "whisper", LlmProvider.OPENAI, "whisper-1",
+                config().baseUrl(), "test-key", 0.0, 0, Map.of("response_format", "text"),
+                null, false, null, null, null,
+                ai.mindconnect.llm.domain.LlmConfigType.SPEECH_TO_TEXT, null);
+
+        TranscriptionResult result = gateway().transcribe(asText, recording());
+
+        assertThat(result.text()).isEqualTo("Plain spoken words.");
+        assertThat(result.language()).isNull();
+    }
+
+    @Test
+    void aProviderErrorNamesStatusAndBody() {
+        responseCode = 401;
+        responseBody = "{\"error\":{\"message\":\"Incorrect API key\"}}";
+
+        assertThatThrownBy(() -> gateway().transcribe(config(), recording()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("401")
+                .hasMessageContaining("Incorrect API key");
+    }
+
+    @Test
+    void aKeylessLocalServerGetsNoAuthorizationHeader() {
+        LlmConfig local = LlmConfig.speechToText("local", LlmProvider.OPENAI, "whisper-large-v3",
+                config().baseUrl(), null);
+
+        gateway().transcribe(local, recording());
+
+        assertThat(lastAuth.get()).isNull();
+    }
+
+    @Test
+    void anEmptyRecordingIsRejectedBeforeAnyCall() {
+        assertThatThrownBy(() -> TranscriptionRequest.of(new byte[0], "speech.webm", "audio/webm"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("audio");
+    }
+}

--- a/agents/doc/manual-tests/chat/dictation.md
+++ b/agents/doc/manual-tests/chat/dictation.md
@@ -1,0 +1,61 @@
+---
+id: chat-dictation
+area: chat
+requires: [server-9091, openai-key, microphone]
+duration: ~4 min
+last-verified: never (the browser path was verified with a stubbed recorder on 2026-09-09; a real microphone has not been through it)
+---
+
+# Speaking into the chat instead of typing
+
+**Goal:** The composer's microphone records, the recording becomes text in the
+input, and nothing is sent until the person who spoke presses Send.
+
+## Preconditions
+
+- Admin UI running at http://localhost:9091 (otherwise: SKIPPED)
+- An LLM config named `speech-to-text` — the seeded one, or an alias of that
+  name pointing at a speech-to-text config. Its key must work; test it once on
+  its own detail page (otherwise: SKIPPED)
+- A working microphone, and the page opened over `http://localhost` or HTTPS.
+  Over plain HTTP to a host name the browser hands out no microphone: that is
+  the browser's rule, and this case is then SKIPPED.
+
+## Setup
+
+1. Open http://localhost:9091/chat and start a session with any agent.
+
+## Steps
+
+1. Look at the composer.
+   **Expected:** Between the **+** and the model button there is a microphone.
+2. Type `Frage:` into the input, then click the microphone and allow the
+   microphone if the browser asks.
+   **Expected:** The microphone turns red and the input's placeholder counts
+   seconds — *Recording… 1 s*, *2 s*, … The typed text stays.
+3. Say one sentence, then click the microphone again.
+   **Expected:** Within a few seconds the input reads `Frage:` followed by a
+   space and what was said. The placeholder is back to *Ask anything …*, the
+   microphone is no longer red. Nothing has been sent.
+4. Press Send.
+   **Expected:** The message is sent as it stands in the input — the agent
+   answers the dictated sentence.
+5. Turn `speech-to-text` into an alias: open it in the admin UI, tick **Is
+   Alias**, set *Delegates To* to another speech-to-text config, save. Dictate
+   again in the chat.
+   **Expected:** Dictation still works, now through the config behind the
+   alias. Undo the change afterwards.
+
+## Cleanup
+
+- Delete the test session from the chat's session list.
+- Undo the alias from step 5 if it was left in place.
+
+## Notes
+
+- The transcript is what the model heard; judge by "the words match what was
+  said", not by an exact string.
+- Without a `speech-to-text` config the microphone answers with a toast naming
+  the config to create — that is the error path working, not a FAIL.
+- Recording holds the microphone until the second click. If a step fails
+  mid-recording, reload the page to release it.

--- a/agents/doc/manual-tests/llm-configs/speech-to-text-config.md
+++ b/agents/doc/manual-tests/llm-configs/speech-to-text-config.md
@@ -1,0 +1,89 @@
+---
+id: llm-configs-speech-to-text
+area: llm-configs
+requires: [server-9091, openai-key]
+duration: ~4 min
+last-verified: 2026-09-09 (whisper-1 against api.openai.com, admin UI on 9098; the Record path with a stubbed recorder)
+---
+
+# A speech-to-text config transcribes a recording
+
+**Goal:** A config of type `SPEECH_TO_TEXT` reaches the transcription
+endpoint, and the admin UI's Test dialog turns an uploaded recording into
+text.
+
+## Preconditions
+
+- Admin UI running at http://localhost:9091 (otherwise: SKIPPED)
+- `OPENAI_API_KEY` set in the environment the server was started with
+  (otherwise: SKIPPED — or point Base URL at a local Whisper server and
+  leave the key empty)
+- A short audio file with speech. On macOS one can be made in two commands:
+
+  ```bash
+  say -o /tmp/speech.aiff "The quick brown fox jumps over the lazy dog."
+  afconvert -f WAVE -d LEI16@16000 -c 1 /tmp/speech.aiff /tmp/speech.wav
+  ```
+
+## Setup
+
+1. Open http://localhost:9091/admin/llm-configs and click **+ New LLM Config**.
+
+## Steps
+
+1. Set **Type** to `Speech to text`.
+   **Expected:** The settings group below the base fields changes its title to
+   *Speech-to-text settings* and shows no temperature, output-token or
+   capability fields.
+2. Set **Provider** to `OPENAI`.
+   **Expected:** An *OPENAI parameters* group appears with **Language**,
+   **Prompt** and **Response Format**.
+3. Fill in Name `whisper-test`, Model `whisper-1`, Base URL
+   `https://api.openai.com`, API Key `${OPENAI_API_KEY}`, Language `en`,
+   Response Format `verbose_json`. Save.
+   **Expected:** The list shows `whisper-test` with `OPENAI · whisper-1`.
+4. Open `whisper-test`.
+   **Expected:** The detail view says **Type: Speech to text** and lists
+   Language and Response Format. It shows no Temperature, Max Output Tokens,
+   Context Window or Capabilities row.
+5. Click **Test**.
+   **Expected:** The dialog *Test whisper-test* opens with a drop zone
+   labelled **Recording**, a **Record** button and the line *Or speak: Record
+   starts, Stop transcribes.* — no message textarea.
+6. Drop `/tmp/speech.wav` onto the zone.
+   **Expected:** Within a few seconds the dialog shows a green line
+   `✓ OK · <ms> ms · speech.wav · english · <n> s` and below it the spoken
+   sentence as text.
+7. Click **Record** and allow the microphone when the browser asks. Say a
+   sentence, then click **Stop**.
+   **Expected:** While recording, the button reads **Stop** and the status
+   line counts seconds. After stopping, the same green line appears, this time
+   naming `recording.webm`, with what was spoken as the transcript.
+8. Verify the same call from the shell (replace `{id}` with the config's id
+   from the URL):
+
+   ```bash
+   curl -s -X POST http://localhost:9091/admin/api/llm-configs/{id}/test-audio \
+     -F "audio=@/tmp/speech.wav;type=audio/wav" | grep -o '"text":"[^"]*"' | tail -2
+   ```
+
+   **Expected:** The transcript appears in the response patch.
+
+## Cleanup
+
+- Delete the `whisper-test` config from its detail view.
+
+## Notes
+
+- The transcript is what the model heard: a synthesized voice may mangle
+  proper names. Judge the step by "words came back that match the sentence",
+  not by an exact string.
+- With a wrong key the dialog shows a red `✗ Failed` line naming the HTTP
+  status — that is the error path working, not a FAIL of this case.
+- LM Studio serves no transcription models. Picking it as the provider leaves
+  the model dropdown saying it lists none; that is expected.
+- Recording needs a secure context. Over plain HTTP to a remote host the
+  browser refuses the microphone and the status line says so — that is the
+  browser, not a FAIL. Step 7 is then SKIPPED; the upload steps still apply.
+- Safari records `audio/mp4`, Chrome and Firefox `audio/webm`. The file name
+  in the result line follows, so `recording.m4a` there is equally correct.

--- a/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/config/LlmConfig.java
+++ b/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/config/LlmConfig.java
@@ -35,6 +35,21 @@ public class LlmConfig {
         return new ai.mindconnect.llm.adapter.openai.OpenAiEmbeddingsGateway(okHttpClient, objectMapper, encryptionHelper);
     }
 
+    /** Speech-to-text over the OpenAI-compatible transcription endpoint (Whisper, Groq, local servers). */
+    @Bean
+    ai.mindconnect.llm.port.out.TranscriptionGateway transcriptionGateway(
+            OkHttpClient okHttpClient, ObjectMapper objectMapper, EncryptionHelper encryptionHelper) {
+        return new ai.mindconnect.llm.adapter.openai.OpenAiTranscriptionGateway(okHttpClient, objectMapper, encryptionHelper);
+    }
+
+    /** Transcription by config name, aliases followed — the audio counterpart of the chat routing. */
+    @Bean
+    ai.mindconnect.llm.port.in.LlmTranscription llmTranscription(
+            ai.mindconnect.llm.port.out.LlmConfigRepository llmConfigRepository,
+            ai.mindconnect.llm.port.out.TranscriptionGateway transcriptionGateway) {
+        return new ai.mindconnect.llm.service.RoutingLlmTranscriptionService(llmConfigRepository, transcriptionGateway);
+    }
+
     @Bean
     ClaudeGateway claudeGateway(OkHttpClient okHttpClient, ObjectMapper objectMapper,
                                  EncryptionHelper encryptionHelper) {

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/speech-to-text.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/speech-to-text.json
@@ -1,0 +1,12 @@
+{
+  "id": "00000001-0000-0000-0000-000000000012",
+  "name": "speech-to-text",
+  "provider": "OPENAI",
+  "model": "${SPEECH_TO_TEXT_MODEL:whisper-1}",
+  "baseUrl": "${SPEECH_TO_TEXT_BASE_URL:https://api.openai.com}",
+  "apiKey": "${OPENAI_API_KEY}",
+  "additionalParams": {
+    "response_format": "verbose_json"
+  },
+  "type": "SPEECH_TO_TEXT"
+}

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/speech-to-text.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/llm-configs/speech-to-text.json
@@ -5,8 +5,6 @@
   "model": "${SPEECH_TO_TEXT_MODEL:whisper-1}",
   "baseUrl": "${SPEECH_TO_TEXT_BASE_URL:https://api.openai.com}",
   "apiKey": "${OPENAI_API_KEY}",
-  "additionalParams": {
-    "response_format": "verbose_json"
-  },
+  "additionalParams": {},
   "type": "SPEECH_TO_TEXT"
 }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigDetailComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigDetailComponent.java
@@ -32,15 +32,24 @@ public final class LlmConfigDetailComponent implements UiComponent {
                 .field(UiField.text("delegatesTo", "Delegates To", config.delegatesTo()))
                 .field(UiField.text("provider", "Provider",
                         config.provider() != null ? config.provider().name() : null))
-                .field(UiField.text("type", "Type", config.isEmbedding() ? "Embedding" : "Chat"))
-                .field(UiField.text("capabilities", "Capabilities", capabilitiesSummary(config)))
-                .field(UiField.text("model", "Model", config.model()))
+                .field(UiField.text("type", "Type", typeLabel(config)));
+        // Capabilities and the sampling knobs belong to a chat model; a
+        // transcription call has neither, so its detail view does not pretend
+        // to carry them.
+        boolean speech = config.isSpeechToText();
+        if (!speech) {
+            detail.field(UiField.text("capabilities", "Capabilities", capabilitiesSummary(config)));
+        }
+        detail.field(UiField.text("model", "Model", config.model()))
                 .field(UiField.text("baseUrl", "Base URL", config.baseUrl()))
-                .field(UiField.text("apiKey", "API Key", "••••••••"))
-                .field(UiField.number("defaultTemperature", "Temperature", config.defaultTemperature()))
-                .field(UiField.number("maxOutputTokens", "Max Output Tokens", config.maxOutputTokens()))
-                .field(UiField.number("contextWindowTokens", "Context Window", config.contextWindowTokens()))
-                .field(UiField.text("retry", "Retry on rate limit", retrySummary(config)))
+                .field(UiField.text("apiKey", "API Key", "••••••••"));
+        if (!speech) {
+            detail.field(UiField.number("defaultTemperature", "Temperature", config.defaultTemperature()))
+                    .field(UiField.number("maxOutputTokens", "Max Output Tokens", config.maxOutputTokens()))
+                    .field(UiField.number("contextWindowTokens", "Context Window",
+                            config.contextWindowTokens()));
+        }
+        detail.field(UiField.text("retry", "Retry on rate limit", retrySummary(config)))
                 .field(UiField.text("maxConcurrentRequests", "Max Concurrent Requests",
                         config.rateLimit() == null ? "Unlimited"
                                 : String.valueOf(config.rateLimit().maxConcurrentRequests())))
@@ -75,6 +84,15 @@ public final class LlmConfigDetailComponent implements UiComponent {
      * provider's default marked as such; "none" for a config that declared
      * the empty set, "—" when nothing applies (an alias).
      */
+    /** The config type in words, for the detail view. */
+    private static String typeLabel(LlmConfig config) {
+        return switch (config.type()) {
+            case EMBEDDING -> "Embedding";
+            case SPEECH_TO_TEXT -> "Speech to text";
+            case CHAT -> "Chat";
+        };
+    }
+
     private static String capabilitiesSummary(LlmConfig config) {
         var effective = config.effectiveCapabilities();
         if (effective.isEmpty()) return config.declaresCapabilities() ? "none (declared)" : "—";

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
@@ -106,27 +106,38 @@ public final class LlmConfigFormComponent implements UiComponent {
     }
 
     /**
-     * The type-specific settings, swapped in place when the "Embedding Model"
-     * checkbox toggles. Chat configs carry the sampling/retry knobs and the
-     * capability declaration; an embedding model only needs its input window.
+     * The type-specific settings, swapped in place when the type select
+     * changes. Chat configs carry the sampling/retry knobs and the capability
+     * declaration; an embedding model only needs its input window; a
+     * speech-to-text model needs neither — its knobs are the provider
+     * parameters below.
      */
-    public static ai.mindconnect.ui.model.UiFieldGroup typeGroup(boolean isEmbedding, LlmConfig config) {
-        return typeGroup(isEmbedding, config, null);
+    public static ai.mindconnect.ui.model.UiFieldGroup typeGroup(LlmConfigType type, LlmConfig config) {
+        return typeGroup(type, config, null);
     }
 
     /**
      * @param prefill values picked up from LM Studio for the model just
      *                chosen, or {@code null} to show the config's own
      */
-    public static ai.mindconnect.ui.model.UiFieldGroup typeGroup(boolean isEmbedding, LlmConfig config,
+    public static ai.mindconnect.ui.model.UiFieldGroup typeGroup(LlmConfigType type, LlmConfig config,
                                                                  LmStudioPrefill prefill) {
-        var group = ai.mindconnect.ui.model.UiFieldGroup.of("llm-type-cfg",
-                isEmbedding ? "Embedding settings" : "Chat settings");
+        var group = ai.mindconnect.ui.model.UiFieldGroup.of("llm-type-cfg", switch (type) {
+            case EMBEDDING -> "Embedding settings";
+            case SPEECH_TO_TEXT -> "Speech-to-text settings";
+            case CHAT -> "Chat settings";
+        });
         Integer contextWindow = prefill != null && prefill.contextWindowTokens() != null
                 ? prefill.contextWindowTokens()
                 : config == null ? null : config.contextWindowTokens();
         String contextHint = prefill != null && prefill.hint() != null ? prefill.hint() : null;
-        if (isEmbedding) {
+        if (type == LlmConfigType.SPEECH_TO_TEXT) {
+            // Nothing of its own: language, prompt and response format are
+            // provider parameters and render in the group below.
+            return group.hint("A transcription call has no sampling settings. Language, prompt "
+                    + "and response format are provider parameters, in the group below.");
+        }
+        if (type == LlmConfigType.EMBEDDING) {
             group.field(UiField.number("contextWindowTokens", "Max Input Tokens", contextWindow).asEditable()
                     .hint(contextHint != null ? contextHint
                             : "Optional — the embedding model's input window, used to size chunks"));
@@ -268,8 +279,7 @@ public final class LlmConfigFormComponent implements UiComponent {
         if (isLmStudio && (baseUrl == null || baseUrl.isBlank())) {
             baseUrl = LmStudioModelCatalog.DEFAULT_BASE_URL;
         }
-        LlmConfigType configType = LlmConfigType.EMBEDDING.name().equals(type)
-                ? LlmConfigType.EMBEDDING : LlmConfigType.CHAT;
+        LlmConfigType configType = parseType(type);
         // A new config starts with no provider: the picker must not appear for
         // a provider nobody chose, so the first option is a blank the admin
         // has to move off before saving.
@@ -281,12 +291,15 @@ public final class LlmConfigFormComponent implements UiComponent {
         String swapUrl = "/admin/api/llm-configs/field-groups?form=" + formId
                 + (configId == null ? "" : "&id=" + configId);
         group.field(UiField.select("type", "Type",
-                        type == null ? ai.mindconnect.llm.domain.LlmConfigType.CHAT.name() : type,
+                        type == null ? LlmConfigType.CHAT.name() : type,
                         List.of(UiField.Option.of("CHAT", "Chat"),
-                                UiField.Option.of("EMBEDDING", "Embedding")))
+                                UiField.Option.of("EMBEDDING", "Embedding"),
+                                UiField.Option.of("SPEECH_TO_TEXT", "Speech to text")))
                         .asEditable()
                         .hint("Embedding models turn text into vectors (vector stores / semantic "
-                                + "search); no sampling settings, Test embeds the text instead of chatting.")
+                                + "search); speech-to-text models turn a recording into text. "
+                                + "Neither has sampling settings, and Test does the matching thing "
+                                + "instead of chatting.")
                         // Switching swaps the type-specific settings group below.
                         .onChange(UiTrigger.api("POST", swapUrl, formId)))
                 .field(UiField.select("provider", "Provider", provider == null ? "" : provider, providerOptions)
@@ -323,7 +336,9 @@ public final class LlmConfigFormComponent implements UiComponent {
         if (lmStudio == null) {
             return UiField.text("model", "Model", model)
                     .asEditable()
-                    .hint("e.g. gpt-4o, gpt-5, claude-sonnet-4-6");
+                    .hint(type == LlmConfigType.SPEECH_TO_TEXT
+                            ? "e.g. whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe"
+                            : "e.g. gpt-4o, gpt-5, claude-sonnet-4-6");
         }
         if (!lmStudio.available()) {
             return UiField.text("model", "Model", model)
@@ -344,7 +359,11 @@ public final class LlmConfigFormComponent implements UiComponent {
         if (hasModel && !listed) {
             options.add(UiField.Option.of(model, model + " (not installed in LM Studio)"));
         }
-        String what = type == LlmConfigType.EMBEDDING ? "embedding" : "chat";
+        String what = switch (type) {
+            case EMBEDDING -> "embedding";
+            case SPEECH_TO_TEXT -> "speech-to-text";
+            case CHAT -> "chat";
+        };
         String hint = options.size() == 1
                 ? "LM Studio at " + lmStudio.baseUrl() + " lists no " + what + " models."
                 : "Installed in LM Studio at " + lmStudio.baseUrl()
@@ -354,6 +373,16 @@ public final class LlmConfigFormComponent implements UiComponent {
                 .hint(hint)
                 // The pick decides the context window: re-render with reason=model.
                 .onChange(UiTrigger.api("POST", swapUrl + "&reason=model", formId));
+    }
+
+    /** The form's type value as an enum; anything unknown reads as chat. */
+    private static LlmConfigType parseType(String type) {
+        if (type == null || type.isBlank()) return LlmConfigType.CHAT;
+        try {
+            return LlmConfigType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            return LlmConfigType.CHAT;
+        }
     }
 
     /** Marks the group hidden in alias mode — fields stay in the DOM. */
@@ -407,7 +436,8 @@ public final class LlmConfigFormComponent implements UiComponent {
                         isNew ? null : config.baseUrl(),
                         isNew ? null : config.apiKey(),
                         id(), configId, lmStudio))
-                .content(withHiddenIf(isAlias, typeGroup(!isNew && config.isEmbedding(), config)))
+                .content(withHiddenIf(isAlias,
+                        typeGroup(isNew ? LlmConfigType.CHAT : config.type(), config)))
                 .content(withHiddenIf(isAlias, providerParamsGroup(
                         isNew ? null : config.provider(),
                         isNew ? ai.mindconnect.llm.domain.LlmConfigType.CHAT : config.type(),

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigTestComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigTestComponent.java
@@ -3,6 +3,7 @@ package ai.mindconnect.adminui.ui.component;
 import ai.mindconnect.agentrest.service.LlmConfigTestService;
 import ai.mindconnect.chatui.ui.UiComponent;
 import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigType;
 import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.ui.model.UiField;
 import ai.mindconnect.ui.model.UiForm;
@@ -32,13 +33,22 @@ import ai.mindconnect.ui.model.UiText;
 public final class LlmConfigTestComponent implements UiComponent {
 
     private final LlmConfig config;
+    private final LlmConfigType type;
     private final String previousMessage;
     private final LlmConfigTestService.Result result;
 
+    /**
+     * @param type what the config under test really is. For an alias that is
+     *             the type of the config it points at — the test routes by
+     *             name and lands there, so the dialog has to offer what that
+     *             one needs (a recording for speech, a text for the rest).
+     */
     public LlmConfigTestComponent(LlmConfig config,
+                                   LlmConfigType type,
                                    String previousMessage,
                                    LlmConfigTestService.Result result) {
         this.config = config;
+        this.type = type;
         this.previousMessage = previousMessage;
         this.result = result;
     }
@@ -50,7 +60,10 @@ public final class LlmConfigTestComponent implements UiComponent {
 
     @Override
     public UiNode render() {
-        boolean embedding = config.isEmbedding();
+        if (type == LlmConfigType.SPEECH_TO_TEXT) {
+            return renderTranscription();
+        }
+        boolean embedding = type == LlmConfigType.EMBEDDING;
         var form = UiForm.of(id(), null)
                 .field(UiField.textarea("message", embedding ? "Text" : "Message",
                                 previousMessage == null ? "" : previousMessage)
@@ -70,11 +83,66 @@ public final class LlmConfigTestComponent implements UiComponent {
         return stack;
     }
 
+    /**
+     * The speech-to-text shape: a drop zone instead of a textarea. Picking or
+     * dropping a recording posts it to the test endpoint as multipart, and the
+     * transcript comes back in the same dialog. There is no Send button —
+     * choosing the file is the action.
+     */
+    private UiNode renderTranscription() {
+        var upload = ai.mindconnect.ui.model.UiUpload.of(id() + "-audio", "Recording")
+                // Fixed part name — the node id carries the config's uuid.
+                .name("audio")
+                .accept("audio/*,video/webm,.webm,.wav,.mp3,.m4a,.ogg,.flac")
+                .buttonLabel("Choose a recording")
+                .dropText("Drop an audio file here or")
+                .hint("Sent to the transcription endpoint as it is — the transcript comes back below. "
+                        + "WebM, WAV, MP3, M4A, OGG and FLAC all work.")
+                .uploadTo("/admin/api/llm-configs/" + config.id() + "/test-audio");
+
+        // Speaking instead of uploading: the button's trigger runs in the
+        // browser (INVOKE → the handler registered in audio-recorder.js),
+        // which records, posts the recording to the same endpoint the drop
+        // zone uses, and lets the bus apply the answer. A browser without a
+        // microphone — or one that was denied it — says so in the status line
+        // and the drop zone still works.
+        var record = ai.mindconnect.ui.model.UiTrigger.invoke("mc-record-audio");
+        record.setUrl("/admin/api/llm-configs/" + config.id() + "/test-audio");
+
+        var actions = UiForm.of(id(), null)
+                .action(UiAction.primary("record", "Record").icon("mic").onClick(record))
+                .action(UiAction.secondary("close", "Close").icon("close")
+                        .dispatch("POST", "/admin/api/llm-configs/test-dialog/close"));
+
+        var stack = UiStack.of(id() + "-stack")
+                .child(upload)
+                .child(actions)
+                .child(UiText.of(id() + "-record-status", "Or speak: Record starts, Stop transcribes.")
+                        .<UiText>withCssClass("llm-record-status"));
+        if (result != null) stack.child(renderResult());
+        return stack;
+    }
+
+    /**
+     * The tail of the success line. A transcription reports the recording it
+     * heard rather than a finish reason, and reports token counts only when
+     * the endpoint sent them — most speech endpoints bill by the minute.
+     */
+    private String metaTail() {
+        boolean tokens = type != LlmConfigType.SPEECH_TO_TEXT
+                || result.inputTokens() > 0 || result.outputTokens() > 0;
+        String head = tokens
+                ? " · " + result.inputTokens() + " in / " + result.outputTokens() + " out tokens"
+                : "";
+        if (result.finishReason().isEmpty()) return head;
+        return head + " · " + (type == LlmConfigType.SPEECH_TO_TEXT
+                ? result.finishReason()
+                : "finish=" + result.finishReason());
+    }
+
     private UiNode renderResult() {
         if (result.ok()) {
-            String meta = "✓ OK · " + result.durationMs() + " ms · "
-                    + result.inputTokens() + " in / " + result.outputTokens() + " out tokens"
-                    + (result.finishReason().isEmpty() ? "" : " · finish=" + result.finishReason());
+            String meta = "✓ OK · " + result.durationMs() + " ms" + metaTail();
             String body = result.text() == null || result.text().isEmpty()
                     ? "(empty response)"
                     : result.text();

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
@@ -158,7 +158,7 @@ public class LlmConfigUiController {
                                 formId, id, catalog)))
                 .patch(UiPatch.Operation.replace("llm-type-cfg",
                         LlmConfigFormComponent.withHiddenIf(isAlias,
-                                LlmConfigFormComponent.typeGroup(type == LlmConfigType.EMBEDDING, config, prefill))))
+                                LlmConfigFormComponent.typeGroup(type, config, prefill))))
                 .patch(UiPatch.Operation.replace("llm-provider-params",
                         LlmConfigFormComponent.withHiddenIf(isAlias,
                                 LlmConfigFormComponent.providerParamsGroup(provider, type, config))));
@@ -361,6 +361,55 @@ public class LlmConfigUiController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /**
+     * Executes a speech-to-text test: the dropped recording goes to the
+     * transcription endpoint and the dialog comes back with the transcript.
+     * A separate endpoint because this one takes multipart, not a form body.
+     */
+    @PostMapping(value = "/{id}/test-audio",
+            consumes = org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UiPatch> runAudioTest(
+            @PathVariable UUID id,
+            @RequestParam("audio") org.springframework.web.multipart.MultipartFile audio) {
+        return repository.findById(id)
+                .map(c -> {
+                    byte[] bytes;
+                    try {
+                        bytes = audio.getBytes();
+                    } catch (java.io.IOException e) {
+                        return ResponseEntity.ok(testPatch(c, null,
+                                LlmConfigTestService.Result.error(
+                                        "Could not read the upload: " + e.getMessage(), 0)));
+                    }
+                    String filename = audio.getOriginalFilename() == null
+                            ? "recording.webm" : audio.getOriginalFilename();
+                    LlmConfigTestService.Result result = testService.testTranscription(
+                            c, bytes, filename, audio.getContentType());
+                    return ResponseEntity.ok(testPatch(c, null, result));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * What a config under test really is. An alias carries no type of its
+     * own — it points at another config by name, and the test follows that
+     * name — so the type of the config behind it decides what the dialog
+     * asks for.
+     */
+    private LlmConfigType effectiveType(LlmConfig config) {
+        if (!config.isAlias()) return config.type();
+        try {
+            return repository.findResolvedByName(config.name())
+                    .map(LlmConfig::type)
+                    .orElse(config.type());
+        } catch (RuntimeException e) {
+            // A chain that is broken, circular or too deep throws. That is
+            // worth seeing — but in the dialog, where the test reports it,
+            // not as a 500 in place of the dialog.
+            return config.type();
+        }
+    }
+
     /** Close is just "remove the overlay" — the page behind stays as-is. */
     @PostMapping("/test-dialog/close")
     public UiPatch closeTestDialog() {
@@ -376,7 +425,7 @@ public class LlmConfigUiController {
      * outcome of the just-completed call (null for the initial open).
      */
     private UiPatch testPatch(LlmConfig c, String message, LlmConfigTestService.Result result) {
-        var component = new LlmConfigTestComponent(c, message, result);
+        var component = new LlmConfigTestComponent(c, effectiveType(c), message, result);
         UiDialog dialog = UiDialog.of(component.title(), null, component.render());
         dialog.setId("llm-test-dialog");
         return UiPatch.of()

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -9,6 +9,7 @@ import { install as installJsonViewer } from "/sui-ext/jsonviewer/extension.js";
 import { install as installMarkdown }   from "/sui-ext/markdown/extension.js";
 import { install as installDiagram }    from "/sui-ext/diagram/extension.js";
 import { watchConnectionBudget }        from "/js/connection-budget.js";
+import { installAudioRecorder }         from "/js/audio-recorder.js";
 
 // ── Renderer + extensions ────────────────────────────────────────────────────
 
@@ -71,6 +72,11 @@ bus.setFetcher(bffFetch)
 // Too many tabs: each holds a stream or two, and a browser allows six per
 // site. The tabs count each other and warn before the seventh stalls them all.
 watchConnectionBudget(bus);
+
+// The microphone behind the "Record" button of a speech-to-text config's test
+// dialog. Browser-only: the handler records and posts, the server never knows
+// it was not an upload.
+installAudioRecorder(bus);
 
 // Console hook. `mc.streams()` lists the server-sent streams this tab holds
 // (a chat page should show `user-stream` and one `msg-list-…`, nothing

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/LlmConfigFormLmStudioTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/LlmConfigFormLmStudioTest.java
@@ -157,7 +157,7 @@ class LlmConfigFormLmStudioTest {
         assertThat(prefill.capabilities()).containsExactly(LlmCapability.TOOL_CALLING);
         assertThat(prefill.hint()).contains("32768").contains("131072");
 
-        UiFieldGroup chat = LlmConfigFormComponent.typeGroup(false, null, prefill);
+        UiFieldGroup chat = LlmConfigFormComponent.typeGroup(LlmConfigType.CHAT, null, prefill);
         assertThat(field(chat, "contextWindowTokens").getValue()).isEqualTo(32768);
         assertThat(field(chat, "contextWindowTokens").getHint()).startsWith("From LM Studio");
         assertThat(field(chat, "capabilities").getValue()).isEqualTo(List.of("TOOL_CALLING"));
@@ -168,7 +168,7 @@ class LlmConfigFormLmStudioTest {
         assertThat(vision.capabilities()).containsExactlyInAnyOrder(LlmCapability.TOOL_CALLING, LlmCapability.VISION);
         assertThat(vision.hint()).contains("not loaded");
 
-        UiFieldGroup embedding = LlmConfigFormComponent.typeGroup(true, null,
+        UiFieldGroup embedding = LlmConfigFormComponent.typeGroup(LlmConfigType.EMBEDDING, null,
                 LlmConfigFormComponent.LmStudioPrefill.of(NOMIC));
         assertThat(field(embedding, "contextWindowTokens").getValue()).isEqualTo(2048);
     }
@@ -177,7 +177,7 @@ class LlmConfigFormLmStudioTest {
     void withoutAPrefillTheConfigsOwnValuesShow() {
         LlmConfig config = LlmConfig.lmStudio("lm", "openai/gpt-oss-120b", "http://localhost:1234");
 
-        UiFieldGroup chat = LlmConfigFormComponent.typeGroup(false, config, null);
+        UiFieldGroup chat = LlmConfigFormComponent.typeGroup(LlmConfigType.CHAT, config, null);
         assertThat(field(chat, "contextWindowTokens").getValue()).isEqualTo(config.contextWindowTokens());
         assertThat(field(chat, "contextWindowTokens").getHint()).doesNotContain("LM Studio");
         assertThat(field(chat, "capabilities").getValue())

--- a/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/AgentApplication.java
+++ b/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/AgentApplication.java
@@ -104,6 +104,21 @@ public class AgentApplication {
         return new ai.mindconnect.llm.adapter.openai.OpenAiEmbeddingsGateway(okHttpClient, objectMapper, encryptionHelper);
     }
 
+    /** Speech-to-text over the OpenAI-compatible transcription endpoint (Whisper, Groq, local servers). */
+    @Bean
+    ai.mindconnect.llm.port.out.TranscriptionGateway transcriptionGateway(
+            OkHttpClient okHttpClient, ObjectMapper objectMapper, EncryptionHelper encryptionHelper) {
+        return new ai.mindconnect.llm.adapter.openai.OpenAiTranscriptionGateway(okHttpClient, objectMapper, encryptionHelper);
+    }
+
+    /** Transcription by config name, aliases followed — the audio counterpart of the chat routing. */
+    @Bean
+    ai.mindconnect.llm.port.in.LlmTranscription llmTranscription(
+            ai.mindconnect.llm.port.out.LlmConfigRepository llmConfigRepository,
+            ai.mindconnect.llm.port.out.TranscriptionGateway transcriptionGateway) {
+        return new ai.mindconnect.llm.service.RoutingLlmTranscriptionService(llmConfigRepository, transcriptionGateway);
+    }
+
     @Bean
     ClaudeGateway claudeGateway(OkHttpClient okHttpClient, ObjectMapper objectMapper,
                                  EncryptionHelper encryptionHelper) {

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/TranscriptionApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/TranscriptionApiController.java
@@ -1,0 +1,235 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agentrest.dto.TranscriptionJobResponse;
+import ai.mindconnect.agentrest.dto.TranscriptionJobResult;
+import ai.mindconnect.agentrest.service.TranscriptionChannels;
+import ai.mindconnect.agentrest.service.TranscriptionEvent;
+import ai.mindconnect.agentrest.service.TranscriptionJobService;
+import ai.mindconnect.channel.Channel;
+import ai.mindconnect.channel.Subscription;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import ai.mindconnect.taskqueue.TaskRecord;
+import ai.mindconnect.taskqueue.TaskStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Turning a recording into text, as a job.
+ *
+ * <p>Three moves: post the audio and get an id, poll the id for the
+ * transcript, or attach to the job's stream and be told. The submit answer
+ * carries both URLs, so a client picks whichever fits without building a URL
+ * itself.
+ *
+ * <p>Why a job and not a straight answer: a long recording outlasts a
+ * comfortable request, providers do fail now and then, and the queue behind
+ * this already retries and survives a restart. The shape mirrors what
+ * transcription services do for the same reason.
+ */
+@RestController
+@RequestMapping("/api/transcriptions")
+public class TranscriptionApiController {
+
+    private static final Logger log = LoggerFactory.getLogger(TranscriptionApiController.class);
+
+    /** How long an events connection stays open before the client reattaches. */
+    private static final long STREAM_TIMEOUT_MS = 300_000L;
+
+    /** Upper bound for the polling endpoint's optional wait. */
+    private static final int MAX_WAIT_SECONDS = 60;
+
+    private final TranscriptionJobService jobs;
+    private final TranscriptionChannels channels;
+    private final ObjectMapper objectMapper;
+
+    public TranscriptionApiController(TranscriptionJobService jobs, TranscriptionChannels channels,
+                                      ObjectMapper objectMapper) {
+        this.jobs = jobs;
+        this.channels = channels;
+        this.objectMapper = objectMapper;
+    }
+
+    @Operation(tags = "Transcriptions", summary = "Queue a recording for transcription",
+            description = "Multipart upload of an audio file (WebM, WAV, MP3, M4A, OGG, FLAC). "
+                    + "Answers 202 with the job id plus the URL to poll and the URL to stream. "
+                    + "'model' names an LLM config of type SPEECH_TO_TEXT — an alias of that name "
+                    + "is followed; omitted, the config named 'speech-to-text' serves.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<TranscriptionJobResponse> submit(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "model", required = false) String model,
+            @RequestParam(value = "language", required = false) String language,
+            @RequestParam(value = "prompt", required = false) String prompt,
+            Principal user) throws IOException {
+        if (file.isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+        String filename = file.getOriginalFilename() == null ? "recording.webm" : file.getOriginalFilename();
+        TranscriptionJobService.Job job = jobs.submit(file.getBytes(), filename, file.getContentType(),
+                model, language, prompt, user == null ? null : user.getName());
+
+        log.info("POST /api/transcriptions file=\"{}\" ({} bytes) → job {}, recording {}",
+                filename, file.getSize(), job.taskId(), job.fileId());
+        return ResponseEntity.accepted().body(new TranscriptionJobResponse(
+                job.taskId(), "queued",
+                "/api/transcriptions/" + job.taskId(),
+                "/api/transcriptions/" + job.taskId() + "/events",
+                TranscriptionChannels.channelId(job.taskId()),
+                job.fileId(), fileUrl(job.fileId())));
+    }
+
+    @Operation(tags = "Transcriptions", summary = "Fetch a transcription job",
+            description = "The job's status, and its transcript once it is done. 'wait' holds the "
+                    + "request for up to that many seconds (max 60) until the job ends — a caller "
+                    + "who wants the synchronous feel without polling.")
+    @GetMapping("/{taskId}")
+    public ResponseEntity<TranscriptionJobResult> result(
+            @PathVariable String taskId,
+            @RequestParam(value = "wait", required = false) Integer wait,
+            Principal user) {
+        Optional<TaskRecord> found = wait == null || wait <= 0
+                ? jobs.find(taskId)
+                : jobs.await(taskId, Duration.ofSeconds(Math.min(wait, MAX_WAIT_SECONDS)));
+        if (found.isEmpty()) return ResponseEntity.notFound().build();
+
+        TaskRecord task = found.get();
+        if (!mayRead(task, user)) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(describe(task));
+    }
+
+    @Operation(tags = "Transcriptions", summary = "Stream a transcription job's events (SSE)",
+            description = "Server-Sent Events from the job's channel: queued, running, and the "
+                    + "transcript on completion. The stream starts with the job's state as it is "
+                    + "now, so a client that attaches late is not left waiting, and closes when "
+                    + "the job ends. 'afterSeq' resumes a dropped connection without a gap.")
+    @GetMapping(value = "/{taskId}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> events(
+            @PathVariable String taskId,
+            @RequestParam(value = "afterSeq", required = false) Long afterSeq,
+            Principal user) {
+        Optional<TaskRecord> found = jobs.find(taskId);
+        if (found.isEmpty() || !mayRead(found.get(), user)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        SseEmitter emitter = new SseEmitter(STREAM_TIMEOUT_MS);
+        // The task is the truth, the channel is the delivery: a job that ended
+        // before anyone attached is answered from the record, and the stream
+        // closes right away instead of waiting for events that will not come.
+        TaskRecord task = found.get();
+        if (terminal(task.status())) {
+            send(emitter, fromRecord(task));
+            emitter.complete();
+            return ResponseEntity.ok(emitter);
+        }
+
+        Subscription subscription = channels.subscribe(taskId,
+                afterSeq == null ? 0 : afterSeq,
+                event -> {
+                    send(emitter, event.value());
+                    if (terminal(event.value().status())) emitter.complete();
+                });
+        emitter.onCompletion(() -> close(subscription));
+        emitter.onTimeout(() -> close(subscription));
+        emitter.onError(e -> close(subscription));
+        return ResponseEntity.ok(emitter);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * A job recorded a requester when the request carried one. Then only that
+     * requester reads it — an id is a name, not a permission. A job submitted
+     * without a principal (an installation with no login) is readable by
+     * whoever can reach the endpoint, like the rest of this API.
+     */
+    private static boolean mayRead(TaskRecord task, Principal user) {
+        Optional<String> requester = TranscriptionJobService.requesterOf(task);
+        if (requester.isEmpty()) return true;
+        return user != null && requester.get().equals(user.getName());
+    }
+
+    private TranscriptionJobResult describe(TaskRecord task) {
+        TranscriptionResult result = jobs.resultOf(task).orElse(null);
+        return new TranscriptionJobResult(
+                task.id(),
+                task.status().name().toLowerCase(java.util.Locale.ROOT),
+                result == null ? null : result.text(),
+                result == null ? null : result.language(),
+                result == null ? null : result.durationSeconds(),
+                result == null ? 0 : result.inputTokens(),
+                result == null ? 0 : result.outputTokens(),
+                task.failure() == null ? null : task.failure().message(),
+                TranscriptionJobService.recordingOf(task).orElse(null),
+                TranscriptionJobService.recordingOf(task).map(TranscriptionApiController::fileUrl)
+                        .orElse(null),
+                task.submittedAt(),
+                task.endedAt());
+    }
+
+    /** Where a stored recording is fetched, and deleted. */
+    private static String fileUrl(String fileId) {
+        return fileId == null ? null : "/api/files/" + fileId;
+    }
+
+    /** The job's current state as one event, for a client that attached late. */
+    private TranscriptionEvent fromRecord(TaskRecord task) {
+        String status = task.status().name().toLowerCase(java.util.Locale.ROOT);
+        if (task.status() == TaskStatus.COMPLETED) {
+            TranscriptionResult result = jobs.resultOf(task).orElse(null);
+            return result == null ? TranscriptionEvent.status(status)
+                    : TranscriptionEvent.completed(result.text(), result.language());
+        }
+        if (task.status() == TaskStatus.FAILED) {
+            return TranscriptionEvent.failed(
+                    task.failure() == null ? "The job failed" : task.failure().message());
+        }
+        return TranscriptionEvent.status(status);
+    }
+
+    private static boolean terminal(TaskStatus status) {
+        return status == TaskStatus.COMPLETED || status == TaskStatus.FAILED
+                || status == TaskStatus.CANCELLED;
+    }
+
+    private static boolean terminal(String status) {
+        return "completed".equals(status) || "failed".equals(status) || "cancelled".equals(status);
+    }
+
+    private void send(SseEmitter emitter, TranscriptionEvent event) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(event.status())
+                    .data(objectMapper.writeValueAsString(event), MediaType.APPLICATION_JSON));
+        } catch (Exception e) {
+            // The client went away, or the connection broke. Nothing to
+            // salvage here: the job carries on and its result stays fetchable.
+            emitter.completeWithError(e);
+        }
+    }
+
+    private static void close(Subscription subscription) {
+        try {
+            subscription.close();
+        } catch (Exception ignored) {
+            // closing twice is normal — completion and timeout can both fire
+        }
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/TranscriptionJobResponse.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/TranscriptionJobResponse.java
@@ -1,0 +1,27 @@
+package ai.mindconnect.agentrest.dto;
+
+/**
+ * What a submitted transcription job answers with: its id, where to fetch the
+ * result, where to watch it happen, and where the recording now lives. Every
+ * URL is handed over rather than assembled by the caller, so a client never
+ * has to know how they are built.
+ *
+ * @param id        the job's task id
+ * @param status    its status right now, normally {@code queued}
+ * @param resultUrl poll this for the status and, once done, the transcript
+ * @param eventsUrl Server-Sent Events of this job, from its channel
+ * @param channelId the channel the events are published on
+ * @param fileId    the recording in the file store
+ * @param fileUrl   that recording: {@code GET} for its metadata, {@code GET
+ *                  …/content} for the bytes, {@code DELETE} when it has
+ *                  served its purpose. Nothing deletes it for you.
+ */
+public record TranscriptionJobResponse(
+        String id,
+        String status,
+        String resultUrl,
+        String eventsUrl,
+        String channelId,
+        String fileId,
+        String fileUrl
+) {}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/TranscriptionJobResult.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/TranscriptionJobResult.java
@@ -1,0 +1,31 @@
+package ai.mindconnect.agentrest.dto;
+
+import java.time.Instant;
+
+/**
+ * A transcription job as the polling endpoint reports it. Everything below
+ * {@link #status} is filled once there is something to fill it with: the
+ * transcript on {@code completed}, the reason on {@code failed}.
+ *
+ * @param status          queued, running, completed, failed, cancelled or suspended
+ * @param text            the transcript
+ * @param language        the language the model detected, when it reports one
+ * @param durationSeconds length of the recording, when the model reports it
+ * @param error           why the job failed
+ * @param fileId          the recording this job read, still in the file store
+ * @param fileUrl         where to fetch or delete it
+ */
+public record TranscriptionJobResult(
+        String id,
+        String status,
+        String text,
+        String language,
+        Double durationSeconds,
+        int inputTokens,
+        int outputTokens,
+        String error,
+        String fileId,
+        String fileUrl,
+        Instant submittedAt,
+        Instant endedAt
+) {}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/LlmConfigTestService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/LlmConfigTestService.java
@@ -4,7 +4,10 @@ import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.llm.domain.LlmMessage;
 import ai.mindconnect.llm.domain.LlmRequest;
 import ai.mindconnect.llm.domain.LlmStreamChunk;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
 import ai.mindconnect.llm.port.in.LlmEmbeddings;
+import ai.mindconnect.llm.port.in.LlmTranscription;
 import ai.mindconnect.llm.service.RoutingLlmChatService;
 import org.springframework.beans.factory.ObjectProvider;
 import org.slf4j.Logger;
@@ -31,11 +34,14 @@ public class LlmConfigTestService {
 
     private final RoutingLlmChatService chatService;
     private final ObjectProvider<LlmEmbeddings> embeddingsProvider;
+    private final ObjectProvider<LlmTranscription> transcriptionProvider;
 
     public LlmConfigTestService(RoutingLlmChatService chatService,
-                                ObjectProvider<LlmEmbeddings> embeddingsProvider) {
+                                ObjectProvider<LlmEmbeddings> embeddingsProvider,
+                                ObjectProvider<LlmTranscription> transcriptionProvider) {
         this.chatService = chatService;
         this.embeddingsProvider = embeddingsProvider;
+        this.transcriptionProvider = transcriptionProvider;
     }
 
     /**
@@ -50,6 +56,10 @@ public class LlmConfigTestService {
         }
         if (config.isEmbedding()) {
             return testEmbedding(config, message);
+        }
+        if (config.isSpeechToText()) {
+            // Nothing to send as text — this type is tested with a recording.
+            return Result.error("A speech-to-text config is tested by uploading a recording", 0);
         }
         long t0 = System.currentTimeMillis();
         LlmRequest req = LlmRequest.streaming(config.name(), List.of(LlmMessage.user(message)));
@@ -112,6 +122,54 @@ public class LlmConfigTestService {
             log.warn("Embedding test '{}' failed after {} ms: {}", config.name(), durMs, detail, e);
             return Result.error(detail, durMs);
         }
+    }
+
+    /**
+     * Speech-to-text configs: the uploaded recording is transcribed and the
+     * result shows the transcript, so an admin hears back whether endpoint,
+     * model and key line up. A recording is what this test needs — there is
+     * no text to send.
+     *
+     * @param filename    the upload's name; its extension tells the provider
+     *                    which container the bytes are in
+     * @param contentType the upload's media type, or {@code null}
+     */
+    public Result testTranscription(LlmConfig config, byte[] audio, String filename, String contentType) {
+        long t0 = System.currentTimeMillis();
+        LlmTranscription transcription = transcriptionProvider.getIfAvailable();
+        if (transcription == null) {
+            return Result.error("No transcription gateway configured in this application", 0);
+        }
+        if (audio == null || audio.length == 0) {
+            return Result.error("The upload was empty", 0);
+        }
+        try {
+            // By name, like the chat test — so the test follows an alias exactly
+            // as production traffic does.
+            TranscriptionResult result = transcription.transcribe(config.name(),
+                    TranscriptionRequest.of(audio, filename, contentType));
+            long durMs = System.currentTimeMillis() - t0;
+            log.info("Transcription test '{}' OK in {} ms ({} characters)",
+                    config.name(), durMs, result.text().length());
+            String text = result.text().isBlank() ? "(silence — the model heard nothing)" : result.text();
+            return Result.ok(text, result.inputTokens(), result.outputTokens(), durMs,
+                    describeAudio(filename, result));
+        } catch (Exception e) {
+            long durMs = System.currentTimeMillis() - t0;
+            String detail = describeCause(e);
+            log.warn("Transcription test '{}' failed after {} ms: {}", config.name(), durMs, detail, e);
+            return Result.error(detail, durMs);
+        }
+    }
+
+    /** The meta line of a transcription test: file, detected language, length. */
+    private static String describeAudio(String filename, TranscriptionResult result) {
+        StringBuilder sb = new StringBuilder(filename);
+        if (result.language() != null) sb.append(" · ").append(result.language());
+        if (result.durationSeconds() != null) {
+            sb.append(String.format(java.util.Locale.ROOT, " · %.1f s", result.durationSeconds()));
+        }
+        return sb.toString();
     }
 
     /**

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionChannels.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionChannels.java
@@ -1,0 +1,66 @@
+package ai.mindconnect.agentrest.service;
+
+import ai.mindconnect.channel.Channel;
+import ai.mindconnect.channel.ChannelRegistry;
+import ai.mindconnect.channel.Subscription;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+/**
+ * One channel per transcription job — where its events are published and
+ * where a client attaches to watch them.
+ *
+ * <p>The same shape the runtime uses for a session's turn events: a
+ * {@link ChannelRegistry} gives 0..n subscribers, replay from a buffer for
+ * anyone who joins late or reconnects, and a bounded queue per subscriber so
+ * a slow reader can never hold the producer up. Channels that nobody has
+ * touched for a while are evicted.
+ *
+ * <p>The channel id is public — it comes back with the job — but the id is a
+ * name, not a permission: the endpoint that serves the stream is the place
+ * that checks who may read it.
+ */
+@Component
+public final class TranscriptionChannels {
+
+    /** An idle job's channel is worth nothing after this; the result is in the task. */
+    private static final Duration IDLE_EVICTION = Duration.ofMinutes(30);
+
+    private final ChannelRegistry registry;
+
+    public TranscriptionChannels() {
+        this(new ChannelRegistry().withIdleEviction(IDLE_EVICTION));
+    }
+
+    public TranscriptionChannels(ChannelRegistry registry) {
+        this.registry = registry;
+    }
+
+    /** The channel a job publishes on, derived from its task id. */
+    public static String channelId(String taskId) {
+        return "transcription-" + taskId;
+    }
+
+    /** Publishes one event of this job. Never blocks, never throws at the caller. */
+    public void publish(String taskId, TranscriptionEvent event) {
+        registry.<TranscriptionEvent>channel(channelId(taskId)).publish(event);
+    }
+
+    /**
+     * Attaches to a job's channel: everything after {@code afterSeq} from the
+     * buffer first, then live. The event's sequence number is the cursor for
+     * the next attach, so a dropped connection resumes without a gap.
+     */
+    public Subscription subscribe(String taskId, long afterSeq,
+                                  Consumer<Channel.Event<TranscriptionEvent>> consumer) {
+        return registry.<TranscriptionEvent>channel(channelId(taskId)).subscribe(afterSeq, consumer);
+    }
+
+    /** The newest sequence this job has published (0 when nothing has happened). */
+    public long lastSeq(String taskId) {
+        return registry.<TranscriptionEvent>channel(channelId(taskId)).lastSeq();
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionEvent.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionEvent.java
@@ -6,7 +6,7 @@ package ai.mindconnect.agentrest.service;
  * remaining fields are filled when they are known — the transcript on
  * {@code completed}, the reason on {@code failed}.
  *
- * @param status   queued, running, completed, failed or cancelled
+ * @param status   queued, running, delta, completed, failed or cancelled
  * @param text     the transcript, on completion
  * @param language the language the model detected, when it reports one
  * @param error    why the job failed, when it did
@@ -19,6 +19,15 @@ public record TranscriptionEvent(
 ) {
     public static TranscriptionEvent status(String status) {
         return new TranscriptionEvent(status, null, null, null);
+    }
+
+    /**
+     * A piece of the transcript as it forms. {@code text} is the fragment,
+     * not the whole — a client appends it. Whether these arrive one word at a
+     * time or all at once at the end is the model's business.
+     */
+    public static TranscriptionEvent delta(String fragment) {
+        return new TranscriptionEvent("delta", fragment, null, null);
     }
 
     public static TranscriptionEvent completed(String text, String language) {

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionEvent.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionEvent.java
@@ -1,0 +1,31 @@
+package ai.mindconnect.agentrest.service;
+
+/**
+ * One thing that happened to a transcription job, as a client sees it on the
+ * job's channel. {@code status} is the task's status at that moment; the
+ * remaining fields are filled when they are known — the transcript on
+ * {@code completed}, the reason on {@code failed}.
+ *
+ * @param status   queued, running, completed, failed or cancelled
+ * @param text     the transcript, on completion
+ * @param language the language the model detected, when it reports one
+ * @param error    why the job failed, when it did
+ */
+public record TranscriptionEvent(
+        String status,
+        String text,
+        String language,
+        String error
+) {
+    public static TranscriptionEvent status(String status) {
+        return new TranscriptionEvent(status, null, null, null);
+    }
+
+    public static TranscriptionEvent completed(String text, String language) {
+        return new TranscriptionEvent("completed", text, language, null);
+    }
+
+    public static TranscriptionEvent failed(String error) {
+        return new TranscriptionEvent("failed", null, null, error);
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
@@ -1,0 +1,224 @@
+package ai.mindconnect.agentrest.service;
+
+import ai.mindconnect.filestore.FileStore;
+import ai.mindconnect.filestore.StoredFile;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import ai.mindconnect.llm.port.in.LlmTranscription;
+import ai.mindconnect.taskqueue.TaskContext;
+import ai.mindconnect.taskqueue.TaskOutcome;
+import ai.mindconnect.taskqueue.TaskQueue;
+import ai.mindconnect.taskqueue.TaskRecord;
+import ai.mindconnect.taskqueue.TaskStatus;
+import ai.mindconnect.taskqueue.TaskSubmission;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Transcription as a job: the recording is stored, a task is queued, and the
+ * caller gets an id to come back with.
+ *
+ * <p>Why a task and not a straight call: a long recording takes longer than a
+ * caller wants to hold a connection open, the provider does fail now and
+ * then, and the queue already answers both — it retries, it survives a
+ * restart with the Postgres store, and it spreads over nodes. What a caller
+ * gets back is a place to poll and a channel to watch; both are handed over
+ * with the job, so nobody has to assemble a URL.
+ *
+ * <p>The audio does not travel in the task's payload. Payloads are documents,
+ * and a recording is megabytes — it goes to the {@link FileStore} and the
+ * payload names it. That is also what makes a second attempt possible: it
+ * reads the same file.
+ *
+ * <p>The recording stays in the store afterwards, and its id comes back with
+ * the job. It is an upload like any other from there on: fetch it again, keep
+ * it as the evidence behind a transcript, delete it when it has served its
+ * purpose. Nothing here throws away what a caller may still want.
+ */
+@Service
+public class TranscriptionJobService {
+
+    /** The task type this service registers a worker for. */
+    public static final String TYPE = "transcription";
+
+    /**
+     * The LLM config a job uses when the request names none. A name, not a
+     * model: an alias of this name decides what actually serves.
+     */
+    public static final String DEFAULT_CONFIG_NAME = "speech-to-text";
+
+    private static final Logger log = LoggerFactory.getLogger(TranscriptionJobService.class);
+
+    /**
+     * Attempts per job. A retry is a paid provider call, so this is low on
+     * purpose: it covers a hiccup, not an outage.
+     */
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final TaskQueue queue;
+    private final FileStore fileStore;
+    private final ObjectProvider<LlmTranscription> transcription;
+    private final TranscriptionChannels channels;
+    private final ObjectMapper objectMapper;
+
+    public TranscriptionJobService(TaskQueue queue, FileStore fileStore,
+                                   ObjectProvider<LlmTranscription> transcription,
+                                   TranscriptionChannels channels, ObjectMapper objectMapper) {
+        this.queue = queue;
+        this.fileStore = fileStore;
+        this.transcription = transcription;
+        this.channels = channels;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Teaches the queue what a transcription task is. Idempotent per queue. */
+    @PostConstruct
+    void registerWorker() {
+        if (queue.hasRegisteredType(TYPE)) return;
+        queue.register(TYPE, this::run);
+    }
+
+    /**
+     * Stores the recording and queues its transcription.
+     *
+     * @param configName the LLM config to transcribe with, or {@code null} for
+     *                   the default name — an alias is followed
+     * @param userId     who asked, when the request carried a principal;
+     *                   {@code null} on an installation without login
+     * @return the queued task's id
+     */
+    public Job submit(byte[] audio, String filename, String contentType,
+                      String configName, String language, String prompt, String userId)
+            throws IOException {
+        StoredFile stored;
+        try (InputStream content = new java.io.ByteArrayInputStream(audio)) {
+            stored = fileStore.save(filename, contentType, content);
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("fileId", stored.id());
+        payload.put("filename", filename);
+        if (contentType != null) payload.put("contentType", contentType);
+        if (configName != null) payload.put("configName", configName);
+        if (language != null) payload.put("language", language);
+        if (prompt != null) payload.put("prompt", prompt);
+        if (userId != null) payload.put("userId", userId);
+
+        String taskId = queue.submit(TaskSubmission.of(TYPE, payload).withMaxAttempts(MAX_ATTEMPTS));
+        channels.publish(taskId, TranscriptionEvent.status("queued"));
+        log.info("Transcription job {} queued ({} bytes, file {})", taskId, audio.length, stored.id());
+        return new Job(taskId, stored.id());
+    }
+
+    /** A queued job: the task to follow, and the recording it reads. */
+    public record Job(String taskId, String fileId) { }
+
+    /** The job as it stands, or empty when no task has that id. */
+    public Optional<TaskRecord> find(String taskId) {
+        return queue.get(taskId);
+    }
+
+    /**
+     * Waits for the job to end, at most {@code timeout}. Returns the record as
+     * it looks when the wait is over — still running is a valid answer.
+     */
+    public Optional<TaskRecord> await(String taskId, Duration timeout) {
+        if (queue.get(taskId).isEmpty()) return Optional.empty();
+        return Optional.ofNullable(queue.await(taskId, timeout));
+    }
+
+    /** The transcript of a completed job, parsed back out of the task's result. */
+    public Optional<TranscriptionResult> resultOf(TaskRecord task) {
+        if (task.status() != TaskStatus.COMPLETED || task.result() == null) return Optional.empty();
+        try {
+            return Optional.of(objectMapper.readValue(task.result(), TranscriptionResult.class));
+        } catch (Exception e) {
+            log.warn("Transcription job {} has an unreadable result: {}", task.id(), e.toString());
+            return Optional.empty();
+        }
+    }
+
+    /** The recording a job was given, as stored in the file store. */
+    public static Optional<String> recordingOf(TaskRecord task) {
+        Object fileId = task.payload().get("fileId");
+        return fileId == null ? Optional.empty() : Optional.of(String.valueOf(fileId));
+    }
+
+    /** Who asked for this job, when the request carried a principal. */
+    public static Optional<String> requesterOf(TaskRecord task) {
+        Object userId = task.payload().get("userId");
+        return userId == null ? Optional.empty() : Optional.of(String.valueOf(userId));
+    }
+
+    // ── The worker ─────────────────────────────────────────────────────────
+
+    /**
+     * One attempt at a job. Whatever happens is published on the job's channel
+     * before it reaches the queue, so a watcher learns of it without asking —
+     * including the failure, which the queue would otherwise only record.
+     */
+    private TaskOutcome run(TaskContext ctx) throws Exception {
+        String taskId = ctx.task().id();
+        try {
+            return transcribe(ctx);
+        } catch (Exception e) {
+            String reason = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            channels.publish(taskId, TranscriptionEvent.failed(reason));
+            log.warn("Transcription job {} failed on attempt {} of {}: {}",
+                    taskId, ctx.task().attempt(), ctx.task().maxAttempts(), reason);
+            throw e;
+        }
+    }
+
+    /**
+     * Reads the stored recording and transcribes it; the transcript becomes
+     * the task's result, as JSON, so language and duration survive with it.
+     */
+    private TaskOutcome transcribe(TaskContext ctx) throws Exception {
+        String taskId = ctx.task().id();
+        Map<String, Object> payload = ctx.task().payload();
+        String fileId = string(payload, "fileId");
+        channels.publish(taskId, TranscriptionEvent.status("running"));
+
+        LlmTranscription speech = transcription.getIfAvailable();
+        if (speech == null) {
+            throw new IllegalStateException("This server has no speech-to-text gateway");
+        }
+        if (fileStore.find(fileId).isEmpty()) {
+            throw new IllegalStateException("The recording is gone from the file store: " + fileId);
+        }
+
+        byte[] audio;
+        try (InputStream content = fileStore.content(fileId)) {
+            audio = content.readAllBytes();
+        }
+        TranscriptionRequest request = new TranscriptionRequest(audio,
+                string(payload, "filename"), string(payload, "contentType"),
+                string(payload, "language"), string(payload, "prompt"));
+
+        String configName = payload.get("configName") == null
+                ? DEFAULT_CONFIG_NAME : string(payload, "configName");
+        TranscriptionResult result = speech.transcribe(configName, request);
+
+        channels.publish(taskId, TranscriptionEvent.completed(result.text(), result.language()));
+        log.info("Transcription job {} done ({} characters)", taskId,
+                result.text() == null ? 0 : result.text().length());
+        return TaskOutcome.done(objectMapper.writeValueAsString(result));
+    }
+
+    private static String string(Map<String, Object> payload, String key) {
+        Object value = payload.get(key);
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Transcription as a job: the recording is stored, a task is queued, and the
@@ -115,8 +116,14 @@ public class TranscriptionJobService {
         if (prompt != null) payload.put("prompt", prompt);
         if (userId != null) payload.put("userId", userId);
 
-        String taskId = queue.submit(TaskSubmission.of(TYPE, payload).withMaxAttempts(MAX_ATTEMPTS));
+        // The id is ours before the queue has it, so "queued" is on the
+        // channel before a worker can publish "running". Submitting first and
+        // announcing afterwards is a race the worker sometimes wins, and the
+        // events would then arrive out of order.
+        String taskId = "task_" + UUID.randomUUID();
         channels.publish(taskId, TranscriptionEvent.status("queued"));
+        queue.submit(TaskSubmission.of(TYPE, payload).withId(taskId).withMaxAttempts(MAX_ATTEMPTS));
+
         log.info("Transcription job {} queued ({} bytes, file {})", taskId, audio.length, stored.id());
         return new Job(taskId, stored.id());
     }
@@ -209,7 +216,12 @@ public class TranscriptionJobService {
 
         String configName = payload.get("configName") == null
                 ? DEFAULT_CONFIG_NAME : string(payload, "configName");
-        TranscriptionResult result = speech.transcribe(configName, request);
+        // The transcript goes onto the channel as it forms, so a watching
+        // client reads along instead of waiting for the end. A model that
+        // answers in one piece publishes one delta — same events, same code
+        // on the other side.
+        TranscriptionResult result = speech.transcribe(configName, request,
+                fragment -> channels.publish(taskId, TranscriptionEvent.delta(fragment)));
 
         channels.publish(taskId, TranscriptionEvent.completed(result.text(), result.language()));
         log.info("Transcription job {} done ({} characters)", taskId,

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
@@ -151,9 +151,13 @@ class TranscriptionJobServiceTest {
 
         assertThat(finished.await(5, java.util.concurrent.TimeUnit.SECONDS))
                 .as("the transcript reached the channel").isTrue();
+        // The gateway here answers in one piece, so its text arrives as a
+        // single delta before the completion — the same shape a model that
+        // streams produces word by word, which is the point of the delta.
         assertThat(seen).extracting(TranscriptionEvent::status)
-                .containsExactly("queued", "running", "completed");
-        assertThat(seen.get(2).text()).isEqualTo("what was said");
+                .containsExactly("queued", "running", "delta", "completed");
+        assertThat(seen).extracting(TranscriptionEvent::text)
+                .containsExactly(null, null, "what was said", "what was said");
     }
 
     @Test

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
@@ -1,0 +1,210 @@
+package ai.mindconnect.agentrest.service;
+
+import ai.mindconnect.filestore.FileStore;
+import ai.mindconnect.filestore.StoredFile;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import ai.mindconnect.llm.port.in.LlmTranscription;
+import ai.mindconnect.taskqueue.TaskQueue;
+import ai.mindconnect.taskqueue.TaskRecord;
+import ai.mindconnect.taskqueue.TaskStatus;
+import ai.mindconnect.taskqueue.local.LocalTaskQueue;
+import ai.mindconnect.taskqueue.memory.InMemoryTaskStore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A transcription as a queued job: the recording travels through the file
+ * store rather than the payload, the transcript comes back as the task's
+ * result, and the job's channel carries what happened.
+ */
+class TranscriptionJobServiceTest {
+
+    private static final byte[] AUDIO = "pretend this is opus".getBytes(StandardCharsets.UTF_8);
+
+    private LocalTaskQueue queue;
+    private StubFileStore files;
+    private TranscriptionChannels channels;
+    private TranscriptionJobService service;
+    private final AtomicReference<String> usedConfig = new AtomicReference<>();
+    private volatile LlmTranscription gateway;
+
+    @BeforeEach
+    void setUp() {
+        queue = new LocalTaskQueue(new InMemoryTaskStore());
+        files = new StubFileStore();
+        channels = new TranscriptionChannels();
+        gateway = (configName, request) -> {
+            usedConfig.set(configName);
+            return new TranscriptionResult("what was said", "english", 1.5, 3, 4);
+        };
+        service = new TranscriptionJobService(queue, files, provider(() -> gateway),
+                channels, new ObjectMapper());
+        service.registerWorker();
+    }
+
+    @AfterEach
+    void tearDown() {
+        queue.close();
+    }
+
+    @Test
+    void theRecordingGoesToTheStoreAndItsIdIntoThePayload() throws Exception {
+        TranscriptionJobService.Job job = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, null);
+
+        TaskRecord task = queue.get(job.taskId()).orElseThrow();
+        assertThat(job.fileId()).as("the caller learns where the recording went")
+                .isEqualTo(task.payload().get("fileId"));
+        assertThat(task.payload()).containsEntry("filename", "speech.webm")
+                .containsKey("fileId");
+        assertThat(task.payload().get("fileId")).asString().isNotBlank();
+        // The audio itself must not be in the payload — payloads are documents.
+        assertThat(task.payload().values()).noneMatch(v -> v instanceof byte[]);
+    }
+
+    @Test
+    void theTranscriptComesBackAsTheTasksResult() throws Exception {
+        String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, "en", "Mindconnect", null).taskId();
+
+        TaskRecord done = queue.await(taskId, Duration.ofSeconds(5));
+
+        assertThat(done.status()).isEqualTo(TaskStatus.COMPLETED);
+        assertThat(service.resultOf(done)).get()
+                .extracting(TranscriptionResult::text, TranscriptionResult::language)
+                .containsExactly("what was said", "english");
+        assertThat(usedConfig.get()).as("the default config name serves when none is asked for")
+                .isEqualTo(TranscriptionJobService.DEFAULT_CONFIG_NAME);
+    }
+
+    @Test
+    void aNamedConfigIsPassedThrough() throws Exception {
+        String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
+                "whisper-local", null, null, null).taskId();
+
+        queue.await(taskId, Duration.ofSeconds(5));
+
+        assertThat(usedConfig.get()).isEqualTo("whisper-local");
+    }
+
+    @Test
+    void theRecordingStaysInTheStoreAfterwards() throws Exception {
+        TranscriptionJobService.Job job = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, null);
+
+        queue.await(job.taskId(), Duration.ofSeconds(5));
+
+        // The upload belongs to whoever made it: it is fetchable and
+        // deletable through the file API, and nothing here disposes of it.
+        assertThat(files.find(job.fileId())).isPresent();
+    }
+
+    @Test
+    void aJobThatFailsForGoodAlsoCleansUp() throws Exception {
+        gateway = (configName, request) -> {
+            throw new IllegalStateException("provider is down");
+        };
+
+        TranscriptionJobService.Job job = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, null);
+        TaskRecord done = queue.await(job.taskId(), Duration.ofSeconds(10));
+
+        assertThat(done.status()).isEqualTo(TaskStatus.FAILED);
+        assertThat(done.failure().message()).contains("provider is down");
+        assertThat(files.find(job.fileId())).as("a failed job keeps its evidence").isPresent();
+    }
+
+    @Test
+    void theChannelCarriesTheRunFromQueuedToTheTranscript() throws Exception {
+        List<TranscriptionEvent> seen = new java.util.concurrent.CopyOnWriteArrayList<>();
+        java.util.concurrent.CountDownLatch finished = new java.util.concurrent.CountDownLatch(1);
+        String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, null).taskId();
+        // afterSeq 0: everything the job published, including what happened
+        // before this subscriber existed. The latch waits for delivery rather
+        // than for a duration — the queue's completion and the channel's
+        // fan-out are different threads.
+        channels.subscribe(taskId, 0, event -> {
+            seen.add(event.value());
+            if ("completed".equals(event.value().status())) finished.countDown();
+        });
+
+        assertThat(finished.await(5, java.util.concurrent.TimeUnit.SECONDS))
+                .as("the transcript reached the channel").isTrue();
+        assertThat(seen).extracting(TranscriptionEvent::status)
+                .containsExactly("queued", "running", "completed");
+        assertThat(seen.get(2).text()).isEqualTo("what was said");
+    }
+
+    @Test
+    void theRequesterIsRememberedForTheOwnerCheck() throws Exception {
+        String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, "mc_user").taskId();
+
+        assertThat(TranscriptionJobService.requesterOf(queue.get(taskId).orElseThrow()))
+                .contains("mc_user");
+    }
+
+    // ── Stubs ──────────────────────────────────────────────────────────────
+
+    /** Enough of a file store to hold bytes and hand them back. */
+    private static final class StubFileStore implements FileStore {
+        private final Map<String, byte[]> stored = new LinkedHashMap<>();
+        private final Map<String, StoredFile> meta = new LinkedHashMap<>();
+
+        @Override
+        public StoredFile save(String name, String contentType, InputStream content) throws IOException {
+            String id = "file-" + UUID.randomUUID();
+            byte[] bytes = content.readAllBytes();
+            stored.put(id, bytes);
+            StoredFile file = new StoredFile(id, name, contentType, bytes.length, Instant.now());
+            meta.put(id, file);
+            return file;
+        }
+
+        @Override public Optional<StoredFile> find(String id) { return Optional.ofNullable(meta.get(id)); }
+
+        @Override
+        public InputStream content(String id) {
+            return new ByteArrayInputStream(stored.get(id));
+        }
+
+        @Override public List<StoredFile> list() { return List.copyOf(meta.values()); }
+
+        @Override
+        public void delete(String id) {
+            stored.remove(id);
+            meta.remove(id);
+        }
+    }
+
+    /** The single-value ObjectProvider the service asks for its gateway. */
+    private static <T> ObjectProvider<T> provider(java.util.function.Supplier<T> value) {
+        return new ObjectProvider<>() {
+            @Override public T getObject() { return value.get(); }
+            @Override public T getObject(Object... args) { return value.get(); }
+            @Override public T getIfAvailable() { return value.get(); }
+            @Override public T getIfUnique() { return value.get(); }
+        };
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatFormComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatFormComponent.java
@@ -128,21 +128,32 @@ public final class ChatFormComponent implements UiComponent {
 
     // ── Internal builders ──────────────────────────────────────────────────
 
+    /**
+     * The composer's textarea. Built here so anything that refills it —
+     * dictation puts the transcript in — patches in the same field rather
+     * than a lookalike: same id, same placeholder, same Enter-sends.
+     *
+     * @param value what the field starts with; {@code null} for empty
+     */
+    public static UiField messageField(String value) {
+        return UiField.textarea("message", "Message", value)
+                .asEditable().asRequired()
+                // The label stays for the accessible name; the placeholder is
+                // what the composer shows, so the field reads as an invitation
+                // rather than as a labelled form control.
+                .placeholder("Ask anything \u2026")
+                // Chat-style commit: Enter sends, Shift+Enter newline.
+                .submitOnEnter();
+    }
+
     private UiForm idleForm() {
         UiForm form = UiForm.of(id(), null)
-                .field(UiField.textarea("message", "Message", null)
-                        .asEditable().asRequired()
-                        // The label stays for the accessible name; the
-                        // placeholder is what the composer shows, so the
-                        // field reads as an invitation rather than as a
-                        // labelled form control.
-                        .placeholder("Ask anything \u2026")
-                        // Chat-style commit: Enter sends, Shift+Enter newline.
-                        .submitOnEnter())
+                .field(messageField(null))
                 // "+" opens the attach dialog (drop-zone lives there, not on
                 // the page); the paper plane sends. Labels become the
                 // accessible names, the sprite tokens the glyphs.
                 .action(attachAction())
+                .action(recordAction())
                 // Model and tools sit on the composer, where you notice them
                 // while typing — not in a settings page you have to go find.
                 .action(UiAction.secondary("model", modelLabel).icon("ai")
@@ -156,6 +167,27 @@ public final class ChatFormComponent implements UiComponent {
                         // reads.
                         .onClick(trigger(on(ChatUiController.class).chatStream(sessionId, null), id())));
         return form.<UiForm>withCssClass("chat-form");
+    }
+
+    /**
+     * The microphone. Its trigger runs in the browser — the handler
+     * registered in {@code audio-recorder.js} records, posts the recording to
+     * the session's transcribe endpoint and applies the patch that comes
+     * back, which is this same field with the transcript in it. The form id
+     * travels as the payload so the recording carries whatever was already
+     * typed, and so the handler knows which textarea to talk to while it
+     * records.
+     *
+     * <p>A browser with no microphone, or one that was denied it, says so in
+     * the composer's placeholder and nothing else happens; typing is
+     * untouched either way.
+     */
+    private UiAction recordAction() {
+        var trigger = ai.mindconnect.ui.model.UiTrigger.invoke("mc-record-audio", id());
+        trigger.setUrl("/chat/api/sessions/" + sessionId + "/voice/transcribe");
+        return UiAction.icon("record", "Dictate").icon("mic")
+                .onClick(trigger)
+                .<UiAction>withCssClass("chat-record-btn");
     }
 
     /**

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatVoiceUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatVoiceUiController.java
@@ -38,8 +38,13 @@ import java.util.UUID;
 @RequestMapping("/chat/api/sessions/{sessionId}/voice")
 public class ChatVoiceUiController {
 
-    /** The LLM config the chat dictates with. An alias of this name is followed. */
-    public static final String CONFIG_NAME = "speech-to-text";
+    /**
+     * The LLM config the chat dictates with — the same name the transcription
+     * API defaults to, defined once so a rename cannot leave the two apart.
+     * An alias of this name is followed.
+     */
+    public static final String CONFIG_NAME =
+            ai.mindconnect.agentrest.service.TranscriptionJobService.DEFAULT_CONFIG_NAME;
 
     private static final Logger log = LoggerFactory.getLogger(ChatVoiceUiController.class);
 
@@ -141,12 +146,15 @@ public class ChatVoiceUiController {
      * sentence that says what to do rather than a class name.
      */
     private static String reason(Exception e) {
-        String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
-        if (message.contains(CONFIG_NAME)) {
+        // Which failure it is decides the sentence, not what the message
+        // happens to contain: a config of the wrong type mentions the name
+        // too, and telling its owner to create one they already have sends
+        // them the wrong way.
+        if (e instanceof ai.mindconnect.common.DomainException) {
             return "No LLM config named '" + CONFIG_NAME + "'. Create one of type "
                     + "Speech to text in the admin UI, or point an alias of that name at one.";
         }
-        return message;
+        return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
     }
 
     private static UiPatch toast(UiToast toast) {

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatVoiceUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatVoiceUiController.java
@@ -1,0 +1,155 @@
+package ai.mindconnect.chatui.ui.controller;
+
+import ai.mindconnect.chatui.ui.component.ChatFormComponent;
+import ai.mindconnect.llm.domain.TranscriptionRequest;
+import ai.mindconnect.llm.domain.TranscriptionResult;
+import ai.mindconnect.llm.port.in.LlmTranscription;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiToast;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+/**
+ * Speaking into the chat instead of typing. The composer's microphone records
+ * in the browser and posts the recording here; the answer is the composer's
+ * textarea with the transcript in it, so the words land where typed ones do
+ * and are sent — or corrected first — by the person who spoke them. Nothing
+ * is submitted on their behalf.
+ *
+ * <p>The model is the LLM config named {@value #CONFIG_NAME}. That is a name,
+ * not a model: point an alias at whichever speech-to-text config should serve
+ * the chat and this endpoint follows it, the same way an agent's chat model is
+ * chosen.
+ */
+@RestController
+@RequestMapping("/chat/api/sessions/{sessionId}/voice")
+public class ChatVoiceUiController {
+
+    /** The LLM config the chat dictates with. An alias of this name is followed. */
+    public static final String CONFIG_NAME = "speech-to-text";
+
+    private static final Logger log = LoggerFactory.getLogger(ChatVoiceUiController.class);
+
+    private final ObjectProvider<LlmTranscription> transcription;
+    private final ai.mindconnect.agent.port.out.AgentSessionRepository sessions;
+    private final ai.mindconnect.chatui.service.ActiveStreams activeStreams;
+
+    public ChatVoiceUiController(ObjectProvider<LlmTranscription> transcription,
+                                 ai.mindconnect.agent.port.out.AgentSessionRepository sessions,
+                                 ai.mindconnect.chatui.service.ActiveStreams activeStreams) {
+        this.transcription = transcription;
+        this.sessions = sessions;
+        this.activeStreams = activeStreams;
+    }
+
+    /**
+     * Turns the posted recording into text and hands back the composer with
+     * it. Anything already typed arrives as {@code message} and keeps its
+     * place in front of the transcript, so dictating after typing adds rather
+     * than replaces.
+     */
+    @PostMapping(value = "/transcribe", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UiPatch> transcribe(@PathVariable UUID sessionId,
+                                              @RequestParam("audio") MultipartFile audio,
+                                              @RequestParam(value = "message", required = false) String typed,
+                                              @AuthenticationPrincipal OidcUser user) {
+        // Someone else's session is not found here, exactly as it is not found
+        // anywhere else in the chat — dictation is no way around that.
+        if (!ownsSession(sessionId, user)) {
+            return ResponseEntity.notFound().build();
+        }
+        LlmTranscription speech = transcription.getIfAvailable();
+        if (speech == null) {
+            return ResponseEntity.ok(toast(UiToast.error(
+                    "This server has no speech-to-text gateway.").title("Dictation unavailable")));
+        }
+        if (audio.isEmpty()) {
+            return ResponseEntity.ok(toast(UiToast.error(
+                    "The recording was empty.").title("Nothing to transcribe")));
+        }
+
+        String filename = audio.getOriginalFilename() == null ? "recording.webm" : audio.getOriginalFilename();
+        TranscriptionResult result;
+        try {
+            result = speech.transcribe(CONFIG_NAME, TranscriptionRequest.of(
+                    audio.getBytes(), filename, audio.getContentType()));
+        } catch (Exception e) {
+            log.warn("Dictation in session {} failed: {}", sessionId, e.toString());
+            return ResponseEntity.ok(toast(UiToast.error(reason(e)).title("Dictation failed")));
+        }
+
+        String spoken = result.text() == null ? "" : result.text().strip();
+        if (spoken.isEmpty()) {
+            return ResponseEntity.ok(toast(UiToast.error(
+                    "The model heard nothing in the recording.").title("Nothing recognised")));
+        }
+        log.info("Dictated {} characters into session {}", spoken.length(), sessionId);
+        // While a turn streams the composer is a status row: no textarea, so
+        // the patch below would land nowhere and the words would be gone.
+        // The toast keeps them readable until the turn ends.
+        if (isStreaming(sessionId)) {
+            return ResponseEntity.ok(toast(UiToast.info(spoken)
+                    .title("Heard while the agent was answering")
+                    // Sticky: the words are the point, and they are gone once
+                    // the toast is.
+                    .sticky()));
+        }
+        return ResponseEntity.ok(UiPatch.of().patch(UiPatch.Operation.replace(
+                "message", ChatFormComponent.messageField(join(typed, spoken)))));
+    }
+
+    /** The session belongs to whoever is asking — the chat's own rule. */
+    private boolean ownsSession(UUID sessionId, OidcUser user) {
+        String userId = user == null ? "mc_user" : user.getPreferredUsername();
+        return sessions.findById(sessionId)
+                .filter(session -> userId.equals(session.userId()))
+                .isPresent();
+    }
+
+    /**
+     * Is a turn of this session streaming right now? The same question the
+     * chat page asks to decide between the composer and the status row, asked
+     * of the same registry.
+     */
+    private boolean isStreaming(UUID sessionId) {
+        return activeStreams.findHandle("msg-list-" + sessionId).isPresent();
+    }
+
+    /** What was typed, then what was said — with one space between them. */
+    private static String join(String typed, String spoken) {
+        if (typed == null || typed.isBlank()) return spoken;
+        String head = typed.stripTrailing();
+        return head.isEmpty() ? spoken : head + " " + spoken;
+    }
+
+    /**
+     * The failure in one line for a toast. A missing config is the likely one
+     * — nobody has set up {@value #CONFIG_NAME} yet — and it deserves a
+     * sentence that says what to do rather than a class name.
+     */
+    private static String reason(Exception e) {
+        String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+        if (message.contains(CONFIG_NAME)) {
+            return "No LLM config named '" + CONFIG_NAME + "'. Create one of type "
+                    + "Speech to text in the admin UI, or point an alias of that name at one.";
+        }
+        return message;
+    }
+
+    private static UiPatch toast(UiToast toast) {
+        return UiPatch.of().toast(toast);
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
@@ -901,3 +901,24 @@
     font-weight: 500;
     white-space: nowrap;
 }
+
+/* ── Dictation ────────────────────────────────────────────────────────────
+   While the microphone is open the composer's mic button says so in colour —
+   an icon-only button has no label to change — and the textarea's placeholder
+   counts the seconds. Both end when the transcript patches the field back. */
+.chat-record-btn.is-recording,
+.sui-btn.is-recording {
+    color: var(--sui-color-danger, #d33);
+    border-color: var(--sui-color-danger, #d33);
+    animation: mc-recording-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes mc-recording-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.55; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .chat-record-btn.is-recording,
+    .sui-btn.is-recording { animation: none; }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/js/audio-recorder.js
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/js/audio-recorder.js
@@ -1,0 +1,195 @@
+/**
+ * Speaking instead of typing, wherever a button asks for it.
+ *
+ * Two screens use this: the LLM-config test dialog of a speech-to-text config,
+ * and the chat composer's microphone. Both carry a button whose trigger is
+ * `INVOKE` with the handler registered here, and both name the URL the
+ * recording goes to. The first click asks the browser for the microphone and
+ * starts recording; the second stops it and posts the recording to that URL as
+ * multipart/form-data under the part name `audio`, together with whatever the
+ * trigger's payload node holds — the composer's draft text rides along that
+ * way. The response is a UiPatch, returned from the handler so the bus applies
+ * it: the dialog grows a transcript, the composer's textarea fills with one.
+ *
+ * The microphone needs a secure context: this works on localhost and over
+ * HTTPS, and nowhere else. Recording holds the microphone until it is stopped,
+ * so every exit path releases the tracks.
+ */
+
+/** Container formats a browser may hand us, and the file extension each needs. */
+const FORMATS = [
+    { mime: "audio/webm;codecs=opus", ext: "webm" },
+    { mime: "audio/webm",             ext: "webm" },
+    { mime: "audio/mp4",              ext: "m4a"  },  // Safari
+    { mime: "audio/ogg;codecs=opus",  ext: "ogg"  },
+];
+
+function pickFormat() {
+    if (typeof MediaRecorder === "undefined") return null;
+    return FORMATS.find(f => MediaRecorder.isTypeSupported(f.mime)) || null;
+}
+
+/**
+ * Where progress is written. The test dialog has a line of its own; the chat
+ * composer has none and would not want one, so its own textarea says it in the
+ * placeholder — visible, and gone again when the field is patched back.
+ */
+function statusTarget(ctx) {
+    const line = document.querySelector(".llm-record-status");
+    if (line) return { write: text => { line.textContent = text; }, restore: () => {} };
+
+    const formId = ctx.trigger && ctx.trigger.payload;
+    const area = formId ? document.querySelector("#" + CSS.escape(formId) + " textarea") : null;
+    if (!area) return { write: () => {}, restore: () => {} };
+    const original = area.placeholder;
+    return {
+        write: text => { area.placeholder = text || original; },
+        restore: () => { area.placeholder = original; },
+    };
+}
+
+/**
+ * The button while it records. A labelled button says "Stop" — the framework
+ * renders that label as a bare text node next to the icon, so the text node is
+ * what changes; replacing the button's whole content would drop the icon. An
+ * icon-only button has no text at all, and its accessible name carries the
+ * state instead. Both get a class a stylesheet can pick up.
+ */
+function mark(button, recording) {
+    button.classList.toggle("is-recording", recording);
+
+    const text = [...button.childNodes].reverse()
+        .find(node => node.nodeType === Node.TEXT_NODE && node.data.trim() !== "");
+    if (text) {
+        if (recording) {
+            if (button.dataset.idleLabel === undefined) button.dataset.idleLabel = text.data;
+            text.data = "Stop";
+        } else if (button.dataset.idleLabel !== undefined) {
+            text.data = button.dataset.idleLabel;
+        }
+        return;
+    }
+    // Icon-only: nothing to read but the accessible name.
+    if (recording) {
+        if (button.dataset.idleLabel === undefined) {
+            button.dataset.idleLabel = button.getAttribute("aria-label") || "";
+        }
+        button.setAttribute("aria-label", "Stop recording");
+        button.setAttribute("title", "Stop recording");
+    } else if (button.dataset.idleLabel !== undefined) {
+        button.setAttribute("aria-label", button.dataset.idleLabel);
+        button.setAttribute("title", button.dataset.idleLabel);
+    }
+}
+
+export function installAudioRecorder(bus) {
+    // At most one recording at a time — a page shows one such button at once.
+    let session = null;
+
+    function release() {
+        if (!session) return;
+        clearInterval(session.timer);
+        session.stream.getTracks().forEach(track => track.stop());
+        mark(session.button, false);
+        const status = session.status;
+        session = null;
+        return status;
+    }
+
+    async function start(ctx, button) {
+        const status = statusTarget(ctx);
+        // Browsers hand out the microphone only in a secure context: HTTPS,
+        // or localhost. Over plain HTTP navigator.mediaDevices is not even
+        // there, and the failure would otherwise read as "no microphone".
+        if (!window.isSecureContext || !navigator.mediaDevices) {
+            status.write("Recording needs HTTPS — this page is served over plain HTTP.");
+            return;
+        }
+        const format = pickFormat();
+        if (!format) {
+            status.write("This browser cannot record audio.");
+            return;
+        }
+        let stream;
+        try {
+            stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch (e) {
+            status.write(e && e.name === "NotAllowedError"
+                ? "The browser blocked the microphone."
+                : "No microphone available.");
+            return;
+        }
+        // From here the microphone is open. Anything that throws before the
+        // session exists has to give it back, or the browser keeps showing a
+        // recording indicator nobody can switch off.
+        let recorder;
+        const chunks = [];
+        let stopped;
+        try {
+            recorder = new MediaRecorder(stream, { mimeType: format.mime });
+            recorder.addEventListener("dataavailable", e => {
+                if (e.data && e.data.size > 0) chunks.push(e.data);
+            });
+            stopped = new Promise(resolve => recorder.addEventListener("stop", resolve));
+            recorder.start();
+        } catch (e) {
+            stream.getTracks().forEach(track => track.stop());
+            status.write("This browser could not start the recorder.");
+            console.error("MediaRecorder failed to start", e);
+            return;
+        }
+
+        const startedAt = Date.now();
+        session = { recorder, chunks, stream, button, format, stopped, status, timer: null };
+        session.timer = setInterval(
+            () => status.write("Recording… " + Math.round((Date.now() - startedAt) / 1000) + " s"),
+            250);
+        mark(button, true);
+        status.write("Recording… 0 s");
+    }
+
+    async function stop(ctx) {
+        const { recorder, chunks, format, stopped } = session;
+        recorder.stop();
+        await stopped;
+        const status = release();
+
+        const blob = new Blob(chunks, { type: format.mime });
+        if (blob.size === 0) {
+            status.write("Nothing was recorded.");
+            return null;
+        }
+        status.write("Transcribing…");
+
+        const body = new FormData();
+        body.append("audio", blob, "recording." + format.ext);
+        // Whatever the payload node holds travels with the recording — the
+        // composer's draft, so the server can put the transcript after it.
+        Object.entries(ctx.payload || {}).forEach(([key, value]) => {
+            if (typeof value === "string" && value !== "") body.append(key, value);
+        });
+
+        const response = await ctx.fetch(ctx.url, { method: "POST", body });
+        if (!response.ok) {
+            status.write("The server answered " + response.status + ".");
+            return null;
+        }
+        status.restore();
+        return await response.json();
+    }
+
+    bus.registerClientHandler("mc-record-audio", async (ctx) => {
+        if (session) {
+            try {
+                return await stop(ctx);
+            } catch (e) {
+                const status = release() || statusTarget(ctx);
+                status.write("Recording failed.");
+                console.error("Recording failed", e);
+                return null;
+            }
+        }
+        await start(ctx, ctx.sourceElement);
+        return null;
+    });
+}

--- a/website/docs/agents/admin-ui/llm-configs.md
+++ b/website/docs/agents/admin-ui/llm-configs.md
@@ -41,9 +41,10 @@ it, the Test dialog included — it asks for a recording when the config at the
 end of the chain is a speech one.
 
 A fresh installation is seeded with a `speech-to-text` config: OpenAI's
-`whisper-1` behind `${OPENAI_API_KEY}`, answering in `verbose_json`. Point
-`SPEECH_TO_TEXT_BASE_URL` at Groq or a local Whisper server to use it without
-an OpenAI key, and `SPEECH_TO_TEXT_MODEL` at another model.
+`whisper-1` behind `${OPENAI_API_KEY}`. Point `SPEECH_TO_TEXT_BASE_URL` at
+Groq or a local Whisper server to use it without an OpenAI key, and
+`SPEECH_TO_TEXT_MODEL` at another model — the seed pins no response format,
+so switching the model cannot collide with one.
 
 ## Dictating in the chat {#dictation}
 

--- a/website/docs/agents/admin-ui/llm-configs.md
+++ b/website/docs/agents/admin-ui/llm-configs.md
@@ -19,7 +19,11 @@ A config has a `name`, `provider`, `model`, `baseUrl`, `apiKey`,
 `contextWindowTokens`, and optional `additionalParams`, rate-limit and retry
 settings. The form also covers:
 
-- **Type** — `Chat` or `Embedding` (embedding configs power the vector store);
+- **Type** — `Chat`, `Embedding` (embedding configs power the vector store)
+  or `Speech to text` (since 0.5.3: a Whisper-style model that turns a
+  recording into text). Only chat configs have sampling settings; a
+  speech-to-text config takes its language, prompt and response format
+  from the provider parameters;
 - **Capabilities** (chat configs) — what the model reads and does: tool
   calling, vision (images), documents (PDF), audio input. Vision and documents
   steer the runtime: an image or PDF sent with a message reaches the model as
@@ -31,6 +35,38 @@ settings. The form also covers:
 - provider-specific extra parameters, rendered from the provider catalog;
 - an **Encrypt** button next to the API-key field for literal keys.
 
+An alias works for a speech-to-text config like for any other: set
+*Delegates To* and every caller naming the alias lands on the config behind
+it, the Test dialog included — it asks for a recording when the config at the
+end of the chain is a speech one.
+
+A fresh installation is seeded with a `speech-to-text` config: OpenAI's
+`whisper-1` behind `${OPENAI_API_KEY}`, answering in `verbose_json`. Point
+`SPEECH_TO_TEXT_BASE_URL` at Groq or a local Whisper server to use it without
+an OpenAI key, and `SPEECH_TO_TEXT_MODEL` at another model.
+
+## Dictating in the chat {#dictation}
+
+The chat composer has a microphone next to the **+**. Press it, speak, press it
+again: while it records, the mic turns red and the input's placeholder counts
+the seconds; on stop the recording goes to the server, and the transcript lands
+in the input — after whatever was already typed, so dictating adds to a draft
+rather than replacing it. Nothing is sent on its own; the words are read,
+corrected and sent by the person who spoke them.
+
+The chat always asks for the config named **`speech-to-text`**. That is a name,
+not a model: point an alias of that name at whichever config should serve the
+chat, and swap what is behind it without touching anything else. Without such a
+config the mic answers with a toast saying which config to create.
+
+Recording needs a microphone and a **secure context**, which is a browser rule,
+not a setting of this application: the microphone is handed out on HTTPS pages
+and on `localhost`, and nowhere else. A deployment behind TLS — a reverse proxy
+with a certificate, an ingress, Cloud Run — is therefore fine; the same server
+reached over plain `http://` on a host name is not, and the placeholder then
+says the page is served over plain HTTP. Typing and file upload are unaffected
+either way.
+
 ## LM Studio: pick a model instead of typing it {#lm-studio}
 
 A new config starts with no provider selected; the field is required. With
@@ -40,7 +76,9 @@ what it has installed, and the model field becomes a dropdown:
 - the list comes from LM Studio's native REST API (`GET {baseUrl}/api/v0/models`,
   falling back to `/api/v1/models` on newer versions) and is filtered by the
   config's type — chat models (`llm`, `vlm`) for a chat config, embedding
-  models for an embedding config;
+  models for an embedding config. LM Studio serves no transcription models,
+  so a speech-to-text config finds none there and points at OpenAI, Groq or a
+  local Whisper server instead;
 - each entry shows the model's context length and whether it is loaded, e.g.
   `openai/gpt-oss-120b · 32k loaded (max 128k) · tools`;
 - picking a model fills in **Context Window Tokens** with the length the model
@@ -71,6 +109,19 @@ takes a text to embed), sends a real request to the provider
   reports duration, token counts and finish reason.
 - ❌ **Error** — shows the failure (bad key, wrong endpoint, model not found,
   provider unreachable…).
+
+A `Speech to text` config is tested with a recording instead of a message: the
+dialog shows a drop zone, and dropping or picking an audio file (WebM, WAV,
+MP3, M4A, OGG, FLAC) posts it to `POST /admin/api/llm-configs/{id}/test-audio`.
+The transcript comes back in the same dialog, with the detected language and
+the length of the recording when the model reports them.
+
+The dialog can also record: **Record** asks the browser for the microphone and
+counts the seconds, **Stop** sends what was spoken to the same endpoint. It is
+browser-only — the recording is made and posted by the page, the server sees an
+ordinary upload. The microphone needs a secure context, so this works on
+`localhost` and over HTTPS; elsewhere the status line says the browser refused,
+and the drop zone still does the job.
 
 Test a cloud config right after creating it, to confirm the API key and
 `baseUrl` before wiring it into an agent.

--- a/website/docs/agents/environment-variables.md
+++ b/website/docs/agents/environment-variables.md
@@ -64,6 +64,8 @@ as an env var in `SCREAMING_SNAKE` form (e.g. `MINDCONNECT_DATA_BASE_DIR`).
 | `AZURE_OPENAI_DEPLOYMENT` | `azure-openai-default` | Deployment name (default `gpt-4o`) |
 | `GEMINI_API_KEY` | `gemini-default` | Google Gemini key |
 | `GEMINI_MODEL` | `gemini-default` | Override model id (default `gemini-2.0-flash`) |
+| `SPEECH_TO_TEXT_MODEL` | `speech-to-text` | Override model id (default `whisper-1`) |
+| `SPEECH_TO_TEXT_BASE_URL` | `speech-to-text` | Where the transcription endpoint lives (default `https://api.openai.com`) — point it at Groq or a local Whisper server |
 
 Local providers (`lm-studio-default`, `agent-default`, `embeddings`) need **no**
 key — they talk to LM Studio at `http://localhost:1234`.

--- a/website/docs/agents/llm-config-json.md
+++ b/website/docs/agents/llm-config-json.md
@@ -65,7 +65,7 @@ A minimal local config (no key needed):
 | `model` | string | Model id. Supports `${VAR}` / `${VAR:default}`. |
 | `baseUrl` | string | API endpoint (override for proxies / local servers). |
 | `apiKey` | string | API key — almost always an env-var placeholder like `${ANTHROPIC_API_KEY}`. Literal keys are stored encrypted in the Admin UI (the CLI stores them as-is — use placeholders there). |
-| `type` | enum? | `CHAT` (default) or `EMBEDDING` — embedding configs power the vector store. |
+| `type` | enum? | `CHAT` (default), `EMBEDDING` or `SPEECH_TO_TEXT`. Embedding configs power the vector store; speech-to-text configs turn a recording into text through `LlmTranscription` (since 0.5.3). Only chat configs have sampling settings. |
 | `capabilities` | string[]? | What the model reads and does: any of `TOOL_CALLING`, `VISION` (images), `DOCUMENTS` (PDF), `AUDIO_INPUT`. `VISION` and `DOCUMENTS` decide whether an image or PDF sent with a message reaches the model as content or as a placeholder line. **Omitted means not declared** — the provider's default applies (Anthropic and OpenAI: tool calling, vision, documents; Gemini: those plus audio; Azure OpenAI: tool calling, vision; local servers and routers: tool calling only). A declared list, `[]` included, always wins over that default. Chat configs only. |
 | `defaultTemperature` | number | Sampling temperature (e.g. `0.7`). |
 | `maxOutputTokens` | int | Max tokens the model may generate per response. |

--- a/website/docs/agents/llm-gateway.md
+++ b/website/docs/agents/llm-gateway.md
@@ -17,6 +17,13 @@ It is a **library** (a plain `jar`), not a server. The main ports:
 
 - **`LlmChat`** (in-port) — what callers use to stream a chat completion.
 - **`LlmEmbeddings`** (in-port) — embeddings, used by the vector store.
+- **`LlmTranscription`** (in-port) — speech to text, since 0.5.3: name a
+  config, hand over one recording, get one transcript. Routing works as it
+  does for chat, so an alias is followed.
+- **`TranscriptionGateway`** (out-port) — what a provider's speech-to-text
+  adapter implements. `OpenAiTranscriptionGateway` calls the
+  OpenAI-compatible `/v1/audio/transcriptions` endpoint, which OpenAI, Groq
+  and a local Whisper server all speak.
 - **`LlmGateway`** (out-port) — what each provider adapter implements.
 - **`LlmConfigRepository`** (out-port) — where configs are stored;
   `LlmCallListener` lets you observe every call (wire traces).
@@ -25,6 +32,7 @@ Between them sits the routing layer:
 
 ```
 caller → LlmChat (RoutingLlmChatService) → LlmGatewayRegistry → LlmGateway adapter → provider
+caller → LlmTranscription (RoutingLlmTranscriptionService) → TranscriptionGateway adapter → provider
 ```
 
 `RoutingLlmChatService` looks up the agent's `llmConfigName`, finds the matching

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -273,11 +273,32 @@ out, for a caller who wants the synchronous feel without a polling loop (60
 seconds is the cap).
 
 **Streaming.** `GET /api/transcriptions/{id}/events` is Server-Sent Events
-from the job's channel: `queued`, `running`, then `completed` carrying the
-transcript, or `failed` with the reason. The stream opens with the job's
-state as it is now, so attaching late tells you what you missed instead of
-leaving you waiting, and it closes when the job ends. `?afterSeq=` resumes a
-dropped connection from the last event seen, without a gap.
+from the job's channel:
+
+```
+event:queued    data:{"status":"queued"}
+event:running   data:{"status":"running"}
+event:delta     data:{"status":"delta","text":"The"}
+event:delta     data:{"status":"delta","text":" quick"}
+event:completed data:{"status":"completed","text":"The quick brown fox …"}
+```
+
+A `delta` carries a fragment, not the whole: append them as they come. How
+finely they arrive is the model's business — OpenAI's `gpt-4o-transcribe`
+models send the text as it forms, `whisper-1` answers in one piece and so
+sends a single delta at the end. The events are the same either way, so
+client code does not branch on the model. `completed` always carries the
+whole transcript and is the authority; a client that only wants the end can
+ignore every delta.
+
+The stream opens with the job's state as it is now, so attaching late tells
+you what you missed instead of leaving you waiting, and it closes when the
+job ends. `?afterSeq=` resumes a dropped connection from the last event seen,
+without a gap — though a very long transcript can push the earliest deltas
+out of the replay buffer, which is why `completed` repeats the whole text.
+
+A config can turn the asking off with the provider parameter `stream: off`,
+for an endpoint that rejects fields it does not know.
 
 **The recording stays.** It is an upload in the file store like any other:
 `GET /api/files/{id}` for its metadata, `…/content` for the bytes, and

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -233,6 +233,63 @@ loading the open approvals is the right order for a client.
 
 See [working memory](./memory.md) for what the strategies do.
 
+## Transcription
+
+Turning a recording into text is a job, not an answer: the audio is stored,
+a task is queued, and the caller gets an id. A long recording outlasts a
+comfortable request, providers fail now and then, and the queue behind this
+already retries and survives a restart — the same reason transcription
+services hand out job ids rather than holding the connection.
+
+```bash
+curl -X POST http://localhost:9090/api/transcriptions \
+  -F "file=@speech.webm" -F "language=en"
+```
+
+The answer is `202` with everything needed to follow the job:
+
+```json
+{
+  "id": "task_774c0642-…",
+  "status": "queued",
+  "resultUrl": "/api/transcriptions/task_774c0642-…",
+  "eventsUrl": "/api/transcriptions/task_774c0642-…/events",
+  "channelId": "transcription-task_774c0642-…",
+  "fileId": "file-cbec6f35da40…",
+  "fileUrl": "/api/files/file-cbec6f35da40…"
+}
+```
+
+- **`model`** names an LLM config of type `SPEECH_TO_TEXT`. An alias of that
+  name is followed, so an operator decides what serves. Omitted, the config
+  named `speech-to-text` does.
+- **`language`** and **`prompt`** are optional: the ISO-639-1 code of what is
+  spoken, and context that steers the spelling of names.
+
+**Polling.** `GET /api/transcriptions/{id}` answers with the status and, once
+it is done, the transcript plus the detected language and the recording's
+length. `?wait=30` holds the request until the job ends or the seconds run
+out, for a caller who wants the synchronous feel without a polling loop (60
+seconds is the cap).
+
+**Streaming.** `GET /api/transcriptions/{id}/events` is Server-Sent Events
+from the job's channel: `queued`, `running`, then `completed` carrying the
+transcript, or `failed` with the reason. The stream opens with the job's
+state as it is now, so attaching late tells you what you missed instead of
+leaving you waiting, and it closes when the job ends. `?afterSeq=` resumes a
+dropped connection from the last event seen, without a gap.
+
+**The recording stays.** It is an upload in the file store like any other:
+`GET /api/files/{id}` for its metadata, `…/content` for the bytes, and
+`DELETE /api/files/{id}` when it has served its purpose. Nothing deletes it
+for you — a transcript is worth little without the audio behind it, and only
+the caller knows when that stops being true. The job's `fileId` and `fileUrl`
+come back with the submit answer and with every poll.
+
+A job that a request submitted under a login is readable only by that user;
+on an installation without login, by anyone who reaches the endpoint, like
+the rest of this API.
+
 ## Beyond chat
 
 The same server exposes LLM configurations, the file store, session


### PR DESCRIPTION
A speech-to-text model is now an ordinary LLM config, and the chat has a
microphone: press it, speak, press it again, and the words are in the input.

## The config type

`LlmConfigType.SPEECH_TO_TEXT` joins `CHAT` and `EMBEDDING`. That was the
decision worth making: the old branch in the predecessor repository built a
whole `mc-speech` cluster with its own provider enum, repository, encryption
and admin pages, all of it a copy of what `LlmConfig` already does. A third
type gets provider, key, encryption, the admin form and the Test button for
free, and it keeps one obvious question answerable — "which models does this
installation know?" — with one list.

The direction is not a capability set on one `AUDIO` type: a config pins one
model, and `whisper-1` cannot synthesise speech. Text to speech will be a
fourth type when it comes.

## Ports

- `LlmTranscription` (in-port) — name a config, hand over a recording, get a
  transcript. `RoutingLlmTranscriptionService` looks the name up, follows an
  alias exactly as the chat routing does, and refuses a config of the wrong
  type before the call rather than letting the provider complain about an
  endpoint.
- `TranscriptionGateway` (out-port) — `OpenAiTranscriptionGateway` posts
  multipart to `/v1/audio/transcriptions`. OpenAI, Groq and a local Whisper
  server all speak it; the base URL decides. `language`, `prompt`,
  `temperature` and `response_format` come from the config's additional
  parameters, and a request may override language and prompt.

Because routing is by name, `speech-to-text` can be an alias: point it at
whichever config should serve, swap it later, callers unchanged.

## In the chat

The composer's microphone records with `MediaRecorder` and posts the
recording to `POST /chat/api/sessions/{id}/voice/transcribe`, together with
whatever was already typed. The transcript comes back as a patch of the input,
appended after the draft. Nothing is sent on the speaker's behalf. While a
turn is streaming the composer has no input to fill, so the words come back as
a sticky toast instead of being dropped. The endpoint checks session ownership
like every other chat endpoint.

Recording needs a microphone and a secure context — `localhost` or HTTPS, a
browser rule, not a setting of this application. Behind TLS a deployment is
fine; over plain HTTP the status line says so and typing is unaffected.

## In the admin UI

A speech config's Test dialog asks for a recording: drop an audio file, or
press Record, speak, press Stop. The dialog follows an alias to decide what to
ask for, so testing an alias to a speech config offers the drop zone rather
than a message box. The type-specific settings group drops the sampling knobs,
the detail view stops showing rows a transcription call has no use for, and
the LM Studio model picker says it serves no transcription models instead of
offering chat ones.

## Seed

A new installation gets a `speech-to-text` config — `whisper-1` behind
`${OPENAI_API_KEY}`, overridable through `SPEECH_TO_TEXT_MODEL` and
`SPEECH_TO_TEXT_BASE_URL`. An existing installation gets it on the next start,
since seeding checks each entry by id.

## Transcription over the REST API

`POST /api/transcriptions` takes a recording as multipart, stores it and
queues the work. The answer is `202` with the job id and every URL needed to
follow it — one to poll, one to stream, one for the recording:

```json
{
  "id": "task_774c0642-…",
  "status": "queued",
  "resultUrl": "/api/transcriptions/task_774c0642-…",
  "eventsUrl": "/api/transcriptions/task_774c0642-…/events",
  "channelId": "transcription-task_774c0642-…",
  "fileId": "file-cbec6f35da40…",
  "fileUrl": "/api/files/file-cbec6f35da40…"
}
```

A job rather than an answer, because a long recording outlasts a comfortable
request and providers fail now and then. The queue already retries, survives a
restart with the Postgres store, and spreads over nodes; `model` names an LLM
config whose alias is followed.

- **Polling** — `GET /api/transcriptions/{id}` gives the status and, once
  done, the transcript with the detected language and the length. `?wait=30`
  holds the request until the job ends (cap: a minute), for a caller who wants
  the synchronous feel without a loop.
- **Streaming** — `GET /api/transcriptions/{id}/events` is SSE from the job's
  channel: `queued`, `running`, then the transcript in `delta` frames, then
  `completed` with the whole text. How finely the deltas arrive is the model's
  business, and asking costs nothing: the `stream` field goes out only when
  somebody is listening, and the answer's content type says which form came
  back. Measured rather than assumed — `whisper-1` answers `200` with plain
  JSON and ignores the field, `gpt-4o-mini-transcribe` answers
  `text/event-stream`. A model that cannot stream sends one delta at the end,
  so client code never branches on the model, and `completed` always carries
  the authority. The stream opens with the state as it is now, so a late
  arrival is told what it missed rather than left waiting, and `?afterSeq=`
  resumes a dropped connection without a gap. The channel is the runtime's
  own: many subscribers, replay from a buffer, a bounded queue per reader, so
  a slow client cannot hold the job up.
- **The recording stays** in the file store, an upload like any other:
  `GET /api/files/{id}`, `…/content`, and `DELETE /api/files/{id}` when it has
  served its purpose. A transcript is worth little without the audio behind
  it, and only the caller knows when that stops being true.

A generic endpoint over arbitrary channel ids is deliberately not exposed. The
plumbing is generic, the route is not: channels have no owner yet, and one of
them carries every task of the installation. Lifting it is a follow-up, once
channels can say who may read them.

Two findings from reviewing the branch are fixed here as well: dictation no
longer reports a config of the wrong type as a missing one, and the seeded
config pins no response format — `verbose_json` is whisper-1 only and would
have broken the documented `SPEECH_TO_TEXT_MODEL` override.

## Verified

- Against `api.openai.com` with a real recording, through the admin dialog and
  through the chat: transcript, detected language, duration.
- The browser path (record, count, stop, post, apply) with a stubbed recorder,
  including the draft-plus-transcript join and the microphone being released
  when the recorder fails to start.
- Alias routing end to end: `speech-to-text` turned into an alias to a second
  Whisper config, dictation still working, the Test dialog still asking for a
  recording even with the alias stored as type Chat.
- The REST job end to end against `api.openai.com`: submit, poll with
  `?wait=`, stream from the start, attach late to a finished job, and a
  failing job reporting its reason. The recording is still fetchable
  afterwards and goes away on `DELETE`.
- The delta path against `gpt-4o-mini-transcribe`, word by word through our
  own endpoint, and the seeded `whisper-1` config producing the same events
  with a single delta.
- 23 unit tests for the adapter, the routing and the job service; the full
  reactor build.

Manual regression cases: `agents/doc/manual-tests/llm-configs/speech-to-text-config.md`
and `agents/doc/manual-tests/chat/dictation.md`.


