### PR TITLE
Four fixes the whisper review found, just after 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **agents:** an MCP server whose command cannot be run says so at once
+  instead of holding the application back. The Gmail tools spawn their server
+  through docker; on a machine without it — or with a docker link left behind
+  by an uninstalled Docker Desktop — startup used to stall for the full
+  initialization timeout and log a dropped reactive error before deciding the
+  provider was unavailable. The proxy now checks that the command resolves to
+  something executable before spawning, and names it when it does not.
+
+- **agents:** a transcription job asked to wait no longer answers with a
+  server error. `GET /api/transcriptions/{id}?wait=` treats running out of
+  seconds as what it is — the job is still going — and answers with the job as
+  it stands. The transcription call itself now has a deadline of its own, so
+  an endpoint that accepts a connection and then goes quiet can no longer hold
+  a queue worker and leave a job running for ever. And an endpoint that
+  rejects the `stream` field, which is asked for whenever a caller listens for
+  deltas, is simply asked again without it rather than failing the job; a
+  config that would rather skip that round trip sets the provider parameter
+  `stream=off`.
+
 ## [0.6.0] - 2026-09-10
 
 ### Added

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGateway.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGateway.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -41,6 +42,16 @@ public final class OpenAiTranscriptionGateway implements TranscriptionGateway {
     private static final Logger log = LoggerFactory.getLogger(OpenAiTranscriptionGateway.class);
     private static final MediaType OCTET_STREAM = MediaType.get("application/octet-stream");
     private static final int MAX_ERROR_BODY = 500;
+
+    /**
+     * How long one transcription may take. The shared client deliberately has
+     * no read timeout — it also carries the chat's SSE streams, which must
+     * stay open — but a job that runs on the task queue needs an end: an
+     * endpoint that accepts the connection and then goes quiet would
+     * otherwise hold a worker and leave the task running for ever. Generous,
+     * because transcription is slow: a long recording takes minutes.
+     */
+    private static final Duration CALL_TIMEOUT = Duration.ofMinutes(15);
 
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
@@ -84,9 +95,18 @@ public final class OpenAiTranscriptionGateway implements TranscriptionGateway {
             http.header("Authorization", "Bearer " + cfg.apiKey());
         }
 
-        try (Response response = httpClient.newCall(http.build()).execute()) {
+        try (Response response = call(http.build()).execute()) {
             if (!response.isSuccessful()) {
                 String payload = response.body() != null ? response.body().string() : "";
+                // Not every endpoint that speaks this API knows the stream
+                // field. One that rejects it says 400 — worth asking again
+                // without it before giving up, since the field was our idea,
+                // not the caller's. A config can skip this with stream=off.
+                if (askForStream && response.code() == 400) {
+                    log.debug("Endpoint {} refused the stream field; asking again without it",
+                            cfg.baseUrl());
+                    return transcribeWithoutStream(cfg, request, responseFormat, onDelta);
+                }
                 throw new IllegalStateException("Transcription call failed (" + response.code()
                         + "): " + truncate(payload));
             }
@@ -101,6 +121,37 @@ public final class OpenAiTranscriptionGateway implements TranscriptionGateway {
             throw new IllegalStateException("Transcription call to " + cfg.baseUrl() + " failed: "
                     + e.getMessage(), e);
         }
+    }
+
+    /** The same call once more, this time as a plain batch request. */
+    private TranscriptionResult transcribeWithoutStream(LlmConfig cfg, TranscriptionRequest request,
+                                                        String responseFormat,
+                                                        Consumer<String> onDelta) {
+        Request.Builder http = new Request.Builder()
+                .url(cfg.baseUrl() + "/v1/audio/transcriptions")
+                .post(multipartBody(cfg, request, responseFormat, false));
+        if (cfg.apiKey() != null && !cfg.apiKey().isBlank()) {
+            http.header("Authorization", "Bearer " + cfg.apiKey());
+        }
+        try (Response response = call(http.build()).execute()) {
+            if (!response.isSuccessful()) {
+                String payload = response.body() != null ? response.body().string() : "";
+                throw new IllegalStateException("Transcription call failed (" + response.code()
+                        + "): " + truncate(payload));
+            }
+            return readWhole(response, responseFormat, onDelta);
+        } catch (IOException e) {
+            throw new IllegalStateException("Transcription call to " + cfg.baseUrl() + " failed: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    /** One call with this adapter's own deadline on the shared client. */
+    private okhttp3.Call call(Request request) {
+        return httpClient.newBuilder()
+                .callTimeout(CALL_TIMEOUT)
+                .build()
+                .newCall(request);
     }
 
     /** The request body. Package-private so a test can read the parts back. */

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGatewayTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/openai/OpenAiTranscriptionGatewayTest.java
@@ -34,6 +34,9 @@ class OpenAiTranscriptionGatewayTest {
     private static final byte[] AUDIO = "not really audio".getBytes(StandardCharsets.UTF_8);
 
     private HttpServer server;
+    /** Set per call before answering — lets a test stage a 400 then a 200. */
+    private final java.util.Queue<Runnable> responses = new java.util.ArrayDeque<>();
+    private List<String> bodiesSeen;
     private final AtomicReference<String> lastBody = new AtomicReference<>();
     private final AtomicReference<String> lastAuth = new AtomicReference<>();
     private volatile String responseBody = "{\"text\":\"hello\"}";
@@ -45,7 +48,11 @@ class OpenAiTranscriptionGatewayTest {
         server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/v1/audio/transcriptions", exchange -> {
             lastAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
-            lastBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            lastBody.set(body);
+            if (bodiesSeen != null) bodiesSeen.add(body);
+            Runnable staged = responses.poll();
+            if (staged != null) staged.run();
             byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", responseType);
             exchange.sendResponseHeaders(responseCode, bytes.length);
@@ -216,6 +223,35 @@ class OpenAiTranscriptionGatewayTest {
 
         assertThat(result.text()).isEqualTo("half a sentence");
         assertThat(deltas).hasSize(2);
+    }
+
+    @Test
+    void anEndpointThatRefusesTheStreamFieldIsAskedAgainWithoutIt() {
+        // First call: 400, as a server that validates its form strictly
+        // answers an unknown field. Second call must arrive without it.
+        List<String> bodies = new ArrayList<>();
+        responses.add(() -> { responseCode = 400; responseBody = "{\"error\":\"unknown field stream\"}"; });
+        responses.add(() -> { responseCode = 200; responseBody = "{\"text\":\"asked again\"}"; });
+        bodiesSeen = bodies;
+        List<String> deltas = new ArrayList<>();
+
+        TranscriptionResult result = gateway().transcribe(config(), recording(), deltas::add);
+
+        assertThat(result.text()).isEqualTo("asked again");
+        assertThat(bodies).hasSize(2);
+        assertThat(bodies.get(0)).contains("name=\"stream\"");
+        assertThat(bodies.get(1)).as("the retry drops the field").doesNotContain("name=\"stream\"");
+        assertThat(deltas).containsExactly("asked again");
+    }
+
+    @Test
+    void aRefusalThatIsNotAboutTheStreamStillFails() {
+        responseCode = 401;
+        responseBody = "{\"error\":{\"message\":\"Incorrect API key\"}}";
+
+        assertThatThrownBy(() -> gateway().transcribe(config(), recording(), d -> { }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("401");
     }
 
     @Test

--- a/agents/core/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/McpProxyException.java
+++ b/agents/core/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/McpProxyException.java
@@ -5,4 +5,9 @@ public class McpProxyException extends RuntimeException {
     public McpProxyException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    /** For a failure that has no cause to pass on — a command nobody can run. */
+    public McpProxyException(String message) {
+        super(message);
+    }
 }

--- a/agents/core/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/SdkMcpProxy.java
+++ b/agents/core/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/SdkMcpProxy.java
@@ -6,6 +6,9 @@ import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +60,12 @@ public final class SdkMcpProxy implements McpProxy {
 
     @Override
     public McpConnection connect(McpStdioSpawn spawn) {
+        // A command that cannot be run fails here, in a sentence, rather than
+        // in thirty seconds of initialization timeout with a dropped reactive
+        // error in the log. The usual case is an MCP server behind docker on
+        // a machine where docker is not installed or not running.
+        requireExecutable(spawn.command());
+
         ServerParameters params = ServerParameters.builder(spawn.command())
                 .args(spawn.args())
                 .env(spawn.env())
@@ -77,5 +86,31 @@ public final class SdkMcpProxy implements McpProxy {
             throw new McpProxyException("MCP initialize failed: " + e.getMessage(), e);
         }
         return new SdkMcpConnection(client, jsonMapper);
+    }
+
+    /**
+     * Resolves a command the way the OS would before anything tries to run
+     * it: a name with a path separator must be an executable file, a bare
+     * name must be findable on {@code PATH}. A broken symlink counts as
+     * missing — which is exactly what a docker link left behind by an
+     * uninstalled Docker Desktop is.
+     *
+     * @throws McpProxyException when nothing executable answers to the name
+     */
+    static void requireExecutable(String command) {
+        Path direct = Path.of(command);
+        if (direct.getNameCount() > 1 || command.startsWith("/")) {
+            if (Files.isExecutable(direct)) return;
+            throw new McpProxyException("MCP server command is not executable: " + command);
+        }
+        String path = System.getenv("PATH");
+        if (path != null) {
+            for (String dir : path.split(java.io.File.pathSeparator)) {
+                if (dir.isBlank()) continue;
+                if (Files.isExecutable(Path.of(dir, command))) return;
+            }
+        }
+        throw new McpProxyException("MCP server command not found on PATH: " + command
+                + " — install it, or start the service that provides it");
     }
 }

--- a/agents/core/mc-mcp-proxy/src/test/java/ai/mindconnect/mcp/proxy/SdkMcpProxyCommandTest.java
+++ b/agents/core/mc-mcp-proxy/src/test/java/ai/mindconnect/mcp/proxy/SdkMcpProxyCommandTest.java
@@ -1,0 +1,54 @@
+package ai.mindconnect.mcp.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The check that runs before an MCP server is spawned. Without it a command
+ * nobody can run costs thirty seconds of initialization timeout and a dropped
+ * reactive error in the log; with it the caller is told in a sentence.
+ */
+class SdkMcpProxyCommandTest {
+
+    @Test
+    void aNameNobodyOnThePathAnswersToIsRefusedByName() {
+        assertThatThrownBy(() -> SdkMcpProxy.requireExecutable("mc-definitely-not-installed"))
+                .isInstanceOf(McpProxyException.class)
+                .hasMessageContaining("mc-definitely-not-installed")
+                .hasMessageContaining("PATH");
+    }
+
+    @Test
+    void anAbsolutePathThatIsNotThereIsRefusedToo() {
+        assertThatThrownBy(() -> SdkMcpProxy.requireExecutable("/opt/nothing/here/docker"))
+                .isInstanceOf(McpProxyException.class)
+                .hasMessageContaining("not executable");
+    }
+
+    @Test
+    void anOrdinaryCommandPasses() {
+        // "sh" is on the PATH of every machine this runs on, CI included.
+        assertThatCode(() -> SdkMcpProxy.requireExecutable("sh")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void theCheckIsImmediate() {
+        long start = System.currentTimeMillis();
+        var spawn = new McpStdioSpawn("mc-definitely-not-installed", List.of("run"),
+                Map.of(), Duration.ofSeconds(30), Duration.ofSeconds(60));
+
+        assertThatThrownBy(() -> new SdkMcpProxy().connect(spawn))
+                .isInstanceOf(McpProxyException.class);
+
+        // The point of the check: no waiting for a startup timeout that can
+        // never be met.
+        assertThat(System.currentTimeMillis() - start).isLessThan(2_000L);
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
@@ -8,6 +8,7 @@ import ai.mindconnect.llm.port.in.LlmTranscription;
 import ai.mindconnect.taskqueue.TaskContext;
 import ai.mindconnect.taskqueue.TaskOutcome;
 import ai.mindconnect.taskqueue.TaskQueue;
+import ai.mindconnect.taskqueue.TaskQueueException;
 import ai.mindconnect.taskqueue.TaskRecord;
 import ai.mindconnect.taskqueue.TaskStatus;
 import ai.mindconnect.taskqueue.TaskSubmission;
@@ -138,11 +139,21 @@ public class TranscriptionJobService {
 
     /**
      * Waits for the job to end, at most {@code timeout}. Returns the record as
-     * it looks when the wait is over — still running is a valid answer.
+     * it looks when the wait is over — <em>still running</em> is a valid
+     * answer, and the common one for a recording longer than the patience of
+     * the caller.
+     *
+     * <p>The queue treats a timeout as an error and throws; here it is the
+     * expected outcome, so it is caught and answered with the job as it
+     * stands. Only an id nobody knows comes back empty.
      */
     public Optional<TaskRecord> await(String taskId, Duration timeout) {
         if (queue.get(taskId).isEmpty()) return Optional.empty();
-        return Optional.ofNullable(queue.await(taskId, timeout));
+        try {
+            return Optional.ofNullable(queue.await(taskId, timeout));
+        } catch (TaskQueueException e) {
+            return queue.get(taskId);
+        }
     }
 
     /** The transcript of a completed job, parsed back out of the task's result. */

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
@@ -161,6 +161,36 @@ class TranscriptionJobServiceTest {
     }
 
     @Test
+    void aWaitShorterThanTheJobAnswersWithTheJobAsItStands() throws Exception {
+        java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+        gateway = (configName, request) -> {
+            try {
+                release.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return new TranscriptionResult("eventually", null, null, 0, 0);
+        };
+        String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, null).taskId();
+
+        // The queue treats a timeout as an error; a caller asking to wait a
+        // moment must still be told what the job is doing, not handed a
+        // failure.
+        Optional<TaskRecord> waited = service.await(taskId, Duration.ofMillis(200));
+
+        assertThat(waited).isPresent();
+        assertThat(waited.get().status().terminal()).as("still working").isFalse();
+        release.countDown();
+        queue.await(taskId, Duration.ofSeconds(5));
+    }
+
+    @Test
+    void anUnknownJobIsStillEmpty() {
+        assertThat(service.await("task_nobody", Duration.ofMillis(50))).isEmpty();
+    }
+
+    @Test
     void theRequesterIsRememberedForTheOwnerCheck() throws Exception {
         String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
                 null, null, null, "mc_user").taskId();

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -270,7 +270,8 @@ The answer is `202` with everything needed to follow the job:
 it is done, the transcript plus the detected language and the recording's
 length. `?wait=30` holds the request until the job ends or the seconds run
 out, for a caller who wants the synchronous feel without a polling loop (60
-seconds is the cap).
+seconds is the cap). Running out is not an error: the answer is then the job
+as it stands, and the caller asks again.
 
 **Streaming.** `GET /api/transcriptions/{id}/events` is Server-Sent Events
 from the job's channel:


### PR DESCRIPTION
The review of `feature/whisper` turned up four things. They missed v0.6.0 by
minutes — the pull request was merged from the state GitHub still knew while
the commit carrying them was already pushed — so here they are on their own.

## A wait that runs out is not a failure

`GET /api/transcriptions/{id}?wait=10` answered **500** whenever the job took
longer than the wait, which is the case the parameter exists for. The task
queue treats a timeout as an error and throws `TaskQueueException`; nothing
caught it. It is caught now, and the answer is the job as it stands — the
documented behaviour. A recording that needs three minutes and a caller who
will wait ten seconds is an ordinary combination.

## A call that ends

The transcription call inherited the shared HTTP client's read timeout, which
is deliberately zero because the same client carries the chat's SSE streams. A
job on the task queue is a different matter: an endpoint that accepts the
connection and then goes quiet would park a worker for ever, with the task
stuck `RUNNING`, its lease renewed, no attempt counted and no retry. This one
call now carries its own deadline of fifteen minutes — generous for a long
recording, and finite.

## A field that not every server knows

`stream=true` goes out whenever a caller listens for deltas. That was verified
against OpenAI, where `whisper-1` ignores it and the transcribe models honour
it — but a stricter server answers `400`, and it would have failed every job
through the REST API while the chat microphone and the admin Test dialog kept
working, because those pass no delta consumer. Since the field is ours and not
the caller's, a `400` after asking for a stream simply asks again without it.
A config that would rather skip the extra round trip sets the provider
parameter `stream=off`.

## A command that is there, or is not

Unrelated to transcription, and the reason a start on this machine took 47
seconds: an MCP server whose command cannot be run was only discovered by the
SDK's initialization timeout, after a dropped reactive error in the log. The
Gmail tools spawn their server through docker; on a machine without it — or
with a link left behind by an uninstalled Docker Desktop — that is half a
minute of silence for something knowable in a millisecond. The proxy now
resolves the command the way the OS would, broken symlinks included, and names
it when nothing answers.

## Verified

- Six new tests: the wait that runs out and the unknown job; the retry without
  the stream field and a `401` that must still fail; the command check by name,
  by absolute path, and the one that measures it stays under two seconds.
- The full reactor build with tests.

The live OpenAI tests in these modules currently fail on this machine with
`429 no credits remaining`, which is an account matter and unrelated; they are
disabled in CI, where `TEST_OPENAI` is not set.
