### PR TITLE
Tool providers warm up in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Changed
+
+- **agents:** resolving tools no longer holds up the start. Providers that
+  reach outside the process — the Gmail tools spawn an MCP server in a
+  container — used to bind on the startup thread, so a machine without a
+  container runtime paid the full initialization timeout before the
+  application served its first request; here that was 47 seconds against 2.
+  Every provider now binds on its own virtual thread, the first round gets a
+  short grace period so in-process providers are ready when the runtime is,
+  and anything slower joins the catalog the moment it is ready. A provider
+  that fails for a passing reason is tried again a few times over about a
+  minute, which means a container runtime started after the application no
+  longer needs a restart to be noticed. `SpiToolRegistry` is `AutoCloseable`;
+  closing it stops the warm-up.
+
 ### Fixed
 
 - **agents:** an MCP server whose command cannot be run says so at once

--- a/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/SpiToolRegistry.java
+++ b/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/SpiToolRegistry.java
@@ -49,18 +49,43 @@ import java.util.UUID;
  * in {@code META-INF/services/...ToolFactory} or
  * {@code META-INF/services/...MultiToolProvider}. No runtime code change.
  */
-public class SpiToolRegistry implements ToolRegistry {
+public class SpiToolRegistry implements ToolRegistry, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(SpiToolRegistry.class);
 
+    /**
+     * How long to wait before each further binding attempt. Four retries over
+     * roughly a minute: long enough for a container runtime that starts
+     * alongside the application, short enough that nobody waits on it.
+     */
+    private static final long[] RETRY_DELAYS = { 2_000L, 5_000L, 15_000L, 45_000L };
+
+    /**
+     * How long the constructor gives the first round of binds before it
+     * returns anyway. Most providers are in-process and bind in microseconds
+     * — a caller that builds a runtime and runs a turn on the next line
+     * should find them there. The ones that talk to something outside miss
+     * this window and join later, which is the whole point.
+     */
+    private static final long FIRST_ROUND_GRACE_MS = 200L;
+
     private final Map<String, ToolFactory> factoriesByName;
     private final List<MultiToolProvider> providers;
+    private final List<Thread> warmUpThreads = new java.util.concurrent.CopyOnWriteArrayList<>();
+    private final long[] retryDelays;
+    private java.util.concurrent.CountDownLatch firstRound;
 
     public SpiToolRegistry(ToolEnvironment environment) {
         this(environment, Thread.currentThread().getContextClassLoader());
     }
 
     public SpiToolRegistry(ToolEnvironment environment, ClassLoader classLoader) {
+        this(environment, classLoader, RETRY_DELAYS);
+    }
+
+    /** For tests: the same registry with its own patience. */
+    SpiToolRegistry(ToolEnvironment environment, ClassLoader classLoader, long[] retryDelays) {
+        this.retryDelays = retryDelays;
         // 1) Single-tool ToolFactory SPI
         Map<String, ToolFactory> facMap = new LinkedHashMap<>();
         for (ToolFactory factory : ServiceLoader.load(ToolFactory.class, classLoader)) {
@@ -86,36 +111,108 @@ public class SpiToolRegistry implements ToolRegistry {
         }
         this.factoriesByName = Map.copyOf(facMap);
 
-        // 2) Multi-tool MultiToolProvider SPI. Only the provider set is fixed
-        //    here — each provider's toolNames() is consulted live on every
-        //    lookup, so dynamic sources (workflow store, remote catalogs)
-        //    surface changes without a restart.
-        List<MultiToolProvider> active = new ArrayList<>();
+        // 2) Multi-tool MultiToolProvider SPI. The provider SET is what the
+        //    classpath offers — every one of them is kept. What changes over
+        //    time is whether a provider is ready and which names it carries,
+        //    and both are asked live on every lookup. That is what lets the
+        //    binding happen off this thread: a provider joins the catalog the
+        //    moment it is ready, without anybody restarting anything.
+        List<MultiToolProvider> discovered = new ArrayList<>();
         for (MultiToolProvider provider : ServiceLoader.load(MultiToolProvider.class, classLoader)) {
-            try {
-                provider.bind(environment);
-            } catch (RuntimeException e) {
-                log.error("MultiToolProvider {} failed to bind — bundle will be unavailable",
-                        provider.getClass().getName(), e);
-                continue;
-            }
-            if (!provider.isAvailable()) {
-                log.warn("MultiToolProvider {} reports itself unavailable — bundle will be skipped",
-                        provider.getClass().getSimpleName());
-                continue;
-            }
-            active.add(provider);
+            discovered.add(provider);
         }
-        this.providers = List.copyOf(active);
+        this.providers = List.copyOf(discovered);
 
-        log.info("SpiToolRegistry: registered {} single-tool factor(ies) and {} provider(s) currently contributing {} additional tool(s)",
-                factoriesByName.size(), providers.size(),
-                providers.stream().mapToInt(p -> p.toolNames().size()).sum());
+        log.info("SpiToolRegistry: {} single-tool factor(ies); warming up {} provider(s) in the background",
+                factoriesByName.size(), providers.size());
         if (log.isDebugEnabled()) {
             log.debug("  factories: {}", factoriesByName.keySet());
-            for (MultiToolProvider provider : providers) {
-                log.debug("  provider {}: {}", provider.getClass().getSimpleName(), provider.toolNames());
+        }
+        warmUp(environment);
+        awaitFirstRound();
+    }
+
+    /**
+     * Binds every provider off the caller's thread, one virtual thread each.
+     *
+     * <p>Binding can be slow and can fail for reasons that pass: an MCP server
+     * behind a container needs the container runtime to be up, a remote
+     * catalog needs the network. Doing it here would make every such case a
+     * slow start, and doing it once would make a runtime that appears a minute
+     * later useless until the next restart. So each provider gets a few
+     * attempts with a widening gap, and the first one that succeeds puts the
+     * bundle in the catalog.
+     */
+    private void warmUp(ToolEnvironment environment) {
+        this.firstRound = new java.util.concurrent.CountDownLatch(providers.size());
+        for (MultiToolProvider provider : providers) {
+            Thread worker = Thread.ofVirtual()
+                    .name("tool-warmup-" + provider.getClass().getSimpleName())
+                    .start(() -> bindWithRetries(provider, environment));
+            warmUpThreads.add(worker);
+        }
+    }
+
+    /**
+     * Waits for the first attempt of every provider, but not for long. What is
+     * ready by then is ready when the constructor returns; the rest arrives
+     * while the application is already serving.
+     */
+    private void awaitFirstRound() {
+        try {
+            if (!firstRound.await(FIRST_ROUND_GRACE_MS, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                log.info("SpiToolRegistry: {} provider(s) still warming up — they join when ready",
+                        firstRound.getCount());
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** One provider's attempts, until it is available or the attempts run out. */
+    private void bindWithRetries(MultiToolProvider provider, ToolEnvironment environment) {
+        String name = provider.getClass().getSimpleName();
+        for (int attempt = 1; attempt <= retryDelays.length + 1; attempt++) {
+            try {
+                provider.bind(environment);
+                if (provider.isAvailable()) {
+                    log.info("MultiToolProvider {} is ready with {} tool(s): {}",
+                            name, provider.toolNames().size(), provider.toolNames());
+                    return;
+                }
+                // The first "not yet" is worth a line; the retries are not.
+                if (attempt == 1) {
+                    log.info("MultiToolProvider {} is not available yet — trying again", name);
+                } else {
+                    log.debug("MultiToolProvider {} still unavailable (attempt {})", name, attempt);
+                }
+            } catch (RuntimeException e) {
+                log.warn("MultiToolProvider {} failed to bind on attempt {}: {}",
+                        name, attempt, e.toString());
+            } finally {
+                if (attempt == 1) firstRound.countDown();
+            }
+            if (attempt > retryDelays.length) break;
+            try {
+                Thread.sleep(retryDelays[attempt - 1]);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;                      // close() — stop trying, quietly
+            }
+        }
+        log.warn("MultiToolProvider {} stayed unavailable — its tools are not offered. "
+                + "Fix what it needs and restart, or leave it be if it is not wanted here.", name);
+    }
+
+    /**
+     * Stops the warm-up. Virtual threads never hold a JVM open, so this is for
+     * a registry that outlives its usefulness before the process does — a test,
+     * or an application context that closes.
+     */
+    @Override
+    public void close() {
+        for (Thread thread : warmUpThreads) {
+            thread.interrupt();
         }
     }
 
@@ -124,7 +221,7 @@ public class SpiToolRegistry implements ToolRegistry {
         // Union of ToolFactory names + each provider's *current* names.
         // ToolFactory keys come first (their order) followed by provider keys.
         Set<String> union = new LinkedHashSet<>(factoriesByName.keySet());
-        for (MultiToolProvider provider : providers) {
+        for (MultiToolProvider provider : ready()) {
             union.addAll(provider.toolNames());
         }
         return Set.copyOf(union);
@@ -138,13 +235,26 @@ public class SpiToolRegistry implements ToolRegistry {
             byGroup.computeIfAbsent(groupOrDefault(factory.group()), g -> new java.util.TreeSet<>())
                     .add(factory.name());
         }
-        for (MultiToolProvider provider : providers) {
+        for (MultiToolProvider provider : ready()) {
             Set<String> names = provider.toolNames();
             if (names.isEmpty()) continue;
             byGroup.computeIfAbsent(groupOrDefault(provider.group()), g -> new java.util.TreeSet<>())
                     .addAll(names);
         }
         return byGroup;
+    }
+
+    /**
+     * The providers that are ready this moment. A provider still warming up,
+     * or one that gave up, contributes nothing — and contributes again as soon
+     * as that changes, because nobody caches this.
+     */
+    private List<MultiToolProvider> ready() {
+        List<MultiToolProvider> available = new ArrayList<>(providers.size());
+        for (MultiToolProvider provider : providers) {
+            if (provider.isAvailable()) available.add(provider);
+        }
+        return available;
     }
 
     private static String groupOrDefault(String group) {
@@ -180,7 +290,7 @@ public class SpiToolRegistry implements ToolRegistry {
                             AliasTool.wrap(agentTool, factory.create(agentTool, scope)))));
         }
 
-        for (MultiToolProvider provider : providers) {
+        for (MultiToolProvider provider : ready()) {
             if (!provider.toolNames().contains(registryName)) {
                 continue;
             }

--- a/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/SpiToolRegistryWarmUpTest.java
+++ b/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/SpiToolRegistryWarmUpTest.java
@@ -1,0 +1,125 @@
+package ai.mindconnect.agent.tool;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Binding providers is no longer part of starting up. The registry is usable
+ * at once, each provider joins the catalog when it is ready, and one that
+ * fails for a passing reason gets another go.
+ */
+class SpiToolRegistryWarmUpTest {
+
+    /** Nothing in these tests asks the environment for anything. */
+    private static final ToolEnvironment EMPTY = new ToolEnvironment() {
+        @Override public <T> Optional<T> get(Class<T> type) { return Optional.empty(); }
+        @Override public Optional<String> getString(String key) { return Optional.empty(); }
+    };
+
+    private SpiToolRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        WarmUpProviders.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (registry != null) registry.close();
+    }
+
+    @Test
+    void theRegistryIsBuiltWithoutWaitingForItsProviders() {
+        WarmUpProviders.slowBindMillis = 2_000;
+
+        long start = System.currentTimeMillis();
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[0]);
+        long took = System.currentTimeMillis() - start;
+
+        // The slow provider is still binding — the constructor did not wait.
+        assertThat(took).as("construction is not the place to wait").isLessThan(500L);
+        assertThat(registry.knownToolNames()).doesNotContain("slow_tool");
+    }
+
+    @Test
+    void anInProcessProviderIsThereWhenTheConstructorReturns() {
+        // The grace window: a provider that binds in microseconds must be
+        // usable on the next line, or the Spring-free builder would hand out
+        // a runtime whose tools appear a moment later.
+        WarmUpProviders.slowBindMillis = 5_000;
+
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[0]);
+
+        assertThat(registry.knownToolNames()).contains("fast_tool");
+    }
+
+    @Test
+    void aProviderJoinsTheCatalogWhenItIsReady() {
+        WarmUpProviders.slowBindMillis = 200;
+
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[0]);
+
+        assertThat(within(5_000, () -> registry.knownToolNames().contains("slow_tool")))
+                .as("the provider joined once it was ready").isTrue();
+        // And it arrives in its group, so a catalog shows it where it belongs.
+        assertThat(registry.toolNamesByGroup()).containsKey("warmup-slow");
+    }
+
+    @Test
+    void aProviderThatFailsForAPassingReasonIsTriedAgain() {
+        WarmUpProviders.flakyFailures = 2;
+
+        // Two short delays: the third attempt is the one that works.
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[]{ 50, 50 });
+
+        assertThat(within(5_000, () -> registry.knownToolNames().contains("flaky_tool")))
+                .as("the third attempt carried it").isTrue();
+        assertThat(WarmUpProviders.flakyBinds.get()).isEqualTo(3);
+    }
+
+    @Test
+    void aProviderThatNeverComesUpIsSimplyNotOffered() {
+        WarmUpProviders.flakyFailures = 99;
+
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[]{ 20, 20 });
+
+        // Three attempts, then it is left alone — and nothing it would have
+        // contributed shows up in the catalog.
+        assertThat(within(5_000, () -> WarmUpProviders.flakyBinds.get() >= 3)).isTrue();
+        assertThat(registry.knownToolNames()).doesNotContain("flaky_tool");
+    }
+
+    /** Polls until the condition holds, or the milliseconds run out. */
+    private static boolean within(long millis, BooleanSupplier condition) {
+        long deadline = System.currentTimeMillis() + millis;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) return true;
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        return condition.getAsBoolean();
+    }
+
+    @Test
+    void closingStopsTheWarmUp() throws Exception {
+        WarmUpProviders.slowBindMillis = 5_000;
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[]{ 5_000 });
+
+        registry.close();
+        Thread.sleep(200);
+
+        // The slow bind was interrupted, so the bundle never became available
+        // — and no thread is left sleeping on a retry.
+        assertThat(registry.knownToolNames()).doesNotContain("slow_tool");
+    }
+}

--- a/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/WarmUpProviders.java
+++ b/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/WarmUpProviders.java
@@ -1,0 +1,106 @@
+package ai.mindconnect.agent.tool;
+
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The providers the warm-up test drives, registered through
+ * {@code META-INF/services} so they arrive the way real ones do — through the
+ * ServiceLoader, not through a constructor.
+ *
+ * <p>They talk to each other through static state on purpose: the registry
+ * builds its own instances, so a test can only reach them from the outside.
+ * {@link #reset()} puts that state back between tests.
+ */
+public final class WarmUpProviders {
+
+    private WarmUpProviders() {
+    }
+
+    /** How long {@link Slow#bind} takes before the bundle is ready. */
+    static volatile long slowBindMillis = 300;
+    /** How many attempts {@link Flaky#bind} throws on before it works. */
+    static volatile int flakyFailures = 2;
+
+    static final AtomicInteger slowBinds = new AtomicInteger();
+    static final AtomicInteger flakyBinds = new AtomicInteger();
+
+    static void reset() {
+        slowBindMillis = 300;
+        flakyFailures = 2;
+        slowBinds.set(0);
+        flakyBinds.set(0);
+    }
+
+    /** Ready, but not at once — like an MCP server that has to be spawned. */
+    public static final class Slow implements MultiToolProvider {
+        private volatile boolean bound;
+
+        @Override public Set<String> toolNames() { return bound ? Set.of("slow_tool") : Set.of(); }
+
+        @Override public String group() { return "warmup-slow"; }
+
+        @Override
+        public void bind(ToolEnvironment env) {
+            slowBinds.incrementAndGet();
+            try {
+                Thread.sleep(slowBindMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            bound = true;
+        }
+
+        @Override public boolean isAvailable() { return bound; }
+
+        @Override
+        public Optional<Tool> create(String toolName, AgentTool agentTool, ToolCallScope scope) {
+            return Optional.empty();
+        }
+    }
+
+    /** Ready the moment it is asked — like every in-process provider. */
+    public static final class Fast implements MultiToolProvider {
+        private volatile boolean bound;
+
+        @Override public Set<String> toolNames() { return bound ? Set.of("fast_tool") : Set.of(); }
+
+        @Override public String group() { return "warmup-fast"; }
+
+        @Override public void bind(ToolEnvironment env) { bound = true; }
+
+        @Override public boolean isAvailable() { return bound; }
+
+        @Override
+        public Optional<Tool> create(String toolName, AgentTool agentTool, ToolCallScope scope) {
+            return Optional.empty();
+        }
+    }
+
+    /** Fails a few times first — like a container runtime that starts late. */
+    public static final class Flaky implements MultiToolProvider {
+        private volatile boolean bound;
+
+        @Override public Set<String> toolNames() { return bound ? Set.of("flaky_tool") : Set.of(); }
+
+        @Override public String group() { return "warmup-flaky"; }
+
+        @Override
+        public void bind(ToolEnvironment env) {
+            if (flakyBinds.incrementAndGet() <= flakyFailures) {
+                throw new IllegalStateException("not yet, attempt " + flakyBinds.get());
+            }
+            bound = true;
+        }
+
+        @Override public boolean isAvailable() { return bound; }
+
+        @Override
+        public Optional<Tool> create(String toolName, AgentTool agentTool, ToolCallScope scope) {
+            return Optional.empty();
+        }
+    }
+}

--- a/agents/core/mc-agent-tool-spi/src/test/resources/META-INF/services/ai.mindconnect.agent.tool.MultiToolProvider
+++ b/agents/core/mc-agent-tool-spi/src/test/resources/META-INF/services/ai.mindconnect.agent.tool.MultiToolProvider
@@ -1,0 +1,3 @@
+ai.mindconnect.agent.tool.WarmUpProviders$Slow
+ai.mindconnect.agent.tool.WarmUpProviders$Flaky
+ai.mindconnect.agent.tool.WarmUpProviders$Fast

--- a/website/docs/agents/creating-a-tool.md
+++ b/website/docs/agents/creating-a-tool.md
@@ -205,10 +205,24 @@ public interface MultiToolProvider {
 }
 ```
 
-The lifecycle mirrors `ToolFactory` (no-arg constructor → `bind` once →
+The lifecycle mirrors `ToolFactory` (no-arg constructor → `bind` →
 `isAvailable` → `create` per resolution), and registration is the same
 ServiceLoader mechanism with
 `META-INF/services/ai.mindconnect.agent.tool.MultiToolProvider`.
+
+**`bind` runs off the startup path.** A provider may have to reach outside the
+process — spawn a container, ask a remote catalog — and that is no reason for
+an application to wait. The registry starts every provider's `bind` on its own
+virtual thread and gives the first round a couple of hundred milliseconds
+before it carries on, which is plenty for the in-process providers and not
+enough for the others. Whoever misses that window joins the catalog the moment
+`isAvailable()` turns true; `toolNames()` and `isAvailable()` are asked live on
+every lookup, so nothing has to be told. A `bind` that throws, or one that
+leaves the provider unavailable, is tried again a few times over about a
+minute — the case worth catching is a container runtime that starts alongside
+the application rather than before it. Two consequences for a provider author:
+`bind` may run concurrently with the first lookups, so publish your state
+safely, and it may run more than once, so make it repeatable.
 
 Two things are specific to providers:
 


### PR DESCRIPTION
Binding a tool provider is no longer part of starting up.

A provider that reaches outside the process binds slowly and sometimes fails
for a reason that passes. The Gmail tools spawn an MCP server in a container;
on a machine where the container runtime is missing or not yet up, the
application used to wait out the SDK's full initialization timeout before
serving its first request. Measured here: **47 seconds against 2**.

```
SpiToolRegistry: 30 single-tool factor(ies); warming up 2 provider(s) in the background
MultiToolProvider WorkflowToolProvider is ready with 0 tool(s)
SpiToolRegistry: 1 provider(s) still warming up — they join when ready
Started AdminUiApplication in 1.873 seconds
```

## What changed

**The provider list is no longer frozen at construction.** Every provider the
classpath offers stays in it, and each lookup asks live who is ready — the way
`toolNames()` has always been asked. Without this a provider that becomes
ready later could never join, which is what made binding a startup concern to
begin with.

**Binding runs on a virtual thread per provider**, with four further attempts
over about a minute. The case worth catching is a container runtime that comes
up alongside the application rather than before it: that used to need a restart
to be noticed.

**The constructor waits 200 ms for the first round**, then carries on.
In-process providers bind in microseconds and are ready when the runtime is —
which matters for the Spring-free `AgentRuntimeBuilder`, where a caller may run
a turn on the very next line. Anything slower joins later.

**`SpiToolRegistry` is `AutoCloseable`.** Closing interrupts the warm-up, so a
test or a closing context leaves nothing sleeping on a retry.

## Why not the task queue

It was the obvious candidate and it is the wrong tool. A task can be claimed by
another node, but binding fills the state of *this* process — with the Postgres
store the warm-up could happen on the wrong JVM. On top of that,
`mc-agent-tool-spi` deliberately depends on `mc-common` alone, and routing the
binding through the queue would close a bean cycle: queue → `ToolCallWorker` →
`ToolRegistry` → queue. The retry idea from that design is kept; the machinery
is not.

## Verified

- Six tests: the constructor does not wait; a provider joins when ready; one
  that fails twice is carried by its third attempt; one that never comes up is
  simply not offered; an in-process provider is there when the constructor
  returns; closing stops the warm-up. The providers arrive through
  `META-INF/services`, the way real ones do.
- The Admin UI started against the real Gmail provider, which is failing on
  this machine and retrying in the background while the application serves.
- The full reactor build with tests.

## For tool authors

`creating-a-tool.md` now says what this means: `bind` may run concurrently with
the first lookups, so publish state safely, and it may run more than once, so
make it repeatable.
