### PR TITLE
Ship the admin UI as a container image

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,69 @@
+# Builds the deployable image and pushes it to GHCR.
+#
+# The server never builds anything: it pulls
+# ghcr.io/mindconnect-ai/mc-agent-admin-ui and starts it. Old versions live in
+# the registry rather than on the host's disk, which is what makes a small box
+# workable.
+name: docker-images
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-images-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build jar
+        run: >
+          mvn -B --no-transfer-progress
+          -pl agents/server/mc-agent-admin-ui-app -am
+          install -DskipTests
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── admin UI ────────────────────────────────────────────────────────────
+      - id: meta-admin
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/mc-agent-admin-ui
+          tags: |
+            type=sha,format=long
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          # Context is the module's target directory: the build only needs the
+          # jar, and shipping the whole repo would send gigabytes to the daemon.
+          context: agents/server/mc-agent-admin-ui-app/target
+          file: agents/server/mc-agent-admin-ui-app/Dockerfile
+          push: true
+          tags: ${{ steps.meta-admin.outputs.tags }}
+          labels: ${{ steps.meta-admin.outputs.labels }}
+          cache-from: type=gha,scope=admin-ui
+          cache-to: type=gha,mode=max,scope=admin-ui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Added
+
+- **agents:** a container image for the admin UI, published to GHCR on every
+  push to `main` as `ghcr.io/mindconnect-ai/mc-agent-admin-ui`. It is a layered
+  Spring Boot image, so a new version is a ~3 MB application layer on top of an
+  unchanged dependency layer instead of a fresh 344 MB — which is what makes
+  redeploying onto a small VPS practical. Chromium ships in the image, so the
+  Playwright-backed browser tools work without downloading a browser at
+  runtime. `deploy/` holds a single-host Compose setup to run it behind Caddy,
+  which obtains and renews its TLS certificates itself, next to Postgres and
+  Keycloak.
+
 ### Fixed
 
 - **agents:** a tool provider that cannot say whether it is ready no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **agents:** the admin UI's Logout button no longer ends with "The backend is
+  unreachable". The header's logout is a link, and the SPA router turned every
+  such click into a fetch — but logout answers with a redirect to Keycloak on
+  another host, which a fetch cannot follow. The session was destroyed all the
+  same, so it logged you out and showed an error while doing it. Logout is now
+  an ordinary page navigation.
+
 - **agents:** a tool provider that cannot say whether it is ready no longer
   takes the catalogue with it. `isAvailable()` became a per-lookup call when
   provider binding moved off the startup path; a provider throwing there would

