### PR TITLE
The chat returns to the conversation you were in, and marks chats started elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ fresh empty one, so nothing has to be moved by hand at release time.
   last — in another tab, over the REST API — so returning through the
   *Chat* menu entry, or a page that re-requested `/chat`, jumped away from
   the one you were working in. It now opens the conversation this browser
-  session last had on screen, while it still exists.
+  session last had on screen, while it still exists. A conversation started
+  elsewhere since then shows up in the chat list at once, marked *new* until
+  you open it.
 
 - **agents:** a response reviewer follows its own rules again when the user's
   message is itself an instruction. The reviewer received the user's words as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
   and `vector_delete_file` tools refuse the upload store of any other chat
   session, so the model cannot be talked into reading another user's
   attachments by naming their store.
+
+- **agents:** coming back to the chat no longer lands in a different
+  conversation. The chat opened whichever conversation had been started
+  last — in another tab, over the REST API — so returning through the
+  *Chat* menu entry, or a page that re-requested `/chat`, jumped away from
+  the one you were working in. It now opens the conversation this browser
+  session last had on screen, while it still exists.
+
 - **agents:** a response reviewer follows its own rules again when the user's
   message is itself an instruction. The reviewer received the user's words as
   its own prompt, so "Antworte exakt mit: Hallo Welt" often made it answer

