### PR TITLE
Write every file store atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **agents:** tool calls no longer fail at random when sub-agents run in
+  parallel. With the file persistence most stores truncated a file and wrote it
+  anew, so a tool task reading the conversation while a sibling task saved a
+  message found an empty file and ended with "tool call was interrupted before
+  completion: tool task ended FAILED without a result". Every file store now
+  writes into a temporary file and moves it into place in one step, and an
+  unreadable summaries file is no longer overwritten with just the newest
+  summary. A tool task that does fail is logged, and the tool result names the
+  reason.
+
 ## [0.7.0] - 2026-09-11
 
 ### Added

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AgentRuntimeBuilder.java
@@ -457,6 +457,8 @@ public final class AgentRuntimeBuilder {
                 approvalStore, userChannels);
         var taskQueue = new ai.mindconnect.taskqueue.local.LocalTaskQueue(
                 new ai.mindconnect.taskqueue.memory.InMemoryTaskStore());
+        // A failed task would otherwise leave no trace but a tool result saying so.
+        taskQueue.addListener(ai.mindconnect.taskqueue.LoggingTaskListener.failuresOnly());
         toolWorker.attach(taskQueue);
         taskQueue.register(AgentTurnWorker.TYPE, turnWorker);
         taskQueue.register(ToolCallWorker.TYPE, toolWorker);

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/QueuedAgentRoundToolExecutor.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/QueuedAgentRoundToolExecutor.java
@@ -13,6 +13,7 @@ import ai.mindconnect.common.PageRequest;
 import ai.mindconnect.message.domain.MessageType;
 import ai.mindconnect.message.port.in.ConversationManager;
 import ai.mindconnect.taskqueue.TaskContext;
+import ai.mindconnect.taskqueue.TaskFailure;
 import ai.mindconnect.taskqueue.TaskRecord;
 
 import java.util.Optional;
@@ -91,7 +92,18 @@ final class QueuedAgentRoundToolExecutor implements AgentRoundToolExecutor {
         }
         return resultWritten(callId)
                 ? new ToolResult.Running()   // reload-after-wake will see it — never append twice