--- a/agents/server/mc-agent-admin-ui-app/Dockerfile
+++ b/agents/server/mc-agent-admin-ui-app/Dockerfile
@@ -1,0 +1,81 @@
+# Runtime image for the agent admin UI.
+#
+# The jar is built outside this file — in CI, or locally with
+#   mvn -pl agents/server/mc-agent-admin-ui-app -am install -DskipTests
+# — and passed in as JAR_FILE. Building Maven inside the image would drag a
+# multi-gigabyte ~/.m2 into the build and buys nothing over the CI cache.
+#
+#   docker build -f agents/server/mc-agent-admin-ui-app/Dockerfile \
+#                agents/server/mc-agent-admin-ui-app/target
+#
+# The context is the module's target directory, so only the jar is sent.
+
+ARG JRE_IMAGE=eclipse-temurin:21-jre-jammy
+
+# ── 1. split the fat jar ─────────────────────────────────────────────────────
+# The dependency layer is 342 MB and changes only when dependencies do; the
+# application layer is 2.6 MB. Deploying a new version therefore pushes and
+# pulls single-digit megabytes instead of a third of a gigabyte.
+FROM ${JRE_IMAGE} AS layers
+WORKDIR /build
+ARG JAR_FILE=*-exec.jar
+COPY ${JAR_FILE} app.jar
+# The destination must be empty, and /build already holds app.jar — so
+# extract into a subdirectory rather than into the working directory.
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
+# ── 2. browser for the web-browser tools ─────────────────────────────────────
+# mc-agent-tools-web-browser drives Playwright, which needs a real browser and
+# its system libraries. Chromium only — firefox and webkit would add several
+# hundred megabytes that nothing here launches.
+#
+# Do NOT narrow this with --only-shell, tempting as the 549 MB looks:
+# Playwright.create() runs the driver's own "install" on startup, finds the
+# browser set incomplete and tries to download the missing full Chromium at
+# runtime. That download hangs here, so the first web_read_browser call never
+# returns — no browser process, no CPU, no error.
+#
+# This layer changes only with the Playwright version, so redeployments never
+# re-download it.
+FROM ${JRE_IMAGE} AS browsers
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+# The CLI needs the Playwright jars on its classpath, but only while it runs.
+# A COPY would leave them in a 358 MB layer that a later rm cannot reclaim, so
+# bind-mount them for the duration of this one command instead.
+RUN --mount=type=bind,from=layers,source=/build/extracted/dependencies/BOOT-INF/lib,target=/tmp/lib \
+    java -cp "/tmp/lib/*" com.microsoft.playwright.CLI install --with-deps chromium \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── 3. runtime ───────────────────────────────────────────────────────────────
+FROM browsers AS runtime
+WORKDIR /app
+RUN useradd --system --create-home --uid 10001 mindconnect
+
+# Ordered least- to most-volatile so Docker reuses the big layers.
+COPY --from=layers --chown=mindconnect /build/extracted/dependencies/ ./
+COPY --from=layers --chown=mindconnect /build/extracted/spring-boot-loader/ ./
+COPY --from=layers --chown=mindconnect /build/extracted/snapshot-dependencies/ ./
+COPY --from=layers --chown=mindconnect /build/extracted/application/ ./
+
+RUN mkdir -p /app/data /app/logs && chown mindconnect /app/data /app/logs
+VOLUME ["/app/data", "/app/logs"]
+
+USER mindconnect
+EXPOSE 9090
+
+# Heap follows the container limit instead of the host's RAM — without this a
+# JVM on a 4 GB box claims a quarter of the whole machine per container.
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70"
+
+# Everything the browser needs is baked in above. Forbid the runtime download
+# outright so an incomplete image fails loudly on the first call instead of
+# hanging on a fetch nobody is watching.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+# The app exposes no /health endpoint and pulls in no actuator, so this only
+# proves Tomcat is accepting connections. Adding spring-boot-starter-actuator
+# and probing /actuator/health would be the stronger check.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+  CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/9090' || exit 1
+
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/index.html
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/index.html
@@ -77,6 +77,9 @@
     <!-- "New group" next to the agent form's group select: the rubrics come
          from the agents themselves, so naming a new one needs a field. -->
     <script src="/js/group-picker.js" defer></script>
+    <!-- Logout leaves the SPA for Keycloak, so it must be a real navigation
+         and not a routed fetch. See the file for what goes wrong otherwise. -->
+    <script src="/js/logout.js" defer></script>
     <!-- Hands the active theme's colours to the json-viewer web component,
          which paints from a palette inside its own shadow root and so cannot
          be reached from app.css. -->

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/logout.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/logout.js
@@ -1,0 +1,27 @@
+/*
+ * Logout has to leave the SPA, and the router will not let it.
+ *
+ * AdminLayout renders the header's Logout as a plain UiLink, and the framework
+ * renders that as <a href="/admin/logout" data-href="/admin/logout">. The
+ * EventBus intercepts every data-href click and routes it through fetch,
+ * expecting a UiPage back. But /admin/logout answers with a 302 to Keycloak's
+ * end-session endpoint on another origin, which a fetch cannot follow into —
+ * so the SPA reported "The backend is unreachable" while Spring Security had
+ * in fact already destroyed the session. Logged out, plus an error to look at.
+ *
+ * A capture-phase listener sees the click before the bus's delegated handler
+ * and turns it back into what it has to be: an ordinary top-level navigation.
+ */
+document.addEventListener("click", (event) => {
+    const target = event.target;
+    const link = target instanceof Element
+        ? target.closest('a[href="/admin/logout"]')
+        : null;
+    if (!link) return;
+
+    // stopImmediatePropagation, not preventDefault alone: the bus listens on a
+    // container further up and would otherwise still SPA-route the click.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    window.location.assign("/admin/logout");
+}, true);