--- a/agents/doc/manual-tests/chat/landing-and-new-chats.md
+++ b/agents/doc/manual-tests/chat/landing-and-new-chats.md
@@ -1,0 +1,69 @@
+---
+id: chat-landing-and-new-chats
+area: chat
+requires: [server-9091]
+duration: ~4 min
+last-verified: never
+---
+
+# Coming back to the chat lands where you were; chats started elsewhere are marked new
+
+**Goal:** Returning to the chat through the main menu opens the conversation
+this browser last had on screen, not the one started last; a conversation
+started elsewhere appears in the chat list at once, marked **new** until it
+is opened.
+
+## Preconditions
+
+- Admin UI running at http://localhost:9091 with authentication off, the
+  app's default (otherwise: SKIPPED — the REST steps act as the dev user
+  `mc_user`)
+- No model is needed: nothing is sent to one.
+
+## Setup
+
+1. Note the id of the seeded `default-chat` agent:
+   `AID=$(curl -s http://localhost:9091/api/agents | jq -r '.[] | select(.name=="default-chat") | .id')`
+
+## Steps
+
+1. Open http://localhost:9091/chat and click **New chat** (in the empty state,
+   or at the top of the chat list). Note the id from the URL as `<mine>`.
+   **Expected:** The URL is `/chat/sessions/<mine>`. In the chat list (the
+   history button left of the conversation's title) its row is selected and
+   shows an age such as `1m`, not `new`.
+2. Keep the chat list open. From a terminal, start a chat elsewhere:
+   ```bash
+   curl -s -X POST http://localhost:9091/api/sessions -H 'content-type: application/json' \
+        -d "{\"agentId\":\"$AID\",\"userId\":\"mc_user\"}" | jq -r .id
+   ```
+   Note the printed id as `<elsewhere>`.
+   **Expected:** Without a reload, a row `New chat` appears at the top of the
+   list with the badge **new** in the success colour. The page stays on
+   `<mine>`.
+3. Click **Agents** in the main menu, then **Chat**.
+   **Expected:** The URL is `/chat/sessions/<mine>` — not `<elsewhere>`,
+   although `<elsewhere>` was started later. Its row still says **new**.
+4. Click the `<elsewhere>` row.
+   **Expected:** The URL is `/chat/sessions/<elsewhere>`; its row no longer
+   says **new**.
+5. Click **Agents**, then **Chat**.
+   **Expected:** The URL is `/chat/sessions/<elsewhere>` — the chat last on
+   screen.
+6. Delete `<elsewhere>` (its row's **…** → **Delete**, confirm).
+   **Expected:** The most recently started remaining chat opens; no error.
+
+## Cleanup
+
+- Delete `<mine>` (its row's **…** → **Delete**).
+
+## Notes
+
+- The record lives in the HTTP session. A new browser session — another
+  browser, a private window — opens the most recently started chat and marks
+  nothing as new: only chats started after it began count.
+- Tabs of the same browser share the HTTP session. A chat started in one tab
+  is marked new live in the other, and plainly once that tab renders again,
+  since the first tab has had it on screen.
+- Automated twins: `ChatLandingTest`, `SeenChatsTest`,
+  `ChatShellComponentBadgeTest` (mc-agent-chat-ui-rest).

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatShellComponent.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/component/ChatShellComponent.java
@@ -43,6 +43,7 @@ public final class ChatShellComponent implements UiComponent {
     private final java.util.Map<AgentId, String> agentIcons;
     private java.util.Set<SessionId> running = java.util.Set.of();
     private java.util.Set<SessionId> waiting = java.util.Set.of();
+    private java.util.Set<SessionId> unseen = java.util.Set.of();
 
     public ChatShellComponent(List<? extends AgentSessionHeader> sessions, AgentSession active,
                               String agentName, UiNode content) {
@@ -83,6 +84,18 @@ public final class ChatShellComponent implements UiComponent {
     public static final String BADGE_NEEDS_INPUT = "needs input";
     /** The row badge of a chat with a turn in flight. */
     public static final String BADGE_RUNNING = "running";
+    /** The row badge of a chat started elsewhere that this browser has not had on screen yet. */
+    public static final String BADGE_NEW = "new";
+
+    /**
+     * Which conversations were started elsewhere — in another tab, over the
+     * REST API — since this browser began, and have not been opened here.
+     * Their rows say {@value #BADGE_NEW} until they are.
+     */
+    public ChatShellComponent withUnseen(java.util.Set<SessionId> unseen) {
+        this.unseen = unseen == null ? java.util.Set.of() : unseen;
+        return this;
+    }
 
     @Override
     public String id() {
@@ -126,15 +139,25 @@ public final class ChatShellComponent implements UiComponent {
         SessionId activeId = active == null ? null : active.id();
         for (AgentSessionHeader s : sessions) {
             String label = s.title() != null && !s.title().isBlank() ? s.title() : "New chat";
-            String badge = waiting.contains(s.id()) ? BADGE_NEEDS_INPUT
-                    : running.contains(s.id()) ? BADGE_RUNNING
-                    : ago(s.startedAt());
+            String badge = badge(s, waiting, running, unseen);
             menu.item(UiMenuItem.link("chat-" + s.id().value(), label, "/chat/sessions/" + s.id().value())
                     .icon(iconFor(s))
                     .badge(badge)
                     .selected(s.id().equals(activeId)));
         }
         return menu;
+    }
+
+    /**
+     * What a row says in place of its age, most urgent first: an answer is
+     * waited for, a turn is in flight, the chat has not been opened here yet.
+     */
+    static String badge(AgentSessionHeader s, java.util.Set<SessionId> waiting,
+                        java.util.Set<SessionId> running, java.util.Set<SessionId> unseen) {
+        if (waiting.contains(s.id())) return BADGE_NEEDS_INPUT;
+        if (running.contains(s.id())) return BADGE_RUNNING;
+        if (unseen.contains(s.id())) return BADGE_NEW;
+        return ago(s.startedAt());
     }
 
     /** The icon of the agent this conversation belongs to, or the generic one. */

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatLanding.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatLanding.java
@@ -1,0 +1,33 @@
+package ai.mindconnect.chatui.ui.controller;
+
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.runtime.domain.view.AgentSessionHeader;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Which chat {@code /chat} opens. The one this browser last had on screen,
+ * as long as the user still has it; otherwise the most recently started.
+ *
+ * <p>Opening the most recently started chat every time made the chat jump:
+ * a user who came back through the menu, or whose page re-requested
+ * {@code /chat}, landed in whatever chat had been started last — in another
+ * tab, over the REST API — instead of the one they were working in.
+ */
+final class ChatLanding {
+
+    private ChatLanding() {}
+
+    /**
+     * @param newestFirst the user's chats, most recently started first
+     * @param lastShown   the chat last on screen in this browser session, or {@code null}
+     * @return the chat to open; empty when the user has none
+     */
+    static Optional<SessionId> pick(List<? extends AgentSessionHeader> newestFirst, SessionId lastShown) {
+        if (lastShown != null && newestFirst.stream().anyMatch(chat -> lastShown.equals(chat.id()))) {
+            return Optional.of(lastShown);
+        }
+        return newestFirst.isEmpty() ? Optional.empty() : Optional.of(newestFirst.get(0).id());
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -359,23 +359,35 @@ public class ChatUiController {
         return value instanceof String id ? SessionId.of(id) : null;
     }
 
-    /** Notes the chat about to be shown, so coming back to the chat lands on it again. */
-    private static void rememberShown(SessionId sessionId) {
+    /** The browser session's record of the chats it has had on screen, and since when. */
+    static final String SEEN_CHATS = "mc.chat.seen";
+
+    /**
+     * Notes the chat about to be shown — so coming back to the chat lands on
+     * it again, and so it no longer counts as new — and returns what this
+     * browser session has now seen, for marking the chats started elsewhere.
+     */
+    private static SeenChats rememberShown(SessionId sessionId) {
         var attributes = org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
-        if (attributes != null) {
-            attributes.setAttribute(LAST_SHOWN_CHAT, sessionId.value(),
-                    org.springframework.web.context.request.RequestAttributes.SCOPE_SESSION);
-        }
+        if (attributes == null) return SeenChats.from(java.time.Instant.now()).withShown(sessionId);
+        int session = org.springframework.web.context.request.RequestAttributes.SCOPE_SESSION;
+        attributes.setAttribute(LAST_SHOWN_CHAT, sessionId.value(), session);
+        Object stored = attributes.getAttribute(SEEN_CHATS, session);
+        SeenChats seen = (stored instanceof SeenChats known ? known : SeenChats.from(java.time.Instant.now()))
+                .withShown(sessionId);
+        attributes.setAttribute(SEEN_CHATS, seen, session);
+        return seen;
     }
 
     private UiPage shell(AgentSession session,
                          List<? extends AgentSessionHeader> sessions) {
-        rememberShown(session.id());
+        var seen = rememberShown(session.id());
         var agent = agentResolver.resolve(session);
         var chat = buildChatPage(session, agent);
         var appShell = new ai.mindconnect.chatui.ui.component.ChatShellComponent(
                 sessions, session, agent.name(), chat.renderContent(), agentIcons())
                 .withActivity(runningSessions(sessions), waitingSessions(sessions))
+                .withUnseen(seen.unseen(sessions))
                 .render();
         var page = UiPage.of("/chat/sessions/" + session.id().value(), appShell);
         // A reload during a live turn reattaches instead of showing a dead form.

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatUiController.java
@@ -124,9 +124,8 @@ public class ChatUiController {
     public ResponseEntity<UiPage> home(@AuthenticationPrincipal OidcUser user) {
         // Headers for the sidebar; only the chat being shown is loaded whole.
         var sessions = sessionRepository.findHeadersByUser(UserId.of(userId(user)));
-        var latest = sessions.isEmpty()
-                ? java.util.Optional.<AgentSession>empty()
-                : sessionRepository.findById(sessions.get(0).id());
+        var latest = ChatLanding.pick(sessions, lastShownChat())
+                .flatMap(sessionRepository::findById);
         if (latest.isEmpty()) {
             // A GET does not create anything: a prefetch, a link preview or two
             // tabs opening at once would each leave an empty chat behind. The
@@ -345,8 +344,33 @@ public class ChatUiController {
     // ── Building the shell ──────────────────────────────────────────────────
 
     /** The chat app shell: history left, agent and title on top, conversation. */
+    /** The browser session's note of the chat it last had on screen. */
+    static final String LAST_SHOWN_CHAT = "mc.chat.lastShown";
+
+    /**
+     * The chat this browser session last had on screen, or {@code null}.
+     * Kept in the HTTP session rather than on the chat: it is where this
+     * browser was, not something about the conversation.
+     */
+    private static SessionId lastShownChat() {
+        var attributes = org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
+        Object value = attributes == null ? null : attributes.getAttribute(LAST_SHOWN_CHAT,
+                org.springframework.web.context.request.RequestAttributes.SCOPE_SESSION);
+        return value instanceof String id ? SessionId.of(id) : null;
+    }
+
+    /** Notes the chat about to be shown, so coming back to the chat lands on it again. */
+    private static void rememberShown(SessionId sessionId) {
+        var attributes = org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            attributes.setAttribute(LAST_SHOWN_CHAT, sessionId.value(),
+                    org.springframework.web.context.request.RequestAttributes.SCOPE_SESSION);
+        }
+    }
+
     private UiPage shell(AgentSession session,
                          List<? extends AgentSessionHeader> sessions) {
+        rememberShown(session.id());
         var agent = agentResolver.resolve(session);
         var chat = buildChatPage(session, agent);
         var appShell = new ai.mindconnect.chatui.ui.component.ChatShellComponent(

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/SeenChats.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/SeenChats.java
@@ -1,0 +1,50 @@
+package ai.mindconnect.chatui.ui.controller;
+
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.runtime.domain.view.AgentSessionHeader;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * What one browser session has had on screen of the chat, and since when:
+ * enough to tell a conversation started elsewhere — in another tab, over the
+ * REST API — from one the user has already looked at. Kept in the HTTP
+ * session; immutable, so the new value is stored back after every change.
+ *
+ * @param since when this browser session first showed a chat; chats started
+ *              before it are not new to it
+ * @param shown ids of the chats it has had on screen
+ */
+record SeenChats(Instant since, Set<String> shown) implements Serializable {
+
+    SeenChats {
+        shown = shown == null ? Set.of() : Set.copyOf(shown);
+    }
+
+    /** A browser session that begins now and has shown nothing yet. */
+    static SeenChats from(Instant since) {
+        return new SeenChats(since, Set.of());
+    }
+
+    /** The same record with {@code chat} on it. */
+    SeenChats withShown(SessionId chat) {
+        if (shown.contains(chat.value())) return this;
+        Set<String> more = new HashSet<>(shown);
+        more.add(chat.value());
+        return new SeenChats(since, more);
+    }
+
+    /** The chats started after this browser session began that it has not had on screen. */
+    Set<SessionId> unseen(List<? extends AgentSessionHeader> chats) {
+        return chats.stream()
+                .filter(chat -> chat.startedAt() != null && chat.startedAt().isAfter(since))
+                .filter(chat -> !shown.contains(chat.id().value()))
+                .map(AgentSessionHeader::id)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/css/chat-ui.css
@@ -320,6 +320,14 @@
     color: var(--sui-warning, #b45309);
     font-weight: 600;
 }
+/* A chat started elsewhere that this browser has not opened yet. */
+#chat-menu li.sui-menu-item.is-new .sui-menu-badge {
+    color: var(--sui-success, #15803d);
+    font-weight: 600;
+}
+#chat-menu li.sui-menu-item.is-new .sui-menu-label {
+    font-weight: 600;
+}
 
 /* The row's own badge steps aside so the two never overlap. */
 #chat-menu li.sui-menu-item:hover .sui-menu-badge,

--- a/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/js/chat-ui.js
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/resources/static/js/chat-ui.js
@@ -102,12 +102,18 @@
      */
     const BADGE_RUNNING = "running";
     const BADGE_NEEDS_INPUT = "needs input";
+    // A chat started elsewhere that this browser has not opened yet.
+    const BADGE_NEW = "new";
 
     function markRow(row) {
         const badge = row.querySelector(".sui-menu-badge");
         const text = badge ? badge.textContent.trim() : "";
         row.classList.toggle("is-running", text === BADGE_RUNNING);
         row.classList.toggle("needs-input", text === BADGE_NEEDS_INPUT);
+        row.classList.toggle("is-new", text === BADGE_NEW);
+        // Remembered on the row: a turn in the chat replaces the badge for a
+        // while, and "new" has to come back when it ends.
+        if (text === BADGE_NEW) row.dataset.unseen = "1";
     }
 
     function setBadge(row, text) {
@@ -122,11 +128,48 @@
         markRow(row);
     }
 
+    /*
+     * A chat started elsewhere — another tab, the REST API — has no row until
+     * the page is rendered again, so the user would not know it exists. It
+     * gets one now, cloned from a row the server rendered so the markup is
+     * the framework's, and marked new until it is opened (the server stops
+     * marking it once it has been on screen).
+     */
+    function addNewRow(sessionId) {
+        const menu = document.getElementById(MENU_ID);
+        if (!menu) return null;
+        const rows = Array.from(menu.querySelectorAll("li.sui-menu-item"))
+            .filter((r) => (r.dataset.id || "").startsWith("chat-") && r.dataset.id !== "chat-new"
+                && r.querySelector("a.sui-menu-link"));
+        if (rows.length === 0) return null; // nothing to model the row on; the next render shows it
+        const row = rows[0].cloneNode(true);
+        row.id = "chat-" + sessionId;
+        row.dataset.id = "chat-" + sessionId;
+        row.classList.remove("is-running", "needs-input", "is-new", "chat-row");
+        Array.from(row.classList).filter((c) => /active|selected/.test(c)).forEach((c) => row.classList.remove(c));
+        row.querySelector(".chat-row-menu")?.remove();
+        const link = row.querySelector("a.sui-menu-link");
+        const href = "/chat/sessions/" + sessionId;
+        link.setAttribute("href", href);
+        if (link.hasAttribute("data-href")) link.setAttribute("data-href", href);
+        link.removeAttribute("aria-current");
+        const label = row.querySelector(".sui-menu-label");
+        if (label) label.textContent = "New chat";
+        const tip = row.querySelector(".sui-menu-tip");
+        if (tip) tip.textContent = "New chat";
+        rows[0].parentNode.insertBefore(row, rows[0]);
+        setBadge(row, BADGE_NEW);
+        return row;
+    }
+
     /** One event of the user's stream, applied to the row it concerns. */
     function applyUserEvent(event) {
         if (!event || !event.sessionId) return;
         const row = document.getElementById("chat-" + event.sessionId);
-        if (!row) return;
+        if (!row) {
+            if (event.type === "session_started") addNewRow(event.sessionId);
+            return;
+        }
         switch (event.type) {
             case "turn_started":
                 setBadge(row, BADGE_RUNNING);
@@ -139,7 +182,7 @@
                 if (row.classList.contains("needs-input")) setBadge(row, BADGE_RUNNING);
                 break;
             case "turn_finished":
-                setBadge(row, "now");
+                setBadge(row, row.dataset.unseen ? BADGE_NEW : "now");
                 break;
             case "session_titled": {
                 const label = row.querySelector(".sui-menu-label");

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/ChatShellComponentBadgeTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/component/ChatShellComponentBadgeTest.java
@@ -1,0 +1,40 @@
+package ai.mindconnect.chatui.ui.component;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.domain.SessionStatus;
+import ai.mindconnect.agent.runtime.domain.view.AgentSessionHeader;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A history row says the most urgent thing about its chat in place of its age. */
+class ChatShellComponentBadgeTest {
+
+    private record Chat(SessionId id, Instant startedAt) implements AgentSessionHeader {
+        public AgentId agentDefinitionId() { return null; }
+        public UserId userId() { return null; }
+        public ConversationId conversationId() { return null; }
+        public String title() { return null; }
+        public SessionStatus status() { return null; }
+        public Instant completedAt() { return null; }
+        public SessionId parentSessionId() { return null; }
+    }
+
+    private final Chat chat = new Chat(SessionId.random(), Instant.now().minusSeconds(3 * 3600));
+    private final Set<SessionId> it = Set.of(chat.id());
+    private final Set<SessionId> none = Set.of();
+
+    @Test
+    void waitingBeatsRunningBeatsNewBeatsAge() {
+        assertThat(ChatShellComponent.badge(chat, it, it, it)).isEqualTo(ChatShellComponent.BADGE_NEEDS_INPUT);
+        assertThat(ChatShellComponent.badge(chat, none, it, it)).isEqualTo(ChatShellComponent.BADGE_RUNNING);
+        assertThat(ChatShellComponent.badge(chat, none, none, it)).isEqualTo(ChatShellComponent.BADGE_NEW);
+        assertThat(ChatShellComponent.badge(chat, none, none, none)).isEqualTo("3h");
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/controller/ChatLandingTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/controller/ChatLandingTest.java
@@ -1,0 +1,50 @@
+package ai.mindconnect.chatui.ui.controller;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.domain.SessionStatus;
+import ai.mindconnect.agent.runtime.domain.view.AgentSessionHeader;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Coming back to the chat lands where the user was, not on whatever was started last. */
+class ChatLandingTest {
+
+    private record Chat(SessionId id) implements AgentSessionHeader {
+        public AgentId agentDefinitionId() { return null; }
+        public UserId userId() { return null; }
+        public ConversationId conversationId() { return null; }
+        public String title() { return null; }
+        public SessionStatus status() { return null; }
+        public Instant startedAt() { return null; }
+        public Instant completedAt() { return null; }
+        public SessionId parentSessionId() { return null; }
+    }
+
+    private static final Chat STARTED_LAST = new Chat(SessionId.random());
+    private static final Chat WORKED_IN = new Chat(SessionId.random());
+    private static final List<Chat> NEWEST_FIRST = List.of(STARTED_LAST, WORKED_IN);
+
+    @Test
+    void theChatLastOnScreenWins_evenWhenAnotherWasStartedSince() {
+        assertThat(ChatLanding.pick(NEWEST_FIRST, WORKED_IN.id())).contains(WORKED_IN.id());
+    }
+
+    @Test
+    void withoutOneOnRecordTheMostRecentlyStartedOpens() {
+        assertThat(ChatLanding.pick(NEWEST_FIRST, null)).contains(STARTED_LAST.id());
+    }
+
+    @Test
+    void aChatThatIsGoneNoLongerCounts() {
+        assertThat(ChatLanding.pick(NEWEST_FIRST, SessionId.random()))
+                .as("deleted in another tab, or someone else's").contains(STARTED_LAST.id());
+        assertThat(ChatLanding.pick(List.of(), WORKED_IN.id())).isEmpty();
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/controller/SeenChatsTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/ui/controller/SeenChatsTest.java
@@ -1,0 +1,60 @@
+package ai.mindconnect.chatui.ui.controller;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.domain.SessionStatus;
+import ai.mindconnect.agent.runtime.domain.view.AgentSessionHeader;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A chat started elsewhere is new to this browser until it has been on screen here. */
+class SeenChatsTest {
+
+    private record Chat(SessionId id, Instant startedAt) implements AgentSessionHeader {
+        public AgentId agentDefinitionId() { return null; }
+        public UserId userId() { return null; }
+        public ConversationId conversationId() { return null; }
+        public String title() { return null; }
+        public SessionStatus status() { return null; }
+        public Instant completedAt() { return null; }
+        public SessionId parentSessionId() { return null; }
+    }
+
+    private static final Instant BEGAN = Instant.parse("2026-09-11T10:00:00Z");
+    private static final Chat BEFORE = new Chat(SessionId.random(), BEGAN.minusSeconds(3600));
+    private static final Chat ELSEWHERE = new Chat(SessionId.random(), BEGAN.plusSeconds(60));
+    private static final Chat HERE = new Chat(SessionId.random(), BEGAN.plusSeconds(30));
+
+    @Test
+    void aChatStartedElsewhereIsNewUntilItHasBeenOnScreen() {
+        SeenChats seen = SeenChats.from(BEGAN).withShown(HERE.id());
+        List<Chat> chats = List.of(ELSEWHERE, HERE, BEFORE);
+
+        assertThat(seen.unseen(chats)).containsExactly(ELSEWHERE.id());
+        assertThat(seen.withShown(ELSEWHERE.id()).unseen(chats)).isEmpty();
+    }
+
+    @Test
+    void theChatsFromBeforeThisBrowserBeganAreNotNewToIt() {
+        assertThat(SeenChats.from(BEGAN).unseen(List.of(BEFORE)))
+                .as("a first visit does not mark the whole history").isEmpty();
+        assertThat(SeenChats.from(BEGAN).unseen(List.of(new Chat(SessionId.random(), null)))).isEmpty();
+    }
+
+    @Test
+    void recordingAChatLeavesTheStoredValueAlone() {
+        SeenChats stored = SeenChats.from(BEGAN);
+        SeenChats after = stored.withShown(ELSEWHERE.id());
+
+        assertThat(stored.shown()).isEmpty();
+        assertThat(after.shown()).containsExactly(ELSEWHERE.id().value());
+        assertThat(after.withShown(ELSEWHERE.id())).as("showing it twice changes nothing").isSameAs(after);
+        assertThat(after.since()).isEqualTo(BEGAN);
+    }
+}


### PR DESCRIPTION
## Summary

The chat jumped to another conversation. `/chat` opened whichever conversation had been started last, so coming back through the *Chat* menu entry — or any other request of `/chat` — landed somewhere else as soon as a chat had been started since: in another tab, over the REST API. Reproduced in the app with a tracer on `history.pushState`: menu click → `GET /chat` → the newest session's page → the address bar moves.

- **Landing.** The chat notes in the HTTP session which conversation it last had on screen (every page render of a chat goes through `shell()`), and `/chat` opens that one while it still exists. `ChatLanding` makes the choice: the last one shown, otherwise the most recently started. A new browser session behaves as before.
- **Chats started elsewhere are marked *new*.** Staying put would hide a conversation that appeared meanwhile. `SeenChats`, also in the HTTP session, records since when this browser has been in the chat and which chats it has shown; a chat started after that and not yet opened here says **new** in its row (after *needs input* and *running*, before its age). The user stream adds the row the moment the chat starts — `chat-ui.js` clones a server-rendered row so the markup stays the framework's — and a finished turn in it does not turn the mark back into an age. Opening the chat clears it. A first visit marks nothing.

Deleting a chat still opens the most recently started one.

## Tests
- `ChatLandingTest`: the chat last on screen wins even when another was started since; without one the newest opens; a chat that is gone no longer counts.
- `SeenChatsTest`: a chat started elsewhere is new until shown; chats from before the browser session are not; recording is immutable.
- `ChatShellComponentBadgeTest`: needs input > running > new > age.
- chat-ui-rest, admin-ui-rest and admin-ui-app tests pass (74).
- Live, in the admin app with file persistence: in chat A, a chat B started over REST appeared at once at the top of the list with **new**, the page stayed on A; *Agents* → *Chat* returned to A with B still marked; opening B cleared the mark; *Agents* → *Chat* then returned to B.
- New manual test: `agents/doc/manual-tests/chat/landing-and-new-chats.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