-                : new ToolResult.Lost("tool task ended " + task.get().status() + " without a result");
+                : new ToolResult.Lost("tool task ended " + task.get().status() + " without a result"
+                        + failureOf(task.get()));
+    }
+
+    /** Why the task failed, as far as the queue recorded it — for the model and for whoever reads the log. */
+    private static String failureOf(TaskRecord task) {
+        TaskFailure failure = task.failure();
+        if (failure == null) return "";
+        String type = failure.type() == null ? null : failure.type().substring(failure.type().lastIndexOf('.') + 1);
+        String message = failure.message() == null ? "" : failure.message();
+        if (message.length() > 300) message = message.substring(0, 300) + "…";
+        return " (" + (type == null ? "" : type + ": ") + message + ")";
     }
 
     private boolean resultWritten(String callId) {

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/config/DefaultAgentRuntimeConfig.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/config/DefaultAgentRuntimeConfig.java
@@ -368,6 +368,8 @@ public class DefaultAgentRuntimeConfig {
     @Bean(destroyMethod = "close")
     LocalTaskQueue taskQueue(AgentTurnWorker agentTurnWorker, ToolCallWorker toolCallWorker) {
         LocalTaskQueue queue = new LocalTaskQueue(new InMemoryTaskStore());
+        // A failed task is otherwise visible only in the task dialog, and only while it is recent.
+        queue.addListener(ai.mindconnect.taskqueue.LoggingTaskListener.failuresOnly());
         toolCallWorker.attach(queue);                       // awaits sub-agent turns
         queue.register(AgentTurnWorker.TYPE, agentTurnWorker);
         queue.register(ToolCallWorker.TYPE, toolCallWorker);

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentDefinitionRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentDefinitionRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.AgentId;
 
@@ -36,7 +37,7 @@ public class FileAgentDefinitionRepository implements AgentDefinitionRepository 
     @Override
     public AgentDefinition save(AgentDefinition def) {
         try {
-            objectMapper.writeValue(fileFor(def.id().value()).toFile(), def);
+            AtomicFiles.write(fileFor(def.id().value()), out -> objectMapper.writeValue(out, def));
             return def;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentSessionRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentSessionRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.AgentId;
 import ai.mindconnect.agent.SessionId;
@@ -49,17 +50,9 @@ public class FileAgentSessionRepository implements AgentSessionRepository {
     public AgentSession save(AgentSession session) {
         Path file = fileFor(session);
         try {
-            Files.createDirectories(file.getParent());
-            // Written beside the target and moved over it in one step: a session is
-            // read while other threads save it (tool tasks, title generation), and a
-            // reader must never see the half-written file.
-            Path tmp = Files.createTempFile(file.getParent(), FILE_NAME + ".", ".tmp");
-            try {
-                objectMapper.writeValue(tmp.toFile(), session);
-                Files.move(tmp, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-            } finally {
-                Files.deleteIfExists(tmp);
-            }
+            // A session is read while other threads save it (tool tasks, title
+            // generation); a reader must never see the half-written file.
+            AtomicFiles.write(file, out -> objectMapper.writeValue(out, session));
             return session;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileConversationSummaryRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileConversationSummaryRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.message.domain.ConversationId;
 
@@ -43,16 +44,18 @@ public class FileConversationSummaryRepository implements ConversationSummaryRep
     public void save(ConversationSummary summary) {
         Path file = fileFor(summary.conversationId());
         try {
-            Files.createDirectories(file.getParent());
-            List<ConversationSummary> existing = load(file);
+            // Read strictly: rewriting the file from a list that failed to load
+            // would replace every earlier summary with just this one.
+            List<ConversationSummary> existing = Files.exists(file) ? read(file) : new ArrayList<>();
             existing.add(summary);
             existing.sort(Comparator.comparingInt(ConversationSummary::fromSequenceNum));
-            mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), existing);
+            AtomicFiles.write(file, out -> mapper.writerWithDefaultPrettyPrinter().writeValue(out, existing));
             log.debug("Saved summary {} for conversation {} (seq {}-{})",
                     summary.id(), summary.conversationId(),
                     summary.fromSequenceNum(), summary.toSequenceNum());
         } catch (IOException e) {
-            log.warn("Failed to save summary for conversation {}: {}", summary.conversationId(), e.getMessage());
+            log.warn("Failed to save summary for conversation {} (existing summaries left untouched): {}",
+                    summary.conversationId(), e.getMessage());
         }
     }
 
@@ -82,17 +85,20 @@ public class FileConversationSummaryRepository implements ConversationSummaryRep
                 .resolve(FILE_NAME);
     }
 
-    /** Summaries written before the namespace was recorded take it from the conversation asked for. */
+    /** For reading: an unreadable file counts as no summaries, the turn goes on without them. */
     private List<ConversationSummary> load(Path file) {
         if (!Files.exists(file)) return new ArrayList<>();
         try {
-            List<ConversationSummary> list = mapper.readerFor(LIST_TYPE)
-                    .readValue(file.toFile());
-            list.sort(Comparator.comparingInt(ConversationSummary::fromSequenceNum));
-            return new ArrayList<>(list);
+            return read(file);
         } catch (IOException e) {
             log.warn("Failed to read summaries from {}: {}", file, e.getMessage());
             return new ArrayList<>();
         }
+    }
+
+    private List<ConversationSummary> read(Path file) throws IOException {
+        List<ConversationSummary> list = mapper.readerFor(LIST_TYPE).readValue(file.toFile());
+        list.sort(Comparator.comparingInt(ConversationSummary::fromSequenceNum));
+        return new ArrayList<>(list);
     }
 }

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileLlmCallTraceRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileLlmCallTraceRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.message.domain.ConversationId;
@@ -72,7 +73,7 @@ public class FileLlmCallTraceRepository implements LlmCallTraceRepository {
         Path file = turnDir.resolve(filenameFor(trace));
         try {
             Files.createDirectories(turnDir);
-            mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), trace);
+            AtomicFiles.write(file, out -> mapper.writerWithDefaultPrettyPrinter().writeValue(out, trace));
             log.debug("Saved LLM trace {} for turn {} ({} ms, {} prompt + {} completion tokens)",
                     trace.id(), trace.context().turnId(), trace.durationMs(),
                     trace.promptTokens(), trace.completionTokens());

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileTodoListRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileTodoListRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.SessionId;
 
@@ -54,7 +55,7 @@ public class FileTodoListRepository implements TodoListRepository {
         Path file = fileFor(list.sessionId());
         try {
             Files.createDirectories(file.getParent());
-            mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), list);
+            AtomicFiles.write(file, out -> mapper.writerWithDefaultPrettyPrinter().writeValue(out, list));
             log.debug("Saved todo list for session {} ({} items)", list.sessionId(), list.items().size());
             return list;
         } catch (IOException e) {

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkingMemoryRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkingMemoryRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.SessionId;
 
@@ -40,7 +41,7 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
         Path file = sessionDir(auth.userId().value(), sessionId).resolve(MEMORY_FILE);
         try {
             Files.createDirectories(file.getParent());
-            mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), memory);
+            AtomicFiles.write(file, out -> mapper.writerWithDefaultPrettyPrinter().writeValue(out, memory));
             log.debug("Saved working memory for session {} ({} tokens)", sessionId, memory.totalTokens());
         } catch (IOException e) {
             log.warn("Failed to save working memory for session {}: {}", sessionId, e.getMessage());
@@ -70,7 +71,7 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
         Path file = sessionDir(auth.userId().value(), sessionId).resolve(SUMMARY_FILE);
         try {
             Files.createDirectories(file.getParent());
-            Files.writeString(file, summary);
+            AtomicFiles.writeString(file, summary);
             log.debug("Saved summary for session {}", sessionId);
         } catch (IOException e) {
             log.warn("Failed to save summary for session {}: {}", sessionId, e.getMessage());

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkspaceStore.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkspaceStore.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.runtime.tools.workspace.WorkspaceScope;
 import ai.mindconnect.agent.runtime.tools.workspace.WorkspaceStore;
@@ -45,7 +46,7 @@ public class FileWorkspaceStore implements WorkspaceStore {
     public void write(WorkspaceScope scope, String filename, String content) {
         Path file = scopeDir(scope).resolve(filename);
         try {
-            Files.writeString(file, content);
+            AtomicFiles.writeString(file, content);
             log.debug("WorkspaceStore.write: {}", file);
         } catch (IOException e) {
             log.warn("WorkspaceStore.write failed for {}: {}", file, e.getMessage());
@@ -111,6 +112,8 @@ public class FileWorkspaceStore implements WorkspaceStore {
             return stream
                     .filter(p -> !Files.isDirectory(p))
                     .map(p -> p.getFileName().toString())
+                    // a write in progress: AtomicFiles' temporary file beside the target
+                    .filter(name -> !(name.startsWith(".") && name.endsWith(".tmp")))
                     .sorted()
                     .toList();
         } catch (IOException e) {

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/file/FileLlmConfigRepository.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/file/FileLlmConfigRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.llm.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.llm.domain.LlmConfigId;
 
@@ -36,7 +37,7 @@ public class FileLlmConfigRepository implements LlmConfigRepository {
     @Override
     public void save(LlmConfig config) {
         try {
-            objectMapper.writeValue(fileFor(config.id().value()).toFile(), config);
+            AtomicFiles.write(fileFor(config.id().value()), out -> objectMapper.writeValue(out, config));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileConversationRepository.java
+++ b/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileConversationRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.message.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.message.domain.ConversationId;
 
@@ -47,7 +48,7 @@ public class FileConversationRepository implements ConversationRepository {
         Path file = fileFor(conversation.id());
         try {
             Files.createDirectories(file.getParent());
-            objectMapper.writeValue(file.toFile(), conversation);
+            AtomicFiles.write(file, out -> objectMapper.writeValue(out, conversation));
             return conversation;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileMessageRepository.java
+++ b/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileMessageRepository.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.message.adapter.file;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.message.domain.ConversationId;
 import ai.mindconnect.message.domain.MessageId;
@@ -62,7 +63,7 @@ public class FileMessageRepository implements MessageRepository {
             Files.createDirectories(dir);
             Path file = fileFor(message);
             boolean isUpdate = Files.exists(file);
-            objectMapper.writeValue(file.toFile(), message);
+            AtomicFiles.write(file, out -> objectMapper.writeValue(out, message));
             if (!isUpdate) {
                 log.fine("Saved new message " + message.id());
             } else {

--- a/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/file/FileMessageRepositoryConcurrencyTest.java
+++ b/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/file/FileMessageRepositoryConcurrencyTest.java
@@ -1,0 +1,69 @@
+package ai.mindconnect.message.adapter.file;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.message.domain.ConversationId;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A conversation is read while other threads write into it — a tool task loads
+ * the history while its sibling tasks save their results and the turn updates
+ * token counts. A reader must never see a half-written message file: that
+ * surfaced as tool tasks failing without a result when sub-agents ran in
+ * parallel ("No content to map due to end-of-input").
+ */
+class FileMessageRepositoryConcurrencyTest {
+
+    @Test
+    void historyReadsWhileSavingNeverSeeAHalfWrittenMessage(@TempDir Path dir) throws Exception {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        FileMessageRepository repo = new FileMessageRepository(dir, mapper, new Namespace("test"));
+        ConversationId conversation = ConversationId.random();
+        Message message = repo.save(Message.of(conversation, "agent", ParticipantType.AGENT,
+                MessageType.TOOL_RESULT, "x".repeat(20_000), 1));
+
+        AtomicBoolean writing = new AtomicBoolean(true);
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+        Thread writer = Thread.ofPlatform().start(() -> {
+            try {
+                for (int i = 0; i < 400; i++) {
+                    repo.save(message.withTokenCount(i));
+                }
+            } catch (Throwable t) {
+                failures.add(t);
+            } finally {
+                writing.set(false);
+            }
+        });
+        int reads = 0;
+        while (writing.get()) {
+            try {
+                List<Message> history = repo.findByConversation(conversation, new PageRequest(0, 100));
+                assertThat(history).hasSize(1);
+                reads++;
+            } catch (Throwable t) {
+                failures.add(t);
+                break;
+            }
+        }
+        writer.join();
+
+        assertThat(failures).isEmpty();
+        assertThat(reads).isPositive();
+        assertThat(repo.findById(conversation, message.id())).map(Message::tokenCount).contains(399);
+    }
+}

--- a/agents/vectorstore/mc-file-store/pom.xml
+++ b/agents/vectorstore/mc-file-store/pom.xml
@@ -20,6 +20,11 @@
         object storage (s3) or database backends slot in as sibling modules.</description>
 
     <dependencies>
+        <!-- AtomicFiles: stored files are written whole or not at all. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-common</artifactId>
+        </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-file-store-core</artifactId>

--- a/agents/vectorstore/mc-file-store/src/main/java/ai/mindconnect/filestore/filesystem/FilesystemFileStore.java
+++ b/agents/vectorstore/mc-file-store/src/main/java/ai/mindconnect/filestore/filesystem/FilesystemFileStore.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.filestore.filesystem;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.EntityId;
 import ai.mindconnect.filestore.FileId;
@@ -53,7 +54,8 @@ public final class FilesystemFileStore implements FileStore {
         Path target = dir.resolve(safeName);
         long size = Files.copy(content, target, StandardCopyOption.REPLACE_EXISTING);
         StoredFile file = new StoredFile(id, safeName, contentType, size, Instant.now());
-        MAPPER.writerWithDefaultPrettyPrinter().writeValue(dir.resolve("meta.json").toFile(), file);
+        // The metadata is what makes the upload exist for readers; it lands whole or not at all.
+        AtomicFiles.write(dir.resolve("meta.json"), out -> MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, file));
         return file;
     }
 

--- a/agents/vectorstore/mc-vector-store-tools/pom.xml
+++ b/agents/vectorstore/mc-vector-store-tools/pom.xml
@@ -19,6 +19,11 @@
         agents only ever handle text. The ingestion pipeline itself is a workflow seed.</description>
 
     <dependencies>
+        <!-- AtomicFiles: stored files are written whole or not at all. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-common</artifactId>
+        </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-agent-tool-spi</artifactId>

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistry.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistry.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.vectorstore.tools;
 
+import ai.mindconnect.common.util.AtomicFiles;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -129,7 +130,7 @@ public final class FileVectorStoreRegistry {
     private void write(Path dir, String name, Object value) {
         try {
             Files.createDirectories(dir);
-            MAPPER.writerWithDefaultPrettyPrinter().writeValue(fileFor(dir, name).toFile(), value);
+            AtomicFiles.write(fileFor(dir, name), out -> MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, value));
         } catch (IOException e) {
             throw new UncheckedIOException("Could not write " + fileFor(dir, name), e);
         }

--- a/common/mc-common/src/main/java/ai/mindconnect/common/util/AtomicFiles.java
+++ b/common/mc-common/src/main/java/ai/mindconnect/common/util/AtomicFiles.java
@@ -1,0 +1,62 @@
+package ai.mindconnect.common.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Writes a file so that nobody ever reads it half-written.
+ *
+ * <p>The content goes into a temporary file beside the target, and that file is
+ * moved over the target in one step. A reader sees the old content or the new,
+ * never an empty or truncated file — which is what a plain
+ * {@code Files.writeString(target, …)} or {@code mapper.writeValue(file, …)}
+ * hands out while it truncates and rewrites. File-backed stores are read while
+ * other threads write them (a tool task loading the history its sibling is
+ * appending to), so every store write goes through here.
+ *
+ * <p>This covers torn reads, not lost updates: two writers still overwrite each
+ * other, the last one wins. The temporary file starts with a dot and ends in
+ * {@code .tmp}, so directory listings that filter by extension skip it.
+ */
+public final class AtomicFiles {
+
+    /** Writes the content into the stream it is handed; the stream is closed afterwards either way. */
+    @FunctionalInterface
+    public interface Content {
+        void writeTo(OutputStream out) throws IOException;
+    }
+
+    private AtomicFiles() {
+    }
+
+    /** Replaces {@code target} with what {@code content} writes, creating the parent directories. */
+    public static void write(Path target, Content content) throws IOException {
+        Path file = target.toAbsolutePath();
+        Path dir = file.getParent();
+        Files.createDirectories(dir);
+        Path tmp = Files.createTempFile(dir, "." + file.getFileName() + ".", ".tmp");
+        try {
+            try (OutputStream out = Files.newOutputStream(tmp)) {
+                content.writeTo(out);
+            }
+            try {
+                Files.move(tmp, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                // A file system without atomic rename: still better than truncating in place.
+                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    /** Replaces {@code target} with {@code text}, UTF-8. */
+    public static void writeString(Path target, String text) throws IOException {
+        write(target, out -> out.write(text.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/common/mc-common/src/test/java/ai/mindconnect/common/util/AtomicFilesTest.java
+++ b/common/mc-common/src/test/java/ai/mindconnect/common/util/AtomicFilesTest.java
@@ -1,0 +1,78 @@
+package ai.mindconnect.common.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AtomicFilesTest {
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void writesAndReplacesAndLeavesNoTemporaryFile() throws Exception {
+        Path target = dir.resolve("sub/state.json");
+
+        AtomicFiles.writeString(target, "{\"v\":1}");
+        AtomicFiles.writeString(target, "{\"v\":2}");
+
+        assertThat(Files.readString(target)).isEqualTo("{\"v\":2}");
+        try (Stream<Path> files = Files.list(target.getParent())) {
+            assertThat(files).containsExactly(target);
+        }
+    }
+
+    @Test
+    void aFailingWriteLeavesTheOldContentAndNoTemporaryFile() throws Exception {
+        Path target = dir.resolve("state.json");
+        AtomicFiles.writeString(target, "old");
+
+        assertThatThrownBy(() -> AtomicFiles.write(target, out -> {
+            out.write("half".getBytes());
+            throw new IOException("disk full");
+        })).hasMessage("disk full");
+
+        assertThat(Files.readString(target)).isEqualTo("old");
+        try (Stream<Path> files = Files.list(dir)) {
+            assertThat(files).containsExactly(target);
+        }
+    }
+
+    @Test
+    void aReaderNeverSeesAnEmptyFile() throws Exception {
+        Path target = dir.resolve("state.json");
+        String content = "x".repeat(64_000);
+        AtomicFiles.writeString(target, content);
+        AtomicBoolean done = new AtomicBoolean();
+        AtomicReference<String> seen = new AtomicReference<>();
+
+        Thread writer = new Thread(() -> {
+            try {
+                for (int i = 0; i < 300; i++) AtomicFiles.writeString(target, content);
+            } catch (IOException e) {
+                seen.set("writer failed: " + e);
+            } finally {
+                done.set(true);
+            }
+        });
+        writer.start();
+        while (!done.get()) {
+            String read = Files.readString(target);
+            if (read.length() != content.length()) {
+                seen.compareAndSet(null, "read " + read.length() + " chars");
+            }
+        }
+        writer.join();
+
+        assertThat(seen.get()).isNull();
+    }
+}

--- a/taskqueue/mc-task-queue/src/main/java/ai/mindconnect/taskqueue/LoggingTaskListener.java
+++ b/taskqueue/mc-task-queue/src/main/java/ai/mindconnect/taskqueue/LoggingTaskListener.java
@@ -16,6 +16,9 @@ import org.slf4j.LoggerFactory;
  * queue.addListener(new LoggingTaskListener());
  * </pre>
  *
+ * <p>{@link #failuresOnly()} logs nothing but failed tasks — for a host that does
+ * not want a line per task but must not lose a failure silently.
+ *
  * <p>What listeners canNOT see are failures a method swallows internally —
  * those few places log directly (a broken subscriber, a publish that failed,
  * a fallback that kicked in).
@@ -23,48 +26,66 @@ import org.slf4j.LoggerFactory;
 public final class LoggingTaskListener implements TaskListener {
 
     private final Logger log;
+    private final boolean failuresOnly;
 
     public LoggingTaskListener() {
         this(LoggerFactory.getLogger("ai.mindconnect.taskqueue.tasks"));
     }
 
     public LoggingTaskListener(Logger log) {
+        this(log, false);
+    }
+
+    private LoggingTaskListener(Logger log, boolean failuresOnly) {
         this.log = log;
+        this.failuresOnly = failuresOnly;
+    }
+
+    /** Logs failed tasks at WARN and nothing else. */
+    public static LoggingTaskListener failuresOnly() {
+        return new LoggingTaskListener(LoggerFactory.getLogger("ai.mindconnect.taskqueue.tasks"), true);
     }
 
     @Override
     public void onSubmitted(TaskRecord task) {
+        if (failuresOnly) return;
         log.debug("submitted {} [{}] priority={} parent={}",
                 task.id(), task.type(), task.priority(), task.parentTaskId());
     }
 
     @Override
     public void onStarted(TaskRecord task) {
+        if (failuresOnly) return;
         log.info("started {} [{}] attempt={}", task.id(), task.type(), task.attempt());
     }
 
     @Override
     public void onStateChanged(TaskRecord task) {
+        if (failuresOnly) return;
         log.debug("progress {} [{}] {}", task.id(), task.type(), task.state());
     }
 
     @Override
     public void onSuspended(TaskRecord task) {
+        if (failuresOnly) return;
         log.info("suspended {} [{}] waiting for {}", task.id(), task.type(), task.waitingFor());
     }
 
     @Override
     public void onWoken(TaskRecord task) {
+        if (failuresOnly) return;
         log.info("woken {} [{}]", task.id(), task.type());
     }
 
     @Override
     public void onTerminal(TaskRecord task) {
+        if (failuresOnly && task.status() != TaskStatus.FAILED) return;
         long tookMs = task.startedAt() == null || task.endedAt() == null
                 ? -1 : task.endedAt().toEpochMilli() - task.startedAt().toEpochMilli();
         switch (task.status()) {
-            case FAILED -> log.warn("failed {} [{}] after {}ms: {}",
+            case FAILED -> log.warn("failed {} [{}] after {}ms: {}{}",
                     task.id(), task.type(), tookMs,
+                    task.failure() != null && task.failure().type() != null ? task.failure().type() + ": " : "",
                     task.failure() != null ? task.failure().message() : null);
             case CANCELLED -> log.info("cancelled {} [{}] after {}ms", task.id(), task.type(), tookMs);
             default -> log.info("completed {} [{}] in {}ms result={}",


### PR DESCRIPTION
## Summary

Tool calls failed at random when sub-agents ran in parallel. With the file persistence most stores truncated a file and wrote it anew. A tool task that read the conversation while a sibling task saved a message found an empty file. It ended with `MismatchedInputException: No content to map due to end-of-input`, which the chat only showed as "tool call was interrupted before completion: tool task ended FAILED without a result". The manual test run reproduced it with one `run_agents` call on three web-researchers.

- **Atomic writes.** `AtomicFiles` (in `mc-common`) writes into a temporary file beside the target and moves it over the target in one step. Readers see the old content or the new, never a half-written file. Every file store goes through it:
  - messages and conversations
  - sessions (replaces the inline temp-file code from #61)
  - agent definitions and LLM configs
  - working memory, todos, traces and summaries
  - workspace files; the workspace listing skips in-flight temp files
  - uploaded files' `meta.json` and the vector-store registry
- **Summaries.** An unreadable `summaries.json` is no longer overwritten with only the newest summary.
- **Failures are visible.** `LoggingTaskListener.failuresOnly()` logs failed tasks at WARN; the Spring config and the builder attach it. A lost tool result also names the failure the queue recorded.

Out of scope: locks against lost updates and a version per entity. Those are the follow-up (a shared, locking file repository); `AtomicFiles` becomes its write primitive.

## Tests
- `FileMessageRepositoryConcurrencyTest` reads the history while a writer re-saves a message. Against the old code it fails 3/3 with the exact production error; with the fix it passes 3/3.
- `AtomicFilesTest`: the file is replaced, a failed write keeps the old content, no temp file is left behind, and a reader never sees an empty file.
- The tests of the affected modules pass (mc-common, mc-task-queue, runtime-core, runtime, message-repository, llm-gateway, file-store, vector-store-tools, builder), and the full build compiles.
- Live, file persistence: the reproduction from the manual run twice (research-lead → `run_agents` with three web-researchers). 37 tool results, including 10 `run_agent` and 10 `web_read`, none interrupted. No failed task in the log, and no `.tmp` files left in the data directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