--- a/agents/server/mc-agent-api-app/Dockerfile
+++ b/agents/server/mc-agent-api-app/Dockerfile
@@ -1,0 +1,45 @@
+# Runtime image for the agent REST API (SSE streaming).
+#
+# No browser stage: mc-agent-api-app does not depend on
+# mc-agent-tools-web-browser, so Playwright and Chromium stay out and the
+# image is a fraction of the admin UI's.
+#
+# The jar is built outside this file — in CI, or locally with
+#   mvn -pl agents/server/mc-agent-api-app -am install -DskipTests
+#
+#   docker build -f agents/server/mc-agent-api-app/Dockerfile \
+#                agents/server/mc-agent-api-app/target
+
+ARG JRE_IMAGE=eclipse-temurin:21-jre-alpine
+
+FROM ${JRE_IMAGE} AS layers
+WORKDIR /build
+ARG JAR_FILE=*-exec.jar
+COPY ${JAR_FILE} app.jar
+# The destination must be empty, and /build already holds app.jar — so
+# extract into a subdirectory rather than into the working directory.
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
+FROM ${JRE_IMAGE} AS runtime
+WORKDIR /app
+RUN adduser --system --uid 10001 mindconnect
+
+COPY --from=layers --chown=mindconnect /build/extracted/dependencies/ ./
+COPY --from=layers --chown=mindconnect /build/extracted/spring-boot-loader/ ./
+COPY --from=layers --chown=mindconnect /build/extracted/snapshot-dependencies/ ./
+COPY --from=layers --chown=mindconnect /build/extracted/application/ ./
+
+RUN mkdir -p /app/data && chown mindconnect /app/data
+VOLUME ["/app/data"]
+
+USER mindconnect
+EXPOSE 8080
+
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70"
+
+# No /health endpoint and no actuator in the app, so this only proves Tomcat
+# is accepting connections. See the note in the admin UI's Dockerfile.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD nc -z 127.0.0.1 8080 || exit 1
+
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,34 @@
+# Copy to .env next to docker-compose.yml and fill in. Never commit the .env.
+#   cp .env.example .env && chmod 600 .env
+
+# ── domains ──────────────────────────────────────────────────────────────────
+ADMIN_DOMAIN=admin.example.com
+AUTH_DOMAIN=auth.example.com
+ACME_EMAIL=you@example.com
+
+# ── image tag ────────────────────────────────────────────────────────────────
+# "main" follows the branch; pin a git SHA for a reproducible rollback.
+MC_TAG=main
+
+# ── postgres ─────────────────────────────────────────────────────────────────
+POSTGRES_USER=mindconnect
+POSTGRES_PASSWORD=
+
+# ── keycloak ─────────────────────────────────────────────────────────────────
+KC_ADMIN_USER=admin
+KC_ADMIN_PASSWORD=
+
+# Leave empty for the first start — the realm does not exist yet and the admin
+# UI runs without authentication. Set to "keycloak" once the realm, the client
+# and the secret below are in place, then: docker compose up -d admin-ui
+MC_PROFILES=
+KC_CLIENT_ID=mc-admin-ui
+KC_CLIENT_SECRET=
+
+# ── mindconnect ──────────────────────────────────────────────────────────────
+# Encrypts stored LLM credentials. Exactly 16, 24 or 32 characters.
+# Losing it makes every stored credential unreadable — back it up separately.
+#   openssl rand -hex 16
+MINDCONNECT_ENCRYPTION_SECRET_KEY=
+
+TAVILY_API_KEY=

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,32 @@
+# One block per hostname. Caddy fetches and renews the Let's Encrypt
+# certificates itself — no certbot, no renewal cron. Requires the DNS records
+# to point here and ports 80/443 to be reachable.
+#
+# Reload without downtime:
+#   docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile
+
+{
+	email {$ACME_EMAIL}
+}
+
+# Agent admin UI — also serves the OpenAI-compatible Responses API, so
+# there is no separate API service to route to.
+{$ADMIN_DOMAIN} {
+	# No buffering and no read timeout by default, which is what the agent's
+	# SSE streams need; nginx would require proxy_buffering off plus a raised
+	# proxy_read_timeout here.
+	reverse_proxy admin-ui:9090
+
+	request_body {
+		# Matches spring.servlet.multipart.max-request-size in the app.
+		max_size 100MB
+	}
+}
+
+{$AUTH_DOMAIN} {
+	reverse_proxy keycloak:8080
+}
+
+# {$CARDMARKET_DOMAIN} {
+# 	reverse_proxy cardmarket:8080
+# }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -136,20 +136,40 @@ docker compose exec -T postgres pg_dumpall -U mindconnect | gzip > dump-$(date +
 `.env`. Stored LLM credentials are encrypted with it and are unrecoverable
 without it.
 
