### PR TITLE
Review fixes for the background warm-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **agents:** a tool provider that cannot say whether it is ready no longer
+  takes the catalogue with it. `isAvailable()` became a per-lookup call when
+  provider binding moved off the startup path; a provider throwing there would
+  have failed every turn and every catalogue render, for every provider. It is
+  now caught and logged, and the bundle counts as unavailable. The
+  documentation for tool authors says what `bind` and `isAvailable` may expect
+  of their surroundings — both run more often, and in more places, than they
+  used to.
+
+- **agents:** the Spring runtime starts the tool warm-up once its context is
+  refreshed rather than while the registry is being built. Binding asks the
+  environment for services, and that environment resolves them from the
+  application context: doing it from a warm-up thread mid-refresh meant
+  queueing behind the very startup that was waiting for the first round, so a
+  provider that should have been ready in microseconds could miss its window
+  for no reason. `SpiToolRegistry.deferred(...)` is the registry without the
+  warm-up for a host that starts in phases; embedders that build it directly
+  are unaffected.
+
 ### Changed
 
 - **agents:** resolving tools no longer holds up the start. Providers that

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/config/DefaultAgentRuntimeConfig.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/adapter/config/DefaultAgentRuntimeConfig.java
@@ -271,9 +271,33 @@ public class DefaultAgentRuntimeConfig {
                 .string("vectorStorePassword", vectorStorePassword)
                 .string("vectorStoreEmbeddingConfig", vectorStoreEmbeddingConfig)
                 .build();
-        SpiToolRegistry registry = new SpiToolRegistry(hostBacked(env, applicationContext));
+        // Deferred on purpose: binding asks the environment for services, and
+        // this one resolves them from the application context. Doing that from
+        // a warm-up thread while the context is still refreshing means queuing
+        // behind the very startup that is waiting for the first round. The
+        // listener below starts it once the context is up.
+        SpiToolRegistry registry = SpiToolRegistry.deferred(hostBacked(env, applicationContext));
         registryRef.set(registry);
         return registry;
+    }
+
+    /**
+     * Starts the tool warm-up once the application is up. Providers that reach
+     * outside the process bind on their own threads from here, and the ones
+     * that are in-process are ready a fraction of a second later — nothing in
+     * the startup path waits for either.
+     */
+    @Bean
+    org.springframework.context.ApplicationListener<
+            org.springframework.context.event.ContextRefreshedEvent> toolWarmUpStarter(
+            ai.mindconnect.agent.tool.ToolRegistry toolRegistry) {
+        // ContextRefreshedEvent rather than Boot's ApplicationReadyEvent: this
+        // module carries spring-context alone, and by the time it fires every
+        // singleton is built — which is the property that matters here. The
+        // warm-up itself only ever runs once, however often the event comes.
+        return event -> {
+            if (toolRegistry instanceof SpiToolRegistry spi) spi.warmUp();
+        };
     }
 
     /**

--- a/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/SpiToolRegistry.java
+++ b/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/SpiToolRegistry.java
@@ -73,19 +73,44 @@ public class SpiToolRegistry implements ToolRegistry, AutoCloseable {
     private final List<MultiToolProvider> providers;
     private final List<Thread> warmUpThreads = new java.util.concurrent.CopyOnWriteArrayList<>();
     private final long[] retryDelays;
-    private java.util.concurrent.CountDownLatch firstRound;
+    private final ToolEnvironment environment;
+    private final java.util.concurrent.atomic.AtomicBoolean warmedUp =
+            new java.util.concurrent.atomic.AtomicBoolean();
+    private volatile java.util.concurrent.CountDownLatch firstRound =
+            new java.util.concurrent.CountDownLatch(0);
 
     public SpiToolRegistry(ToolEnvironment environment) {
         this(environment, Thread.currentThread().getContextClassLoader());
     }
 
     public SpiToolRegistry(ToolEnvironment environment, ClassLoader classLoader) {
-        this(environment, classLoader, RETRY_DELAYS);
+        this(environment, classLoader, RETRY_DELAYS, true);
+    }
+
+    /**
+     * The registry without the warm-up: it is built, and nothing is bound
+     * until {@link #warmUp()} is called.
+     *
+     * <p>For a host that starts in phases. Binding asks the environment for
+     * services, and a host whose environment resolves those from a container
+     * that is still starting would have the warm-up queue behind its own
+     * startup — the Spring runtime hands this registry its providers once the
+     * context is up rather than while it is coming up.
+     */
+    public static SpiToolRegistry deferred(ToolEnvironment environment) {
+        return new SpiToolRegistry(environment, Thread.currentThread().getContextClassLoader(),
+                RETRY_DELAYS, false);
     }
 
     /** For tests: the same registry with its own patience. */
     SpiToolRegistry(ToolEnvironment environment, ClassLoader classLoader, long[] retryDelays) {
+        this(environment, classLoader, retryDelays, true);
+    }
+
+    private SpiToolRegistry(ToolEnvironment environment, ClassLoader classLoader,
+                            long[] retryDelays, boolean warmUpNow) {
         this.retryDelays = retryDelays;
+        this.environment = environment;
         // 1) Single-tool ToolFactory SPI
         Map<String, ToolFactory> facMap = new LinkedHashMap<>();
         for (ToolFactory factory : ServiceLoader.load(ToolFactory.class, classLoader)) {
@@ -128,7 +153,17 @@ public class SpiToolRegistry implements ToolRegistry, AutoCloseable {
         if (log.isDebugEnabled()) {
             log.debug("  factories: {}", factoriesByName.keySet());
         }
-        warmUp(environment);
+        if (warmUpNow) warmUp();
+    }
+
+    /**
+     * Binds the providers, once. Returns when the first round has had its
+     * moment — see {@link #FIRST_ROUND_GRACE_MS} — not when every provider is
+     * ready. Calling it twice does nothing the second time.
+     */
+    public void warmUp() {
+        if (!warmedUp.compareAndSet(false, true)) return;
+        startWarmUp();
         awaitFirstRound();
     }
 
@@ -143,7 +178,7 @@ public class SpiToolRegistry implements ToolRegistry, AutoCloseable {
      * attempts with a widening gap, and the first one that succeeds puts the
      * bundle in the catalog.
      */
-    private void warmUp(ToolEnvironment environment) {
+    private void startWarmUp() {
         this.firstRound = new java.util.concurrent.CountDownLatch(providers.size());
         for (MultiToolProvider provider : providers) {
             Thread worker = Thread.ofVirtual()
@@ -155,7 +190,7 @@ public class SpiToolRegistry implements ToolRegistry, AutoCloseable {
 
     /**
      * Waits for the first attempt of every provider, but not for long. What is
-     * ready by then is ready when the constructor returns; the rest arrives
+     * ready by then is ready when the warm-up call returns; the rest arrives
      * while the application is already serving.
      */
     private void awaitFirstRound() {
@@ -252,7 +287,16 @@ public class SpiToolRegistry implements ToolRegistry, AutoCloseable {
     private List<MultiToolProvider> ready() {
         List<MultiToolProvider> available = new ArrayList<>(providers.size());
         for (MultiToolProvider provider : providers) {
-            if (provider.isAvailable()) available.add(provider);
+            try {
+                if (provider.isAvailable()) available.add(provider);
+            } catch (RuntimeException e) {
+                // This runs on every lookup now, so a provider that throws
+                // here would fail every turn and every catalogue render — and
+                // take the other providers' tools with it. A bundle that
+                // cannot say whether it is ready is not ready.
+                log.warn("MultiToolProvider {} threw from isAvailable() — treating it as unavailable: {}",
+                        provider.getClass().getSimpleName(), e.toString());
+            }
         }
         return available;
     }

--- a/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/SpiToolRegistryWarmUpTest.java
+++ b/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/SpiToolRegistryWarmUpTest.java
@@ -95,6 +95,37 @@ class SpiToolRegistryWarmUpTest {
         assertThat(registry.knownToolNames()).doesNotContain("flaky_tool");
     }
 
+    @Test
+    void aProviderThatCannotSayWhetherItIsReadyDoesNotBreakTheCatalogue() {
+        WarmUpProviders.slowBindMillis = 10;
+
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[0]);
+
+        // The throwing provider is skipped and everyone else is still served —
+        // this runs on every lookup, so one broken bundle must not take the
+        // catalogue with it.
+        assertThat(within(5_000, () -> registry.knownToolNames().contains("slow_tool"))).isTrue();
+        assertThat(registry.knownToolNames()).contains("fast_tool").doesNotContain("throwing_tool");
+        assertThat(registry.toolNamesByGroup()).doesNotContainKey("warmup-throwing");
+    }
+
+    @Test
+    void aDeferredRegistryBindsNothingUntilItIsAsked() throws Exception {
+        WarmUpProviders.slowBindMillis = 10;
+
+        registry = SpiToolRegistry.deferred(EMPTY);
+        Thread.sleep(200);
+
+        assertThat(registry.knownToolNames())
+                .as("nothing bound before the host says so").isEmpty();
+
+        registry.warmUp();
+
+        assertThat(registry.knownToolNames()).contains("fast_tool");
+        registry.warmUp();   // twice is a no-op, not a second round
+        assertThat(WarmUpProviders.slowBinds.get()).isEqualTo(1);
+    }
+
     /** Polls until the condition holds, or the milliseconds run out. */
     private static boolean within(long millis, BooleanSupplier condition) {
         long deadline = System.currentTimeMillis() + millis;

--- a/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/WarmUpProviders.java
+++ b/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/WarmUpProviders.java
@@ -23,6 +23,8 @@ public final class WarmUpProviders {
     static volatile long slowBindMillis = 300;
     /** How many attempts {@link Flaky#bind} throws on before it works. */
     static volatile int flakyFailures = 2;
+    /** Whether {@link Throwing} throws when asked. */
+    static volatile boolean throwFromIsAvailable = true;
 
     static final AtomicInteger slowBinds = new AtomicInteger();
     static final AtomicInteger flakyBinds = new AtomicInteger();
@@ -30,6 +32,7 @@ public final class WarmUpProviders {
     static void reset() {
         slowBindMillis = 300;
         flakyFailures = 2;
+        throwFromIsAvailable = true;
         slowBinds.set(0);
         flakyBinds.set(0);
     }
@@ -73,6 +76,26 @@ public final class WarmUpProviders {
         @Override public void bind(ToolEnvironment env) { bound = true; }
 
         @Override public boolean isAvailable() { return bound; }
+
+        @Override
+        public Optional<Tool> create(String toolName, AgentTool agentTool, ToolCallScope scope) {
+            return Optional.empty();
+        }
+    }
+
+    /** Cannot say whether it is ready — a broken health check. */
+    public static final class Throwing implements MultiToolProvider {
+        @Override public Set<String> toolNames() { return Set.of("throwing_tool"); }
+
+        @Override public String group() { return "warmup-throwing"; }
+
+        @Override public void bind(ToolEnvironment env) { }
+
+        @Override
+        public boolean isAvailable() {
+            if (throwFromIsAvailable) throw new IllegalStateException("cannot say");
+            return true;
+        }
 
         @Override
         public Optional<Tool> create(String toolName, AgentTool agentTool, ToolCallScope scope) {

--- a/agents/core/mc-agent-tool-spi/src/test/resources/META-INF/services/ai.mindconnect.agent.tool.MultiToolProvider
+++ b/agents/core/mc-agent-tool-spi/src/test/resources/META-INF/services/ai.mindconnect.agent.tool.MultiToolProvider
@@ -1,3 +1,4 @@
 ai.mindconnect.agent.tool.WarmUpProviders$Slow
 ai.mindconnect.agent.tool.WarmUpProviders$Flaky
 ai.mindconnect.agent.tool.WarmUpProviders$Fast
+ai.mindconnect.agent.tool.WarmUpProviders$Throwing

--- a/website/docs/agents/creating-a-tool.md
+++ b/website/docs/agents/creating-a-tool.md
@@ -210,7 +210,7 @@ The lifecycle mirrors `ToolFactory` (no-arg constructor → `bind` →
 ServiceLoader mechanism with
 `META-INF/services/ai.mindconnect.agent.tool.MultiToolProvider`.
 
-**`bind` runs off the startup path.** A provider may have to reach outside the
+**`bind` runs off the startup path, after the host is up.** A provider may have to reach outside the
 process — spawn a container, ask a remote catalog — and that is no reason for
 an application to wait. The registry starts every provider's `bind` on its own
 virtual thread and gives the first round a couple of hundred milliseconds
@@ -222,14 +222,20 @@ leaves the provider unavailable, is tried again a few times over about a
 minute — the case worth catching is a container runtime that starts alongside
 the application rather than before it. Two consequences for a provider author:
 `bind` may run concurrently with the first lookups, so publish your state
-safely, and it may run more than once, so make it repeatable.
+safely, and it may run more than once, so make it repeatable. A host that starts in phases can take the warm-up into
+its own hands — the Spring runtime builds the registry deferred and starts it
+when the context is refreshed, so a provider asking the container for a
+service never queues behind the container's own startup.
 
 Two things are specific to providers:
 
-- **`toolNames()` is consulted on every lookup** (catalog, admin-UI dropdown,
-  name resolution), so a provider backed by mutable data re-reads its source
-  there instead of caching in `bind` — keep it cheap (an in-memory map or a
-  directory listing, not a network round-trip).
+- **`toolNames()` and `isAvailable()` are consulted on every lookup** (catalog,
+  admin-UI dropdown, name resolution), so a provider backed by mutable data
+  re-reads its source there instead of caching in `bind` — keep both cheap (an
+  in-memory map or a directory listing, not a network round-trip, and
+  certainly not a health check). A provider that throws from `isAvailable()`
+  is taken as unavailable and logged, rather than failing the lookup for
+  everyone else.
 - **`group()` doubles as the name namespace**: by convention a provider's tool
   names compose as `group() + "_" + localName` — group `workflow`, workflow
   `pipeline` → tool `workflow_pipeline`; group `gmail` →


### PR DESCRIPTION
Three things the review of #55 turned up. All of them are consequences of
moving provider binding off the startup path, not mistakes carried over.

## A provider that cannot say whether it is ready

`isAvailable()` used to be called once per provider, inside the registry's
constructor. It is now called on every lookup — and it was called without a
guard. A provider that throws there, which is how a health check against a
backend that is down would behave, would have failed every turn, every
catalogue render and every admin-UI tool page, taking every other provider's
tools with it.

It is caught now and the bundle counts as unavailable. A bundle that cannot
say whether it is ready is not ready.

## The contract said less than it should

`creating-a-tool.md` warned that `toolNames()` is consulted on every lookup and
must stay cheap. That now goes for `isAvailable()` too — under the old contract
it ran exactly once, so an author writing to that page could reasonably put a
probe there. The page says it, and says what `bind` may expect of its
surroundings as well.

## Binding no longer runs while the container is still starting

Binding asks the environment for services, and in the Spring runtime that
environment resolves them from the application context. Doing that from a
warm-up thread while the context was refreshing meant queueing behind the very
startup that was waiting for the first round: the providers most likely to make
the 200 ms window are exactly the ones that would miss it.

The runtime now builds the registry through `SpiToolRegistry.deferred(...)` and
starts the warm-up on `ContextRefreshedEvent`, when every singleton exists and
nobody holds the bean mutex. Embedders that construct the registry directly
keep binding at construction — a runtime that quietly has no tools would be
the worse surprise.

My first attempt at this one was a memoizing environment. It would have hidden
the problem rather than removed it: the first resolution still blocks on the
same lock. It is not in this branch.

## Verified

- Eight tests, two of them new: a throwing provider is skipped while the others
  are still served, and a deferred registry binds nothing until it is asked and
  ignores a second request.
- The Admin UI started against the real providers: the warm-up begins at the
  end of the refresh, the in-process provider is ready inside the window, and
  Gmail — which fails on this machine — retries in the background without
  holding anything up.
- The full reactor build with tests.
