### PR TITLE
The upload smoke test opens its chat as the caller

### DIFF
--- a/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/ChatFileUploadSmokeTest.java
+++ b/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/ChatFileUploadSmokeTest.java
@@ -7,6 +7,7 @@ import ai.mindconnect.agent.runtime.port.out.AgentSessionRepository;
 import ai.mindconnect.agent.runtime.service.AgentSessionService;
 import ai.mindconnect.agentrest.service.SessionFileService;
 import ai.mindconnect.agent.UserId;
+import ai.mindconnect.chatui.service.SessionOwnership;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -103,9 +104,12 @@ class ChatFileUploadSmokeTest {
         assumeTrue(embeddingsUp(),
                 "LM Studio is not running at " + LM_STUDIO + " or no embeddings model is loaded");
 
-        // Any seeded agent will do — the upload path is agent-agnostic.
+        // Any seeded agent will do — the upload path is agent-agnostic. The
+        // session has to be the caller's: the chat endpoints refuse anyone
+        // else's, and with authentication off every request runs as the dev
+        // user.
         AgentDefinition agent = agents.findAll().stream().findFirst().orElseThrow();
-        AgentSession session = sessionService.openChat(agent.id(), UserId.of("upload-tester"));
+        AgentSession session = sessionService.openChat(agent.id(), UserId.of(SessionOwnership.ANONYMOUS_USER));
 
         String text = "Mindconnect upload smoke test.\n"
                 + "The secret ingredient of the test soup is paprika.\n".repeat(40);


### PR DESCRIPTION
## Summary

`ChatFileUploadSmokeTest` fails on main wherever an embeddings model is loaded in LM Studio (CI has none, so it skips there). It opened its chat session for `upload-tester` and then uploaded through `/chat/api/sessions/{id}/chat-files`, which runs as the dev user `mc_user` with authentication off. Since #65 the chat endpoints refuse a session that is not the caller's, so the upload answered 404 and the assertion on a 2xx status failed.

The check is right; the test was asking for someone else's chat. It now opens the session for `SessionOwnership.ANONYMOUS_USER`, the user every request runs as without a principal. Test code only, no changelog entry.

## Tests
- Reproduced on plain main (`a937f30`): the test fails at the 2xx assertion, with LM Studio and `text-embedding-nomic-embed-text-v1.5` loaded.
- With the change, on `94045a7`: `ChatFileUploadSmokeTest` passes (1 run, not skipped).
- No other test under `agents/server` opens a session for another user and then calls a chat endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