-## Before CI publishes the image
+## Deploying without CI
 
 Until the workflow has run on `main`, `ghcr.io/mindconnect-ai/mc-agent-admin-ui`
 does not exist and `docker compose pull` fails. The image can be built on the
-host in the meantime — upload the jar and the Dockerfile and build with the tag
-Compose expects:
+host instead — upload the jar and the Dockerfile, then build it under a tag of
+your own:
 
 ```bash
-docker build -f Dockerfile -t ghcr.io/mindconnect-ai/mc-agent-admin-ui:main .
+docker build -f Dockerfile -t ghcr.io/mindconnect-ai/mc-agent-admin-ui:local .
+sed -i 's/^MC_TAG=.*/MC_TAG=local/' ../.env
+docker compose up -d admin-ui
 ```
 
-Compose then uses the local image. Once CI publishes, delete that build
-directory and `docker builder prune` — the build cache is a few gigabytes that
-the host has no further use for.
+Build it on the host, not on a developer machine: an Apple-silicon laptop
+produces arm64 images and this is amd64.
+
+The separate tag matters once CI does publish, because both paths would
+otherwise write `:main`. A local build and CI's would be indistinguishable, a
+stray `docker compose pull` would silently replace yours, and nothing would say
+which is running. With `MC_TAG=local` that same `pull` fails loudly instead —
+there is no `:local` in the registry — and `.env` answers "what is deployed
+right now" in one line.
+
+Going back is the same two settings in reverse:
+
+```bash
+sed -i 's/^MC_TAG=.*/MC_TAG=main/' .env
+docker compose pull && docker compose up -d
+docker builder prune -f
+```
+
+Keep the build directory. It holds a jar and a Dockerfile, and it is the
+difference between a one-command detour and re-uploading 344 MB. Prune the
+build *cache* freely — that is the part which grows.
 
 ## Known gaps
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,164 @@
+# Single-host deployment
+
+Caddy terminates TLS and routes by hostname; Postgres, Keycloak and the agent
+apps sit on the internal Docker network with **no published port**. Nothing but
+Caddy is reachable from the internet.
+
+```
+Internet ──:443──► caddy ──┬──► admin-ui:9090
+                           └──► keycloak:8080
+                                    │
+                                    └──► postgres:5432
+```
+
+The admin UI is the only agent service: it embeds `mc-agent-api-responses-rest`
+and therefore already serves the OpenAI-compatible API alongside its own UI.
+`mc-agent-api-app` is not part of this deployment.
+
+The host runs Docker and nothing else — no Java, no Maven, no nginx. Images are
+built in CI (`.github/workflows/docker-images.yml`) and pulled from GHCR, so the
+server never compiles and old versions occupy registry space rather than the
+host's disk.
+
+## Setup
+
+```bash
+scp -r deploy/ hetzner:/opt/mindconnect/
+ssh hetzner
+cd /opt/mindconnect
+cp .env.example .env && chmod 600 .env && vi .env   # domains, passwords, key
+docker compose up -d
+```
+
+Point the DNS A records at the host first — Caddy asks Let's Encrypt for
+certificates on the first request and needs to be reachable on 80 and 443.
+
+Keycloak starts empty apart from the bootstrap admin. Import the realm — it
+carries the roles, the confidential `mc-admin-ui` client and one enabled user
+without credentials, deliberately: no password is ever written into a file
+here.
+
+```bash
+set -a; . ./.env; set +a
+docker cp keycloak/mindconnect-realm.json mindconnect-keycloak-1:/tmp/realm.json
+KC="docker compose exec -T keycloak /opt/keycloak/bin/kcadm.sh"
+$KC config credentials --server http://localhost:8080 --realm master \
+   --user "$KC_ADMIN_USER" --password "$KC_ADMIN_PASSWORD"
+$KC create realms -f /tmp/realm.json
+CID=$($KC get clients -r mindconnect -q clientId=mc-admin-ui --fields id --format csv --noquotes)
+$KC get clients/$CID/client-secret -r mindconnect --fields value --format csv --noquotes
+```
+
+Put that secret in `KC_CLIENT_SECRET`, set each user's password in the admin
+console at `https://<AUTH_DOMAIN>/admin`, and only then set
+`MC_PROFILES=keycloak` and `docker compose up -d admin-ui`. Turning
+authentication on before a user has a password locks everyone out.
+
+The realm's redirect and post-logout URIs are absolute, so a different
+`ADMIN_DOMAIN` means editing the JSON before importing.
+
+Logout goes through Keycloak's end-session endpoint, which rejects any
+`post_logout_redirect_uri` the client does not list. Verify it after importing
+— and note that `kcadm get clients/<id> --fields attributes` renders nested
+maps as `{}` whether or not they are set, so ask for the whole client instead:
+
+```bash
+$KC get clients/$CID -r mindconnect | grep post.logout
+```
+
+The endpoint itself can be checked without a session; a registered URI answers
+302, anything else 400 "Invalid redirect uri":
+
+```bash
+curl -so /dev/null -w '%{http_code}\n' \
+  "https://<AUTH_DOMAIN>/realms/mindconnect/protocol/openid-connect/logout?client_id=mc-admin-ui&post_logout_redirect_uri=https%3A%2F%2F<ADMIN_DOMAIN>%2F"
+```
+
+## Deploying a new version
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+`MC_TAG` in `.env` selects what "new" means: `main` follows the branch, a git
+SHA pins a version. Rolling back is that variable plus `up -d` — the old image
+is still in GHCR.
+
+Prune what accumulates, or 20 GB will not last:
+
+```bash
+docker image prune -af --filter "until=168h"
+```
+
+## The memory budget
+
+**This is the tight part.** On a 4 GB host the limits in `docker-compose.yml`
+add up to roughly:
+
+| Service | Limit | Note |
+|---|---:|---|
+| caddy | 96 MB | |
+| postgres | 512 MB | one instance, several databases |
+| keycloak | 1 GB | JVM; the floor for it is around 700 MB |
+| admin-ui | 1.6 GB | JVM plus Chromium when a browser tool runs |
+| **sum** | **~3.2 GB** | leaving ~600 MB for the kernel and dockerd |
+
+That fits, with nothing to spare. It does **not** fit alongside another
+application such as the Cardmarket portal — that needs 8 GB. The admin UI's
+limit is the one to raise if you ever get more memory; Chromium is what makes
+its usage spiky.
+
+Two things follow. First, the limits are not decoration: without them each JVM
+sizes its heap against the host's total RAM and three of them will overcommit.
+Under a limit of 1 GB or less the JVM also picks SerialGC by itself, which is
+the right choice here — smaller footprint than G1 and these are not
+latency-critical services.
+
+Second, give the host swap. Hetzner Cloud images ship without it, and swap
+turns a spike that would kill a container into one that merely gets slow:
+
+```bash
+fallocate -l 2G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+sysctl -w vm.swappiness=10
+```
+
+## Backups
+
+The Postgres volume holds everything except workspace files. Neither is backed
+up by anything here yet:
+
+```bash
+docker compose exec -T postgres pg_dumpall -U mindconnect | gzip > dump-$(date +%F).sql.gz
+```
+
+`MINDCONNECT_ENCRYPTION_SECRET_KEY` belongs in a password manager, not only in
+`.env`. Stored LLM credentials are encrypted with it and are unrecoverable
+without it.
+
+## Before CI publishes the image
+
+Until the workflow has run on `main`, `ghcr.io/mindconnect-ai/mc-agent-admin-ui`
+does not exist and `docker compose pull` fails. The image can be built on the
+host in the meantime — upload the jar and the Dockerfile and build with the tag
+Compose expects:
+
+```bash
+docker build -f Dockerfile -t ghcr.io/mindconnect-ai/mc-agent-admin-ui:main .
+```
+
+Compose then uses the local image. Once CI publishes, delete that build
+directory and `docker builder prune` — the build cache is a few gigabytes that
+the host has no further use for.
+
+## Known gaps
+
+- The app exposes no health endpoint, so its container healthcheck only probes
+  the TCP port. Adding `spring-boot-starter-actuator` and probing
+  `/actuator/health` would make `depends_on: service_healthy` meaningful for
+  the app as well.
+- The realm is imported once by hand rather than on every start, so a change
+  to `keycloak/mindconnect-realm.json` does not reach a running Keycloak by
+  itself — re-import it or edit in the admin console.
+- Nothing is backed up automatically yet; see above for the pg_dumpall line
+  that belongs in a cron job.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,119 @@
+# Mindconnect on a single host: Caddy terminates TLS and routes, everything
+# else stays on the internal network with no published port.
+#
+#   docker compose pull && docker compose up -d
+#
+# Memory limits are sized for a 4 GB machine and are deliberately explicit —
+# without them one JVM sizes its heap against the whole host and the kernel
+# picks the victim. See README.md for the budget and its consequences.
+name: mindconnect
+
+services:
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"   # HTTP/3
+    environment:
+      # The Caddyfile resolves {$VAR} against this container's environment,
+      # not against Compose's .env — without these it renders empty hostnames
+      # and an empty email, and refuses to start.
+      ACME_EMAIL: ${ACME_EMAIL:?set in .env}
+      ADMIN_DOMAIN: ${ADMIN_DOMAIN:?set in .env}
+      AUTH_DOMAIN: ${AUTH_DOMAIN:?set in .env}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data       # certificates and ACME account — must persist
+      - caddy_config:/config
+    mem_limit: 96m
+    depends_on:
+      - admin-ui
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?set in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set in .env}
+      POSTGRES_DB: mindconnect
+      # Databases created next to mindconnect on first start.
+      EXTRA_DATABASES: keycloak cardmarket
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init-extra-databases.sh:/docker-entrypoint-initdb.d/10-extra-databases.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d mindconnect"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    mem_limit: 512m
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    restart: unless-stopped
+    # Not "start --optimized": that requires an image built ahead of time with
+    # kc.sh build, and refuses to run on a first-ever start.
+    command: start
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_USERNAME: ${POSTGRES_USER}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      KC_HOSTNAME: https://${AUTH_DOMAIN}
+      # Caddy terminates TLS and forwards X-Forwarded-*; without this Keycloak
+      # builds its issuer and redirect URLs from the internal http address and
+      # every login bounces.
+      KC_PROXY_HEADERS: xforwarded
+      KC_HTTP_ENABLED: "true"
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_ADMIN_USER:?set in .env}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_ADMIN_PASSWORD:?set in .env}
+      JAVA_OPTS_APPEND: "-XX:MaxRAMPercentage=70"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    mem_limit: 1g
+
+  admin-ui:
+    image: ghcr.io/mindconnect-ai/mc-agent-admin-ui:${MC_TAG:-main}
+    restart: unless-stopped
+    environment:
+      # Behind Caddy the app only ever sees plain HTTP. Without this it builds
+      # absolute URLs as http://, which Keycloak then rejects as an
+      # unregistered redirect_uri the moment authentication is switched on.
+      SERVER_FORWARD_HEADERS_STRATEGY: framework
+      MC_PERSISTENCE: postgres
+      MC_POSTGRES_URL: jdbc:postgresql://postgres:5432/mindconnect
+      MC_POSTGRES_USER: ${POSTGRES_USER}
+      MC_POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MINDCONNECT_ENCRYPTION_SECRET_KEY: ${MINDCONNECT_ENCRYPTION_SECRET_KEY:?32 chars, see README}
+      # Empty on the first start: the realm does not exist yet, and the app
+      # then runs with authentication off. Set MC_PROFILES=keycloak in .env
+      # once the realm and the client secret are in place.
+      SPRING_PROFILES_ACTIVE: ${MC_PROFILES:-}
+      KC_ISSUER_URI: https://${AUTH_DOMAIN}/realms/mindconnect
+      KC_CLIENT_ID: ${KC_CLIENT_ID:-mc-admin-ui}
+      KC_CLIENT_SECRET: ${KC_CLIENT_SECRET}
+      TAVILY_API_KEY: ${TAVILY_API_KEY:-}
+    volumes:
+      - admin_data:/app/data     # workspaces and uploads stay on disk
+      - admin_logs:/app/logs
+    # No shm_size needed: PlaywrightHolder launches Chromium with
+    # --disable-dev-shm-usage, so it never touches Docker's small /dev/shm.
+    # It also passes --no-sandbox, which Ubuntu's AppArmor restrictions on
+    # unprivileged user namespaces would otherwise trip over — the container
+    # and its unprivileged user are then the only boundary around whatever
+    # page an agent decides to open.
+    depends_on:
+      postgres:
+        condition: service_healthy
+    mem_limit: 1600m
+
+volumes:
+  caddy_data:
+  caddy_config:
+  postgres_data:
+  admin_data:
+  admin_logs:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -84,6 +84,10 @@ services:
       # absolute URLs as http://, which Keycloak then rejects as an
       # unregistered redirect_uri the moment authentication is switched on.
       SERVER_FORWARD_HEADERS_STRATEGY: framework
