### PR TITLE
Refuse another user's session on every chat endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Fixed
 
+- **agents:** knowing another user's chat session id is no longer enough to
+  act in that chat. Most chat endpoints already checked the owner; sending a
+  message, regenerating a reply, cancelling a turn, attaching, removing or
+  viewing a file, and the turn's live stream (`/chat/api/streams/...`) did
+  not — and a session id travels in URLs and logs. These endpoints now answer
+  404 for a session that is not the caller's, and the stream list shows only
+  the caller's own turns. Inside a chat, the `vector_search`, `vector_upsert`
+  and `vector_delete_file` tools refuse the upload store of any other chat
+  session, so the model cannot be talked into reading another user's
+  attachments by naming their store.
 - **agents:** a response reviewer follows its own rules again when the user's
   message is itself an instruction. The reviewer received the user's words as
   its own prompt, so "Antworte exakt mit: Hallo Welt" often made it answer

--- a/agents/doc/manual-tests/chat/session-isolation.md
+++ b/agents/doc/manual-tests/chat/session-isolation.md
@@ -1,0 +1,71 @@
+---
+id: chat-session-isolation
+area: chat
+requires: [server-9098]
+duration: ~3 min
+last-verified: 2026-09-11 (curl, dev-user mode, branch fix/session-ownership)
+---
+
+# Session isolation: another user's session id opens nothing
+
+**Goal:** Every chat endpoint that is addressed by a session id — or by the
+session's stream channel — answers 404 when the session belongs to another
+user, and works for the owner. No LLM is needed: only the answer codes count.
+
+## Preconditions
+
+- Admin UI started with auth off and a fixed dev user `bob`, e.g. via
+  `start.sh -Dspring-boot.run.arguments="--server.port=9098 --mindconnect.auth.enabled=false --mindconnect.auth.dev-user=bob"`
+  (every chat request runs as `bob`). Otherwise: SKIPPED.
+- `curl`, `python3` and a file to upload (`printf hello > up.txt`).
+
+## Setup
+
+Create one session for `alice` and one for `bob` through the REST API, which
+takes the user from the request body (it is a backend-client API):
+
+```bash
+B=http://localhost:9098
+AG=$(curl -s $B/api/agents | python3 -c 'import sys,json; print(json.load(sys.stdin)[0]["id"])')
+A=$(curl -s -X POST $B/api/sessions -H 'Content-Type: application/json' -d "{\"agentId\":\"$AG\",\"userId\":\"alice\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
+BOB=$(curl -s -X POST $B/api/sessions -H 'Content-Type: application/json' -d "{\"agentId\":\"$AG\",\"userId\":\"bob\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
+c() { printf '%-16s %s\n' "$1" "$(curl -s -o /dev/null -m 5 -w '%{http_code}' "${@:2}")"; }
+```
+
+## Steps
+
+1. **Alice's session, called as bob.**
+   ```bash
+   c "send"          -X POST $B/chat/api/sessions/$A/chat/stream -H 'Content-Type: application/json' -d '{"message":"hi"}'
+   c "regenerate"    -X POST $B/chat/api/sessions/$A/messages/1/regenerate
+   c "cancel turn"   -X DELETE $B/chat/api/sessions/$A/chat
+   c "upload"        -X POST $B/chat/api/sessions/$A/chat-files -F chat-attach=@up.txt
+   c "remove file"   -X DELETE "$B/chat/api/sessions/$A/chat-files?file=up.txt"
+   c "file content"  $B/chat/api/sessions/$A/chat-files/file-x/content
+   c "stream get"    $B/chat/api/streams/msg-list-$A
+   c "stream sse"    $B/chat/api/streams/msg-list-$A/sse
+   c "stream cancel" -X DELETE $B/chat/api/streams/msg-list-$A
+   ```
+   **Expected:** **404** on every line.
+2. **Bob's own session.**
+   ```bash
+   c "upload"      -X POST $B/chat/api/sessions/$BOB/chat-files -F chat-attach=@up.txt
+   curl -s -m 2 -D - -o /dev/null $B/chat/api/streams/msg-list-$BOB/sse | head -1
+   c "stream get"  $B/chat/api/streams/msg-list-$BOB
+   c "send"        -X POST $B/chat/api/sessions/$BOB/chat/stream -H 'Content-Type: application/json' -d '{"message":"hi"}'
+   ```
+   **Expected:** upload **200**; the SSE request answers `HTTP/1.1 200`
+   (the connection stays open until `-m 2` cuts it); `stream get` **404**
+   while no turn runs; send **200**.
+3. **The stream list shows only bob's turns.** Right after step 2's send:
+   ```bash
+   curl -s $B/chat/api/streams
+   ```
+   **Expected:** no entry with `channelId` = `msg-list-$A`, even while one of
+   alice's turns runs; bob's turn (`msg-list-$BOB`) appears while it streams.
+
+## Not covered here
+
+The `vector_search` / `vector_upsert` / `vector_delete_file` guard against a
+foreign `store: session-<id>` is a tool-level rule and is pinned by
+`VectorToolsTest.sessionUploadStoresAreNotReachableFromOtherSessions`.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/SessionOwnership.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/service/SessionOwnership.java
@@ -1,0 +1,75 @@
+package ai.mindconnect.chatui.service;
+
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.runtime.domain.AgentSession;
+import ai.mindconnect.agent.runtime.port.out.AgentSessionRepository;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * The one question every session-addressed chat endpoint has to ask before
+ * it does anything: is this the caller's chat? A session id is not a secret
+ * — it travels in URLs, links, logs and the DOM — so the id alone must not
+ * open a chat. The owner is the user who started it ({@link
+ * AgentSession#userId()}), and a session that is not the caller's is
+ * reported as not existing, which is all a stranger gets to learn.
+ *
+ * <p>Streams are addressed by channel, and the chat's channel is derived
+ * from its session ({@code msg-list-<sessionId>}), so a channel is owned
+ * exactly when the session it names is.
+ */
+@Component
+public class SessionOwnership {
+
+    /** The channel prefix the chat page uses for its message list stream. */
+    public static final String CHANNEL_PREFIX = "msg-list-";
+
+    /** The user every request runs as when no principal is present. */
+    public static final String ANONYMOUS_USER = "mc_user";
+
+    private final AgentSessionRepository sessions;
+
+    public SessionOwnership(AgentSessionRepository sessions) {
+        this.sessions = sessions;
+    }
+
+    /** The session, if it exists and belongs to the caller. */
+    public Optional<AgentSession> owned(SessionId sessionId, OidcUser user) {
+        return sessions.findById(sessionId).filter(session -> owns(session, user));
+    }
+
+    /** The session behind a chat stream channel, if it exists and belongs to the caller. */
+    public Optional<AgentSession> ownedByChannel(String channelId, OidcUser user) {
+        return sessionIdOf(channelId).flatMap(id -> owned(id, user));
+    }
+
+    /** Whether the caller is the user who started the session. */
+    public static boolean owns(AgentSession session, OidcUser user) {
+        String caller = userIdOf(user);
+        return caller != null && session.userId() != null && caller.equals(session.userId().value());
+    }
+
+    /** The caller's user id: the OIDC preferred username, or the fixed dev user without a principal. */
+    public static String userIdOf(OidcUser user) {
+        return user == null ? ANONYMOUS_USER : user.getPreferredUsername();
+    }
+
+    /** The channel the chat page streams a session's turns on. */
+    public static String channelOf(SessionId sessionId) {
+        return CHANNEL_PREFIX + sessionId.value();
+    }
+
+    /** The session a chat channel belongs to; empty for any other channel shape. */
+    public static Optional<SessionId> sessionIdOf(String channelId) {
+        if (channelId == null || !channelId.startsWith(CHANNEL_PREFIX)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(SessionId.of(channelId.substring(CHANNEL_PREFIX.length())));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatAttachmentsComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatAttachmentsComponent.java
@@ -50,7 +50,7 @@ public final class ChatAttachmentsComponent {
                 .rowAction(UiAction.danger("remove", "Remove").icon("remove")
                         .confirm("Remove this file from the conversation?")
                         .onClick(trigger(on(ChatFilesUiController.class)
-                                .remove(sessionId.value(), ROW_ID.toString()))));
+                                .remove(sessionId.value(), ROW_ID.toString(), null))));
         for (AttachedFile f : files) {
             table.row(Map.of(
                     "id", java.net.URLEncoder.encode(f.name(), java.nio.charset.StandardCharsets.UTF_8),

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatFormComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatFormComponent.java
@@ -166,7 +166,7 @@ public final class ChatFormComponent implements UiComponent {
                         // comes back on the session stream this client already
                         // reads, the same one every other client of the session
                         // reads.
-                        .onClick(trigger(on(ChatUiController.class).chatStream(sessionId.value(), null), id())));
+                        .onClick(trigger(on(ChatUiController.class).chatStream(sessionId.value(), null, null), id())));
         return form.<UiForm>withCssClass("chat-form");
     }
 
@@ -199,14 +199,14 @@ public final class ChatFormComponent implements UiComponent {
      * by the same channelId the client uses for re-mount detection.
      */
     private ai.mindconnect.ui.model.UiNode streamingForm() {
-        String channelId = "msg-list-" + sessionId.value();
+        String channelId = ai.mindconnect.chatui.service.SessionOwnership.channelOf(sessionId);
         var row = ai.mindconnect.ui.model.UiStack.of(id());
         row.direction(ai.mindconnect.ui.model.UiStack.Direction.HORIZONTAL);
         row.withCssClass("chat-form chat-form--streaming");
         row.child(ai.mindconnect.ui.model.UiText.of(id() + ":thinking", "AI is thinking")
                 .withCssClass("chat-thinking"));
         row.child(UiAction.danger("stop", "Stop").icon("stop")
-                .onClick(trigger(on(StreamController.class).cancel(channelId))));
+                .onClick(trigger(on(StreamController.class).cancel(channelId, null))));
         return row;
     }
 }

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageComponent.java
@@ -121,7 +121,7 @@ public final class MessageComponent {
                     .confirm("Delete the response(s) after this message and generate a new one?")
                     // Plain dispatch — the regenerated turn streams on the
                     // session's stream like any other.
-                    .onClick(trigger(on(ChatUiController.class).regenerate(sessionId.value(), seq))));
+                    .onClick(trigger(on(ChatUiController.class).regenerate(sessionId.value(), seq, null))));
         }
 
         // Delete-from-here: remove this message and every message after it.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/MessageListComponent.java
@@ -165,7 +165,7 @@ public final class MessageListComponent implements UiComponent {
 
     @Override
     public String id() {
-        return "msg-list-" + sessionId.value();
+        return ai.mindconnect.chatui.service.SessionOwnership.channelOf(sessionId);
     }
 
     @Override

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.chatui.ui.controller;
 
 import ai.mindconnect.agentrest.service.SessionFileService;
+import ai.mindconnect.chatui.service.SessionOwnership;
 import ai.mindconnect.filestore.FileStore;
 import ai.mindconnect.filestore.StoredFile;
 import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
@@ -9,13 +10,17 @@ import ai.mindconnect.agent.runtime.service.AgentSessionService;
 import ai.mindconnect.agent.runtime.service.SessionAgentResolver;
 import ai.mindconnect.ui.model.UiPatch;
 import ai.mindconnect.ui.model.UiToast;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,6 +33,11 @@ import ai.mindconnect.filestore.FileId;
  * {@code POST /api/sessions/{id}/files} (via {@link SessionFileService}), but
  * the response is a {@link UiPatch} with a toast so the event bus can show
  * the outcome in place — the REST endpoint answers raw JSON instead.
+ *
+ * <p>Every endpoint here refuses a session that is not the caller's with a
+ * 404, like every other session-addressed chat endpoint — an upload into a
+ * stranger's chat would put words into their model's mouth, and a file's
+ * bytes are theirs.
  */
 @RestController
 @RequestMapping("/chat/api/sessions/{sessionId}/chat-files")
@@ -38,29 +48,33 @@ public class ChatFilesUiController {
     private final AgentSessionRepository sessions;
     private final AgentSessionService sessionService;
     private final SessionAgentResolver agentResolver;
+    private final SessionOwnership ownership;
 
     public ChatFilesUiController(FileStore fileStore, SessionFileService sessionFiles,
                                  AgentSessionRepository sessions,
                                  AgentSessionService sessionService,
-                                 AgentDefinitionRepository agents) {
+                                 AgentDefinitionRepository agents,
+                                 SessionOwnership ownership) {
         this.fileStore = fileStore;
         this.sessionFiles = sessionFiles;
         this.sessions = sessions;
         this.sessionService = sessionService;
         this.agentResolver = new SessionAgentResolver(agents);
+        this.ownership = ownership;
     }
 
     /**
      * The bytes of a file this chat holds — for the image a message bubble
-     * shows inline. Served only for a file the session references: one of
-     * its attachments, or a part of one of its messages; any other id is
-     * not found, whether or not the store has it.
+     * shows inline. Served only to the session's owner and only for a file the
+     * session references: one of its attachments, or a part of one of its
+     * messages; any other id is not found, whether or not the store has it.
      */
     @org.springframework.web.bind.annotation.GetMapping("/{fileId}/content")
     public org.springframework.http.ResponseEntity<org.springframework.core.io.InputStreamResource> content(
-            @PathVariable("sessionId") String sessionIdValue, @PathVariable String fileId) throws IOException {
+            @PathVariable("sessionId") String sessionIdValue, @PathVariable String fileId,
+            @AuthenticationPrincipal OidcUser user) throws IOException {
         SessionId sessionId = SessionId.of(sessionIdValue);
-        if (!referencedBySession(sessionId, fileId)) {
+        if (!referencedBySession(sessionId, user, fileId)) {
             return org.springframework.http.ResponseEntity.notFound().build();
         }
         StoredFile file = fileStore.find(FileId.of(fileId)).orElse(null);
@@ -79,9 +93,9 @@ public class ChatFilesUiController {
                 .body(new org.springframework.core.io.InputStreamResource(fileStore.content(FileId.of(fileId))));
     }
 
-    /** Does the session hold this file — as an attachment, or as a part of one of its messages? */
-    private boolean referencedBySession(SessionId sessionId, String fileId) {
-        var session = sessions.findById(sessionId).orElse(null);
+    /** Is this the caller's session, and does it hold this file — as an attachment, or as a part of one of its messages? */
+    private boolean referencedBySession(SessionId sessionId, OidcUser user, String fileId) {
+        var session = ownership.owned(sessionId, user).orElse(null);
         if (session == null) return false;
         if (session.attachedFiles().stream().anyMatch(f -> fileId.equals(f.id()))) return true;
         return sessionService.loadHistory(sessionId).stream()
@@ -93,8 +107,10 @@ public class ChatFilesUiController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public UiPatch attach(@PathVariable("sessionId") String sessionIdValue,
-                          @RequestParam("chat-attach") List<MultipartFile> files) throws IOException {
+                          @RequestParam("chat-attach") List<MultipartFile> files,
+                          @AuthenticationPrincipal OidcUser user) throws IOException {
         SessionId sessionId = SessionId.of(sessionIdValue);
+        requireOwned(sessionId, user);
         UiPatch patch = UiPatch.of();
         for (MultipartFile file : files) {
             StoredFile stored;
@@ -120,14 +136,22 @@ public class ChatFilesUiController {
 
     /** Detaches a file by name: its chunks leave the session store, an image leaves the record. */
     @org.springframework.web.bind.annotation.DeleteMapping
-    public UiPatch remove(@PathVariable("sessionId") String sessionIdValue, @RequestParam("file") String fileName) {
+    public UiPatch remove(@PathVariable("sessionId") String sessionIdValue, @RequestParam("file") String fileName,
+                          @AuthenticationPrincipal OidcUser user) {
         SessionId sessionId = SessionId.of(sessionIdValue);
+        requireOwned(sessionId, user);
         sessionFiles.deleteAttachment(sessionId, fileName);
         return UiPatch.of()
                 .patch(UiPatch.Operation.replace("chat-attachments",
                         attachmentsPanel(sessionId)))
                 .patch(attachmentCountRefresh(sessionId))
                 .toast(UiToast.success("Removed from the conversation.").title("File removed"));
+    }
+
+    private void requireOwned(SessionId sessionId, OidcUser user) {
+        if (ownership.owned(sessionId, user).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
     }
 
     /**

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -332,9 +332,8 @@ public class ChatUiController {
      */
     private java.util.Optional<AgentSession> ownedSession(
             SessionId sessionId, OidcUser user) {
-        String userId = userId(user);
         return sessionRepository.findById(sessionId)
-                .filter(session -> UserId.of(userId).equals(session.userId()));
+                .filter(session -> ai.mindconnect.chatui.service.SessionOwnership.owns(session, user));
     }
 
     /** Closes the settings dialog without touching anything. */
@@ -554,7 +553,7 @@ public class ChatUiController {
     }
 
     private static String userId(OidcUser user) {
-        return user == null ? "mc_user" : user.getPreferredUsername();
+        return ai.mindconnect.chatui.service.SessionOwnership.userIdOf(user);
     }
 
     @PostMapping("/agents/{agentId}/sessions")
@@ -617,7 +616,7 @@ public class ChatUiController {
         // registry — not page-local state. Lets a navigate-back during a
         // live turn render the form in Stop-mode without any client-side
         // reconciliation.
-        String channelId = "msg-list-" + session.id().value();
+        String channelId = ai.mindconnect.chatui.service.SessionOwnership.channelOf(session.id());
         var handleOpt = activeStreams.findHandle(channelId);
         var page = new ChatPage(session, agent, history, memory, handleOpt.isPresent(),
                 (toolCallId, running, in, out) ->
@@ -659,7 +658,7 @@ public class ChatUiController {
     private java.util.Set<SessionId> runningSessions(List<? extends AgentSessionHeader> sessions) {
         java.util.Set<SessionId> running = new java.util.HashSet<>();
         for (var s : sessions) {
-            if (activeStreams.findHandle("msg-list-" + s.id().value()).isPresent()) running.add(s.id());
+            if (activeStreams.findHandle(ai.mindconnect.chatui.service.SessionOwnership.channelOf(s.id())).isPresent()) running.add(s.id());
         }
         return running;
     }
@@ -816,13 +815,15 @@ public class ChatUiController {
 
     /**
      * Cooperatively cancels a running chat turn. Returns 204 if a live turn
-     * was signalled, 404 if no chat is currently running. The stream
-     * completes via the normal {@code Done} flow once the loop reaches its
-     * next cancel-check point.
+     * was signalled, 404 if no chat is currently running or the session is
+     * not the caller's. The stream completes via the normal {@code Done} flow
+     * once the loop reaches its next cancel-check point.
      */
     @DeleteMapping("/sessions/{sessionId}/chat")
-    public ResponseEntity<Void> cancelChat(@PathVariable("sessionId") String sessionIdValue) {
+    public ResponseEntity<Void> cancelChat(@PathVariable("sessionId") String sessionIdValue,
+                                           @AuthenticationPrincipal OidcUser user) {
         SessionId sessionId = SessionId.of(sessionIdValue);
+        if (ownedSession(sessionId, user).isEmpty()) return ResponseEntity.notFound().build();
         boolean cancelled = chatService.cancelChat(sessionId);
         log.info("DELETE /chat/api/sessions/{}/chat → cancelled={}", sessionId.value(), cancelled);
         return cancelled ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
@@ -856,7 +857,8 @@ public class ChatUiController {
 
     @PostMapping("/sessions/{sessionId}/chat/stream")
     public ResponseEntity<ai.mindconnect.ui.model.UiPatch> chatStream(@PathVariable("sessionId") String sessionIdValue,
-                                                 @RequestBody Map<String, Object> raw) {
+                                                 @RequestBody Map<String, Object> raw,
+                                                 @AuthenticationPrincipal OidcUser user) {
         SessionId sessionId = SessionId.of(sessionIdValue);
         var body = new FormBody(raw);
         String text = body.str("message");
@@ -864,9 +866,9 @@ public class ChatUiController {
             return ResponseEntity.badRequest().build();
         }
 
-        var sessionOpt = sessionRepository.findById(sessionId);
+        var sessionOpt = ownedSession(sessionId, user);
         if (sessionOpt.isEmpty()) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.notFound().build();
         }
         var agentOpt = java.util.Optional.of(agentResolver.resolve(sessionOpt.get()));
         if (agentOpt.isEmpty()) {
@@ -912,11 +914,12 @@ public class ChatUiController {
      */
     @PostMapping(value = "/sessions/{sessionId}/messages/{seq}/regenerate")
     public ResponseEntity<ai.mindconnect.ui.model.UiPatch> regenerate(@PathVariable("sessionId") String sessionIdValue,
-                                                 @PathVariable int seq) {
+                                                 @PathVariable int seq,
+                                                 @AuthenticationPrincipal OidcUser user) {
         SessionId sessionId = SessionId.of(sessionIdValue);
-        var sessionOpt = sessionRepository.findById(sessionId);
+        var sessionOpt = ownedSession(sessionId, user);
         if (sessionOpt.isEmpty()) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.notFound().build();
         }
         var agentOpt = java.util.Optional.of(agentResolver.resolve(sessionOpt.get()));
         if (agentOpt.isEmpty()) {
@@ -984,7 +987,7 @@ public class ChatUiController {
         // target. This way the client's {@code findStreamTarget} lookup
         // naturally detects "chat page mounted", and both the submitter and
         // any observer resolve the same stream.
-        String channelId = "msg-list-" + sessionId.value();
+        String channelId = ai.mindconnect.chatui.service.SessionOwnership.channelOf(sessionId);
         String returnHref = "/chat/sessions/" + sessionId.value();
         String streamLabel = agent.name() != null ? agent.name() : "Agent";
         String pendingId  = "bot-pending-"  + sessionId.value();

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatVoiceUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatVoiceUiController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import ai.mindconnect.agent.SessionId;
-import ai.mindconnect.agent.UserId;
 
 /**
  * Speaking into the chat instead of typing. The composer's microphone records
@@ -121,9 +120,8 @@ public class ChatVoiceUiController {
 
     /** The session belongs to whoever is asking — the chat's own rule. */
     private boolean ownsSession(SessionId sessionId, OidcUser user) {
-        String userId = user == null ? "mc_user" : user.getPreferredUsername();
         return sessions.findById(sessionId)
-                .filter(session -> UserId.of(userId).equals(session.userId()))
+                .filter(session -> ai.mindconnect.chatui.service.SessionOwnership.owns(session, user))
                 .isPresent();
     }
 
@@ -133,7 +131,7 @@ public class ChatVoiceUiController {
      * of the same registry.
      */
     private boolean isStreaming(SessionId sessionId) {
-        return activeStreams.findHandle("msg-list-" + sessionId.value()).isPresent();
+        return activeStreams.findHandle(ai.mindconnect.chatui.service.SessionOwnership.channelOf(sessionId)).isPresent();
     }
 
     /** What was typed, then what was said — with one space between them. */

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/StreamController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/StreamController.java
@@ -1,10 +1,13 @@
 package ai.mindconnect.chatui.ui.controller;
 
 import ai.mindconnect.chatui.service.ActiveStreams;
+import ai.mindconnect.chatui.service.SessionOwnership;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,6 +33,11 @@ import java.util.Map;
  * <p>The chat-page renderer uses the single-stream lookup to decide
  * between rendering the Send and Stop button. UIs that show a global
  * "what's running?" indicator would use the list endpoint.
+ *
+ * <p>A channel is a chat session's, and so is everything on it — the
+ * reply as it streams, the right to stop it. The endpoints therefore answer
+ * only for channels whose session belongs to the caller (see {@link
+ * SessionOwnership}); the list shows the caller's own streams.
  */
 @RestController
 @RequestMapping("/chat/api/streams")
@@ -39,23 +47,30 @@ public class StreamController {
 
     private final ai.mindconnect.chatui.service.SessionStreams sessionStreams;
 
+    private final SessionOwnership ownership;
+
     @Autowired
     public StreamController(ActiveStreams activeStreams,
-                            ai.mindconnect.chatui.service.SessionStreams sessionStreams) {
+                            ai.mindconnect.chatui.service.SessionStreams sessionStreams,
+                            SessionOwnership ownership) {
         this.activeStreams = activeStreams;
         this.sessionStreams = sessionStreams;
+        this.ownership = ownership;
     }
 
     @GetMapping
-    public ResponseEntity<List<Map<String, Object>>> list() {
+    public ResponseEntity<List<Map<String, Object>>> list(@AuthenticationPrincipal OidcUser user) {
         var streams = activeStreams.snapshot().stream()
+                .filter(h -> owned(h.channelId(), user))
                 .map(StreamController::serialize)
                 .toList();
         return ResponseEntity.ok(streams);
     }
 
     @GetMapping("/{channelId}")
-    public ResponseEntity<Map<String, Object>> get(@PathVariable String channelId) {
+    public ResponseEntity<Map<String, Object>> get(@PathVariable String channelId,
+                                                   @AuthenticationPrincipal OidcUser user) {
+        if (!owned(channelId, user)) return ResponseEntity.notFound().build();
         return activeStreams.findHandle(channelId)
                 .map(h -> ResponseEntity.ok(serialize(h)))
                 .orElseGet(() -> ResponseEntity.notFound().build());
@@ -67,7 +82,9 @@ public class StreamController {
      * 404 if no such stream is registered.
      */
     @DeleteMapping("/{channelId}")
-    public ResponseEntity<Void> cancel(@PathVariable String channelId) {
+    public ResponseEntity<Void> cancel(@PathVariable String channelId,
+                                       @AuthenticationPrincipal OidcUser user) {
+        if (!owned(channelId, user)) return ResponseEntity.notFound().build();
         return activeStreams.cancel(channelId)
                 ? ResponseEntity.noContent().build()
                 : ResponseEntity.notFound().build();
@@ -94,7 +111,9 @@ public class StreamController {
     public ResponseEntity<SseEmitter> resume(
             @PathVariable String channelId,
             @RequestParam(name = "lastSeq", defaultValue = "0") long lastSeq,
-            @RequestParam(name = "from", required = false) Long from) {
+            @RequestParam(name = "from", required = false) Long from,
+            @AuthenticationPrincipal OidcUser user) {
+        if (!owned(channelId, user)) return ResponseEntity.notFound().build();
         // `from` wins over `lastSeq`. The page renderer knows exactly what
         // the page it just rendered already shows and puts that position in
         // the resume URL; the client appends its own lastSeq=0 blindly, and
@@ -151,6 +170,10 @@ public class StreamController {
         headers.add("Sui-Stream-Label",
                 handleOpt.map(ActiveStreams.Handle::label).orElse("Agent"));
         return ResponseEntity.ok().headers(headers).body(emitter);
+    }
+
+    private boolean owned(String channelId, OidcUser user) {
+        return ownership.ownedByChannel(channelId, user).isPresent();
     }
 
     private static Map<String, Object> serialize(ActiveStreams.Handle h) {

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/service/SessionOwnershipTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/service/SessionOwnershipTest.java
@@ -1,0 +1,74 @@
+package ai.mindconnect.chatui.service;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.runtime.domain.AgentSession;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A session id opens a chat only for the user who started it. Anyone else
+ * — another user, or a channel that is not a chat's at all — gets an empty
+ * answer, indistinguishable from "no such session".
+ */
+class SessionOwnershipTest {
+
+    private final InMemoryAgentSessionRepository sessions = new InMemoryAgentSessionRepository();
+    private final SessionOwnership ownership = new SessionOwnership(sessions);
+
+    private final AgentSession alices = sessions.save(
+            AgentSession.start(AgentId.of("default-chat"), UserId.of("alice"), ConversationId.random()));
+
+    @Test
+    void theOwnerReachesTheSessionAndNobodyElseDoes() {
+        assertThat(ownership.owned(alices.id(), user("alice"))).contains(alices);
+        assertThat(ownership.owned(alices.id(), user("bob"))).isEmpty();
+        assertThat(ownership.owned(SessionId.random(), user("alice"))).isEmpty();
+    }
+
+    @Test
+    void withoutAPrincipalTheRequestRunsAsTheDevUser() {
+        var devs = sessions.save(AgentSession.start(AgentId.of("default-chat"),
+                UserId.of(SessionOwnership.ANONYMOUS_USER), ConversationId.random()));
+        assertThat(SessionOwnership.userIdOf(null)).isEqualTo(SessionOwnership.ANONYMOUS_USER);
+        assertThat(ownership.owned(devs.id(), null)).contains(devs);
+        assertThat(ownership.owned(alices.id(), null)).isEmpty();
+    }
+
+    @Test
+    void aChannelIsOwnedExactlyWhenItsSessionIs() {
+        String channel = SessionOwnership.channelOf(alices.id());
+        assertThat(SessionOwnership.sessionIdOf(channel)).contains(alices.id());
+        assertThat(ownership.ownedByChannel(channel, user("alice"))).contains(alices);
+        assertThat(ownership.ownedByChannel(channel, user("bob"))).isEmpty();
+
+        // Channels that are not a chat's: no session, so nobody owns them.
+        assertThat(SessionOwnership.sessionIdOf("msg-list-Not A Session")).isEmpty();
+        assertThat(SessionOwnership.sessionIdOf("user-stream")).isEmpty();
+        assertThat(SessionOwnership.sessionIdOf(null)).isEmpty();
+        assertThat(ownership.ownedByChannel("user-stream", user("alice"))).isEmpty();
+    }
+
+    private static OidcUser user(String name) {
+        var token = OidcIdToken.withTokenValue("t")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(60))
+                .subject(name)
+                .claim(StandardClaimNames.PREFERRED_USERNAME, name)
+                .build();
+        return new DefaultOidcUser(List.of(new SimpleGrantedAuthority("ROLE_USER")), token,
+                StandardClaimNames.PREFERRED_USERNAME);
+    }
+}

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorTools.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorTools.java
@@ -61,7 +61,7 @@ public final class VectorTools {
     public static final class DeleteFileFactory extends BaseFactory {
         @Override public String name() { return "vector_delete_file"; }
         @Override public Tool create(AgentTool agentTool, ToolCallScope scope) {
-            return new DeleteFileTool(stores);
+            return new DeleteFileTool(stores, scope);
         }
     }
 
@@ -100,6 +100,10 @@ public final class VectorTools {
             if (storeName == null || fileId == null
                     || !(arguments.get("chunks") instanceof List<?> rawChunks) || rawChunks.isEmpty()) {
                 return "Error: 'store', 'file_id' and a non-empty 'chunks' array are required.";
+            }
+            String denied = foreignSessionStore(stores, storeName, callScope);
+            if (denied != null) {
+                return denied;
             }
             List<String> texts = new ArrayList<>();
             List<String> titles = new ArrayList<>();
@@ -186,6 +190,10 @@ public final class VectorTools {
                 }
                 storeName = sessionStoreName(callScope.sessionId());
             }
+            String denied = foreignSessionStore(stores, storeName, callScope);
+            if (denied != null) {
+                return denied;
+            }
             int topK = clamp(arguments.get("top_k"), 5, 20);
             try {
                 float[] embedded = stores.embedFor(storeName, List.of(query)).get(0);
@@ -215,7 +223,7 @@ public final class VectorTools {
         }
     }
 
-    record DeleteFileTool(VectorStores stores) implements Tool {
+    record DeleteFileTool(VectorStores stores, ToolCallScope callScope) implements Tool {
         @Override public String name() { return "vector_delete_file"; }
 
         @Override public String description() {
@@ -235,6 +243,10 @@ public final class VectorTools {
             if (storeName == null || fileId == null) {
                 return "Error: 'store' and 'file_id' are required.";
             }
+            String denied = foreignSessionStore(stores, storeName, callScope);
+            if (denied != null) {
+                return denied;
+            }
             try {
                 stores.openWith(stores.settingsFor(storeName)).deleteFile(fileId);
                 return "Removed file '" + fileId + "' from store '" + storeName + "'.";
@@ -245,6 +257,41 @@ public final class VectorTools {
     }
 
     // ── helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * A chat session's upload store holds what one user attached to one chat,
+     * and the model running in that chat is the user's proxy — so from inside
+     * a session a tool may only touch that session's own store. Everything
+     * else it names is a knowledge base (global or an agent's) and stays open.
+     * Two things mark a store as another session's: a registered
+     * {@code SESSION} scope naming a different session, and the
+     * {@code session-} name the upload pipeline uses — the name matters for
+     * stores that do not exist yet, or the model could create
+     * {@code session-<other>} itself and read what lands there later.
+     *
+     * <p>A call without a session is the installation's own run and is not
+     * restricted here: the ingestion workflow that fills an upload store
+     * resolves its tools detached from any session.
+     *
+     * @return the tool's error text, or {@code null} when access is fine
+     */
+    static String foreignSessionStore(VectorStores stores, String storeName, ToolCallScope callScope) {
+        if (callScope == null || callScope.sessionId() == null) {
+            return null;
+        }
+        SessionId own = callScope.sessionId();
+        if (storeName.equals(SearchTool.sessionStoreName(own))) {
+            return null;
+        }
+        VectorStoreInstance settings = stores.settingsFor(storeName);
+        boolean anotherSessionsScope = settings.scope() == VectorStoreInstance.Scope.SESSION
+                && !own.value().equals(settings.scopeRef());
+        if (anotherSessionsScope || storeName.startsWith("session-")) {
+            return "Error: store '" + storeName + "' belongs to another chat session and is not "
+                    + "accessible from this one. Omit 'store' to search the files attached to this chat.";
+        }
+        return null;
+    }
 
     private static Map<String, Object> schema(Map<String, Object> properties, List<String> required) {
         Map<String, Object> schema = new LinkedHashMap<>();

--- a/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/VectorToolsTest.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/VectorToolsTest.java
@@ -1,7 +1,10 @@
 package ai.mindconnect.vectorstore.tools;
 
 import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.agent.tool.Tool;
+import ai.mindconnect.agent.tool.ToolCallScope;
 import ai.mindconnect.agent.tool.ToolEnvironment;
 import ai.mindconnect.llm.domain.LlmConfig;
 import ai.mindconnect.llm.domain.LlmConfigId;
@@ -72,9 +75,17 @@ class VectorToolsTest {
     }
 
     private Tool tool(VectorTools.BaseFactory factory) {
+        return tool(factory, null);
+    }
+
+    private Tool tool(VectorTools.BaseFactory factory, ToolCallScope scope) {
         factory.bind(env);
         assertThat(factory.isAvailable()).isTrue();
-        return factory.create(null, null);
+        return factory.create(null, scope);
+    }
+
+    private static ToolCallScope session(SessionId sessionId) {
+        return new ToolCallScope(UserId.of("alice"), sessionId, null);
     }
 
     @Test
@@ -122,5 +133,66 @@ class VectorToolsTest {
         assertThat(upsert.execute(Map.of("store", "kb", "file_id", "d", "chunks",
                 List.of(Map.of("title", "no text")))))
                 .startsWith("Error:").contains("text");
+    }
+
+    /**
+     * The upload store of a chat is that chat's alone. Named from inside
+     * another session — search, upsert or delete — the store is refused; the
+     * own session reaches it by omitting {@code store} or naming it. A store
+     * named like a session that does not exist yet is refused too, so the
+     * model cannot squat on a foreign session's name. The upload pipeline runs
+     * its tools without a session and keeps filling any session's store.
+     */
+    @Test
+    void sessionUploadStoresAreNotReachableFromOtherSessions() {
+        SessionId mine = SessionId.random();
+        SessionId theirs = SessionId.random();
+        String theirStore = "session-" + theirs.value();
+
+        // Their session's store and a session-scoped store under a free name.
+        Tool theirUpsert = tool(new VectorTools.UpsertFactory(), session(theirs));
+        assertThat(theirUpsert.execute(Map.of("store", theirStore, "scope", "session",
+                "file_id", "secret.pdf", "chunks", List.of(Map.of("text", "the finance report")))))
+                .contains("Stored 1 chunk(s)");
+        assertThat(theirUpsert.execute(Map.of("store", "their-notes", "scope", "session",
+                "file_id", "notes", "chunks", List.of(Map.of("text", "finance notes")))))
+                .contains("Stored 1 chunk(s)");
+
+        // The ingestion workflow resolves its tools detached — no session, no restriction.
+        assertThat(tool(new VectorTools.UpsertFactory()).execute(Map.of("store", theirStore,
+                "file_id", "second.pdf", "chunks", List.of(Map.of("text", "finance appendix")))))
+                .contains("Stored 1 chunk(s)");
+
+        Tool search = tool(new VectorTools.SearchFactory(), session(mine));
+        Tool upsert = tool(new VectorTools.UpsertFactory(), session(mine));
+        Tool delete = tool(new VectorTools.DeleteFileFactory(), session(mine));
+
+        assertThat(search.execute(Map.of("store", theirStore, "query", "finance")))
+                .startsWith("Error:").contains("another chat session").doesNotContain("report");
+        assertThat(search.execute(Map.of("store", "their-notes", "query", "finance")))
+                .startsWith("Error:").contains("another chat session");
+        assertThat(upsert.execute(Map.of("store", theirStore, "file_id", "x",
+                "chunks", List.of(Map.of("text", "planted")))))
+                .startsWith("Error:").contains("another chat session");
+        assertThat(delete.execute(Map.of("store", theirStore, "file_id", "secret.pdf")))
+                .startsWith("Error:").contains("another chat session");
+        assertThat(upsert.execute(Map.of("store", "session-" + SessionId.random().value(), "file_id", "x",
+                "chunks", List.of(Map.of("text", "squatting")))))
+                .startsWith("Error:");
+
+        // The own store stays reachable, by omission and by name.
+        assertThat(upsert.execute(Map.of("store", "session-" + mine.value(), "scope", "session",
+                "file_id", "mine.pdf", "chunks", List.of(Map.of("text", "podman container notes")))))
+                .contains("Stored 1 chunk(s)");
+        assertThat(search.execute(Map.of("query", "container"))).contains("podman");
+        assertThat(search.execute(Map.of("store", "session-" + mine.value(), "query", "container")))
+                .contains("podman");
+
+        // Knowledge bases are not session stores and stay open to everyone.
+        assertThat(upsert.execute(Map.of("store", "kb", "file_id", "d",
+                "chunks", List.of(Map.of("text", "shared knowledge")))))
+                .contains("Stored 1 chunk(s)");
+        assertThat(tool(new VectorTools.SearchFactory(), session(theirs))
+                .execute(Map.of("store", "kb", "query", "knowledge"))).contains("shared");
     }
 }


### PR DESCRIPTION
## What

Knowing another user's chat session id was enough to act in their chat. Most chat endpoints already checked the owner; these did not, and a session id travels in URLs and logs:

- `POST /chat/api/sessions/{id}/chat/stream` (send), `POST …/messages/{seq}/regenerate`, `DELETE …/chat` (cancel)
- `POST` / `DELETE …/chat-files` (attach / remove), `GET …/chat-files/{fileId}/content`
- `GET` / `DELETE /chat/api/streams/{channelId}`, `GET /chat/api/streams/{channelId}/sse`, and the list `GET /chat/api/streams`

Changes:

- **`SessionOwnership`** (`mc-agent-chat-ui-rest`) holds the one rule: the caller is the user who started the session, and a stream channel (`msg-list-<sessionId>`) is owned when its session is. The endpoints above answer **404** for a session that is not the caller's; the stream list shows only the caller's own turns. `ChatUiController` and `ChatVoiceUiController` use the same rule and channel helper instead of their own copies.
- **`vector_search` / `vector_upsert` / `vector_delete_file`**: inside a chat session, any other session's upload store is refused — by its `session-` name (also for stores that do not exist yet, so the model cannot squat a name) or by a registered `SESSION` scope naming a different session. Knowledge bases stay open.
- Manual test `agents/doc/manual-tests/chat/session-isolation.md`, changelog entry under *Fixed*.

## Notes for review

- This picks up the uncommitted work from the old `fix/session-ownership` clone (based on #39) and re-applies it on current `main` rather than rebasing it: many owner checks in `ChatUiController` had landed in the meantime, and the ids are typed now.
- **One deliberate change from that draft:** a tool call *without* a session is not restricted. The workflow tool invoker resolves tools with `ToolCallScope.detached(...)`, so the `file-ingestion` workflow's `vector_upsert` into `session-<id>` runs without a session — refusing it would have broken every chat upload.
- **Known gap:** a workflow exposed as an agent tool also runs its tool steps detached, so a chat model could still reach a foreign session store through such a workflow if it takes a store name. Closing that needs the session to travel into workflow tool steps; out of scope here.
- Sub-agents run in their own session, so they cannot name their parent's upload store either.

## Verification

- `mvn install -pl agents/vectorstore/mc-vector-store-tools,agents/server/mc-agent-chat-ui-rest`: 4 + 25 tests green, including the new `SessionOwnershipTest` and `VectorToolsTest.sessionUploadStoresAreNotReachableFromOtherSessions`.
- The manual test, run with curl against the admin UI of this branch (auth off, dev user `bob`): all nine endpoints on alice's session → 404; on bob's own session upload 200 with "up.txt attached — the agent can now search it" (so ingestion through the workflow still works), SSE 200, send 200; the stream list held only bob's turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