+      # Match the realm's ssoSessionIdleTimeout. Spring's default is 30 minutes,
+      # so without this the servlet session ends long before Keycloak's, and you
+      # are sent back to the login page while your SSO session is still valid.
+      SERVER_SERVLET_SESSION_TIMEOUT: 8h
       MC_PERSISTENCE: postgres
       MC_POSTGRES_URL: jdbc:postgresql://postgres:5432/mindconnect
       MC_POSTGRES_USER: ${POSTGRES_USER}

--- a/deploy/init-extra-databases.sh
+++ b/deploy/init-extra-databases.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Runs once, on the first start of an empty data directory. Keycloak and the
+# other applications get their own database inside the same Postgres instance —
+# a second Postgres container would cost another ~250 MB of RAM for nothing.
+set -e
+for db in ${EXTRA_DATABASES}; do
+	echo "creating database ${db}"
+	psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname postgres <<-SQL
+		CREATE DATABASE "${db}" OWNER "${POSTGRES_USER}";
+	SQL
+done

--- a/deploy/keycloak/mindconnect-realm.json
+++ b/deploy/keycloak/mindconnect-realm.json
@@ -1,0 +1,59 @@
+{
+  "realm": "mindconnect",
+  "enabled": true,
+  "displayName": "Mindconnect",
+  "sslRequired": "all",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "failureFactor": 10,
+  "waitIncrementSeconds": 60,
+  "accessTokenLifespan": 3600,
+  "ssoSessionIdleTimeout": 28800,
+  "ssoSessionMaxLifespan": 86400,
+  "passwordPolicy": "length(12) and notUsername(undefined) and passwordHistory(3)",
+  "clients": [
+    {
+      "clientId": "mc-admin-ui",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "redirectUris": [
+        "https://app.mindconnect.ai/login/oauth2/code/keycloak"
+      ],
+      "webOrigins": [
+        "https://app.mindconnect.ai"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "https://app.mindconnect.ai/"
+      }
+    }
+  ],
+  "roles": {
+    "realm": [
+      { "name": "admin",     "description": "Full administrative access" },
+      { "name": "poweruser", "description": "Extended user with elevated rights" },
+      { "name": "user",      "description": "Standard user" },
+      { "name": "hr",        "description": "Human Resources access" },
+      { "name": "dev",       "description": "Developer access" }
+    ]
+  },
+  "users": [
+    {
+      "username": "david",
+      "email": "beisdog@web.de",
+      "firstName": "David",
+      "lastName": "Beisert",
+      "enabled": true,
+      "emailVerified": true,
+      "realmRoles": ["admin", "user"]
+    }
+  ]
+}


### PR DESCRIPTION
Makes `mc-agent-admin-ui-app` deployable as a container: a layered Dockerfile,
a workflow that builds it on every push to `main` and pushes it to GHCR, and a
`deploy/` directory holding a single-host Compose setup behind Caddy, next to
Postgres and Keycloak.

Everything here has been run end to end on a 4 GB Hetzner box, which is where
most of the detail in the commit messages comes from.

## Why layered

The fat jar is 344 MB — 342 MB dependencies, 2.6 MB application. Splitting it
with Spring Boot's `tools` jarmode means a new version moves single-digit
megabytes instead of a third of a gigabyte. That is what makes redeploying onto
a small VPS practical, and it is also why the first push to GHCR is slow and
every one after it is not.

## Playwright

Chromium ships in the image for the browser tools, and it has to be installed
complete. `--only-shell` makes the image 750 MB smaller and looks free, since
the app only ever launches headless — but `Playwright.create()` then finds the
browser set incomplete on startup and tries to fetch the missing browser at
runtime. That download hangs: the first `web_read_browser` call never returns,
with no browser process, no CPU and nothing in the log.
`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` turns that into a loud failure. The
Dockerfile carries a comment saying so, because the saving will look tempting
again.

## Two handles after merging

1. The GHCR package is private on first publish, even for a public repo — flip
   it to public once, and the server needs no `docker login`.
2. The server can then move from a hand-built image to `docker compose pull`.

## Worth a reviewer's attention

- `agents/server/mc-agent-api-app/Dockerfile` is included but CI does not build
  it and the deployment does not use it. Happy to drop it.
- The workflow runs Maven a second time on the same push that `build.yml`
  already builds. Chaining via `workflow_run` would avoid it at the cost of an
  invisible dependency; this is the deliberate trade.

## Commits

- `55f940a` the deployment itself
- `af4c5dd` an unrelated bug found while testing it: the admin UI's Logout ended
  in "The backend is unreachable" because the SPA router turned the link into a
  fetch that cannot follow a cross-origin redirect. Separate commit, separate
  changelog entry.
- `97b3ed0` corrects the deployment notes so the manual path keeps working
  alongside CI, on a tag of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)