### PR TITLE
Secure the REST API with Keycloak JWTs and personal API tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
   uploaded before this version have no creator: they stay readable by id but are
   no longer listed or deletable through the API. Transcription jobs are readable
   only by whoever submitted them.
+- **agents:** a chat's upload store (`session-…`) answers only to the chat's
+  user. `/api/vector-stores` and the admin UI's vector-store pages no longer
+  list, open, search, fill or delete another user's, and no store can be created
+  under a `session-` name. Ingesting a stored file takes only a file the caller
+  may read, and the admin UI's files tab lists and deletes files by the same
+  rules as `/api/files`.
 - **agents:** the OpenAI Responses API (`/v1`) runs as the authenticated caller
   instead of the fixed `mindconnect.responses.user-id`, which is removed (without
   authentication the dev user, `MC_DEV_USER`, takes its place). Another user's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ### Added
 
+- **agents:** the REST API (`/api/**`) and the OpenAI Responses API (`/v1/**`)
+  accept a bearer token once authentication is on: a Keycloak access token,
+  checked against `KC_ISSUER_URI` (`MC_JWT_AUDIENCES` can require an audience),
+  or a personal API token. A user creates API tokens on the new profile page
+  behind the avatar in the admin UI's header; the secret is shown once, only its
+  hash is stored, and a token can be revoked at any time. A request without an
+  accepted token gets `401` with a JSON body saying why. Before, the API only
+  answered to a browser session with a CSRF token — no program could call it on
+  a secured installation; now it takes bearer tokens only, the browser session
+  no longer counts there, and Swagger UI's **Authorize** takes a token for
+  *Try it out*. The agent server (`mc-agent-api-app`) is secured the
+  same way with `MC_AUTH_ENABLED=true`; it had no authentication at all. Users
+  are recorded on sign-in (`<data>/<namespace>/system/users/` or the `mc_user`
+  table). New modules: `mc-user-core`, `mc-user`, `mc-user-pg`,
+  `mc-agent-security`.
 - **agents:** MCP servers as registered tools. An operator registers a server
   under Admin → MCP Servers — a local process, a Docker image or a remote HTTP
   endpoint — tries it out with *Test connection*, and its tools appear in the
@@ -40,6 +55,30 @@ fresh empty one, so nothing has to be moved by hand at release time.
   a different description for this installation, without touching any agent
   definition. What an agent definition says about a tool still wins for that
   agent. Stored in `<data>/<namespace>/system/tool-settings.json`.
+
+### Changed
+
+- **agents:** the REST API answers only with what belongs to the caller.
+  `POST /api/sessions` takes `{agentId}` and the session belongs to the
+  authenticated user — a `userId` in the body is ignored; `GET /api/sessions`
+  lists the caller's sessions and ignores a `userId` parameter. Every
+  `/api/sessions/{id}/…` endpoint, the user stream (`/api/users/me/stream`) and
+  the workspace endpoints answer 404 for another user's data, exactly like for
+  data that does not exist. A client that passed another user's id to act for
+  them has to authenticate as that user instead.
+- **agents:** uploaded files remember who uploaded them (`creator`, a new
+  `mc_file` column added on start). `GET /api/files` lists only the caller's
+  files, only the uploader may delete one, and a file id in a chat message, a
+  session attach or a `/v1` request must be a file the caller may read. Files
+  uploaded before this version have no creator: they stay readable by id but are
+  no longer listed or deletable through the API. Transcription jobs are readable
+  only by whoever submitted them.
+- **agents:** the OpenAI Responses API (`/v1`) runs as the authenticated caller
+  instead of the fixed `mindconnect.responses.user-id`, which is removed (without
+  authentication the dev user, `MC_DEV_USER`, takes its place). Another user's
+  response or file answers `404 not_found`.
+- **agents:** the CLI's remote mode authenticates with an API token from
+  `MC_REMOTE_TOKEN` (`mindconnect.remote.token`) and no longer sends a user id.
 
 ### Removed
 

--- a/agents/adapter/postgres/mc-file-store-pg/src/main/java/ai/mindconnect/filestore/adapter/pg/PgFileStore.java
+++ b/agents/adapter/postgres/mc-file-store-pg/src/main/java/ai/mindconnect/filestore/adapter/pg/PgFileStore.java
@@ -2,6 +2,7 @@ package ai.mindconnect.filestore.adapter.pg;
 
 import ai.mindconnect.agent.EntityId;
 import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
 import ai.mindconnect.filestore.StoredFile;
@@ -32,6 +33,10 @@ import java.util.Optional;
  */
 public final class PgFileStore implements FileStore {
 
+    /**
+     * The {@code creator} column came later; the {@code ALTER} adds it to a
+     * table created before, whose rows then have no creator.
+     */
     private static final String DDL = """
             CREATE TABLE IF NOT EXISTS mc_file (
                 namespace    TEXT NOT NULL,
@@ -43,9 +48,10 @@ public final class PgFileStore implements FileStore {
                 content      BYTEA NOT NULL,
                 PRIMARY KEY (namespace, id)
             );
+            ALTER TABLE mc_file ADD COLUMN IF NOT EXISTS creator TEXT;
             """;
 
-    private static final String SELECT = "SELECT id, name, content_type, size, created_at FROM mc_file";
+    private static final String SELECT = "SELECT id, name, content_type, size, created_at, creator FROM mc_file";
 
     private final Sql sql;
     private final Namespace namespace;
@@ -59,22 +65,23 @@ public final class PgFileStore implements FileStore {
         this.namespace = Objects.requireNonNull(namespace, "namespace");
     }
 
-    /** Runs the idempotent DDL ({@code CREATE TABLE IF NOT EXISTS …}). */
+    /** Runs the idempotent DDL ({@code CREATE TABLE IF NOT EXISTS …}, {@code ADD COLUMN IF NOT EXISTS …}). */
     public PgFileStore initSchema() {
         sql.execute(DDL);
         return this;
     }
 
     @Override
-    public StoredFile save(String name, String contentType, InputStream content) throws IOException {
+    public StoredFile save(String name, String contentType, InputStream content, UserId creator) throws IOException {
         FileId id = FileId.of("file-" + EntityId.randomValue().replace("-", "").substring(0, 20));
         String safeName = Path.of(name == null || name.isBlank() ? "upload.bin" : name)
                 .getFileName().toString().replaceAll("[^A-Za-z0-9._ -]", "_");
         byte[] bytes = content.readAllBytes();
-        StoredFile file = new StoredFile(id, safeName, contentType, bytes.length, Instant.now());
-        sql.update("INSERT INTO mc_file (namespace, id, name, content_type, size, created_at, content) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                namespace.value(), id.value(), file.name(), file.contentType(), file.size(), file.createdAt(), bytes);
+        StoredFile file = new StoredFile(id, safeName, contentType, bytes.length, Instant.now(), creator);
+        sql.update("INSERT INTO mc_file (namespace, id, name, content_type, size, created_at, content, creator) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                namespace.value(), id.value(), file.name(), file.contentType(), file.size(), file.createdAt(), bytes,
+                creator == null ? null : creator.value());
         return file;
     }
 
@@ -106,7 +113,9 @@ public final class PgFileStore implements FileStore {
 
     private static StoredFile storedFile(Row row) throws SQLException {
         Long size = row.longValue("size");
+        String creator = row.string("creator");
         return new StoredFile(FileId.of(row.string("id")), row.string("name"),
-                row.string("content_type"), size == null ? 0L : size, row.instant("created_at"));
+                row.string("content_type"), size == null ? 0L : size, row.instant("created_at"),
+                creator == null ? null : UserId.of(creator));
     }
 }

--- a/agents/adapter/postgres/mc-file-store-pg/src/test/java/ai/mindconnect/filestore/adapter/pg/PgFileStoreTest.java
+++ b/agents/adapter/postgres/mc-file-store-pg/src/test/java/ai/mindconnect/filestore/adapter/pg/PgFileStoreTest.java
@@ -1,6 +1,8 @@
 package ai.mindconnect.filestore.adapter.pg;
 
 import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStoreBackend;
 import ai.mindconnect.filestore.StoredFile;
 import ai.mindconnect.jdbc.Sql;
@@ -32,6 +34,45 @@ class PgFileStoreTest {
         sql = Sql.of(requirePostgres());
         sql.execute("DROP TABLE IF EXISTS mc_file");
         store = new PgFileStore(sql, NS).initSchema();
+    }
+
+    @Test
+    void theCreatorIsStoredAndReadBack() throws IOException {
+        StoredFile alices = store.save("a.txt", "text/plain", new ByteArrayInputStream(new byte[] {1}),
+                UserId.of("alice"));
+        StoredFile nobodys = store.save("b.txt", "text/plain", new ByteArrayInputStream(new byte[] {2}));
+
+        assertThat(alices.creator()).isEqualTo(UserId.of("alice"));
+        assertThat(store.find(alices.id())).contains(alices);
+        assertThat(store.find(nobodys.id())).get().extracting(StoredFile::creator).isNull();
+        assertThat(store.list()).containsExactlyInAnyOrder(alices, nobodys);
+    }
+
+    @Test
+    void aTableFromBeforeCreatorsGainsTheColumnAndItsRowsHaveNone() throws IOException {
+        sql.execute("DROP TABLE IF EXISTS mc_file");
+        sql.execute("""
+                CREATE TABLE mc_file (
+                    namespace    TEXT NOT NULL,
+                    id           TEXT NOT NULL,
+                    name         TEXT NOT NULL,
+                    content_type TEXT,
+                    size         BIGINT NOT NULL,
+                    created_at   TIMESTAMPTZ NOT NULL,
+                    content      BYTEA NOT NULL,
+                    PRIMARY KEY (namespace, id)
+                );
+                INSERT INTO mc_file VALUES ('test', 'file-0123456789abcdef0123', 'old.txt', 'text/plain', 1,
+                                            now(), decode('01', 'hex'));
+                """);
+
+        PgFileStore upgraded = new PgFileStore(sql, NS).initSchema();
+
+        assertThat(upgraded.find(FileId.of("file-0123456789abcdef0123"))).get()
+                .extracting(StoredFile::name, StoredFile::creator).containsExactly("old.txt", null);
+        StoredFile fresh = upgraded.save("new.txt", "text/plain", new ByteArrayInputStream(new byte[] {2}),
+                UserId.of("bob"));
+        assertThat(upgraded.find(fresh.id())).get().extracting(StoredFile::creator).isEqualTo(UserId.of("bob"));
     }
 
     @Test

--- a/agents/adapter/postgres/mc-user-pg/pom.xml
+++ b/agents/adapter/postgres/mc-user-pg/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-user-pg</artifactId>
+    <name>mc-user-pg</name>
+    <packaging>jar</packaging>
+    <description>
+        Postgres-backed UserRepository and ApiTokenRepository: one JSONB document
+        per user and per token, the token hash indexed for lookup. Plain JDBC on
+        a DataSource via mc-jdbc — no Spring required.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/adapter/postgres/mc-user-pg/src/main/java/ai/mindconnect/user/adapter/pg/PgApiTokenRepository.java
+++ b/agents/adapter/postgres/mc-user-pg/src/main/java/ai/mindconnect/user/adapter/pg/PgApiTokenRepository.java
@@ -1,0 +1,88 @@
+package ai.mindconnect.user.adapter.pg;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.jdbc.DocumentTable;
+import ai.mindconnect.jdbc.Sql;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+import ai.mindconnect.user.port.out.ApiTokenRepository;
+
+import javax.sql.DataSource;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@link ApiTokenRepository} on Postgres. Each token is one row of
+ * {@code mc_api_token}, keyed by {@code (namespace, id)}, with the owner and
+ * the hash of the secret beside the document — the hash under a unique index,
+ * because authenticating a request is a lookup by it.
+ */
+public class PgApiTokenRepository implements ApiTokenRepository {
+
+    private static final String TABLE = "mc_api_token";
+
+    private final DocumentTable<ApiToken> tokens;
+    private final Sql sql;
+    private final Namespace namespace;
+
+    public PgApiTokenRepository(DataSource dataSource, Namespace namespace) {
+        this(Sql.of(dataSource), namespace);
+    }
+
+    /** Share a {@link Sql} — and with it the application's JSON mapper — with the other stores. */
+    public PgApiTokenRepository(Sql sql, Namespace namespace) {
+        this.sql = Objects.requireNonNull(sql, "sql");
+        this.namespace = Objects.requireNonNull(namespace, "namespace");
+        this.tokens = DocumentTable.of(ApiToken.class)
+                .table(TABLE)
+                .partitionKey("namespace", "TEXT", t -> namespace.value())
+                .id("id", "TEXT", t -> t.id().value())
+                .requiredColumn("user_id", "TEXT", t -> t.userId().value())
+                .requiredColumn("token_hash", "TEXT", ApiToken::tokenHash)
+                .uniqueIndex("namespace", "token_hash")
+                .index("namespace", "user_id")
+                .build(sql);
+    }
+
+    /** Runs the idempotent DDL ({@code CREATE TABLE IF NOT EXISTS …}). */
+    public PgApiTokenRepository initSchema() {
+        tokens.createSchema();
+        return this;
+    }
+
+    @Override
+    public void save(ApiToken token) {
+        tokens.save(token);
+    }
+
+    @Override
+    public Optional<ApiToken> findById(ApiTokenId id) {
+        return tokens.findById(namespace.value(), id.value());
+    }
+
+    @Override
+    public Optional<ApiToken> findByHash(String tokenHash) {
+        return tokens.findOne("WHERE namespace = ? AND token_hash = ?", namespace.value(), tokenHash);
+    }
+
+    @Override
+    public List<ApiToken> findByUser(UserId userId) {
+        return tokens.find("WHERE namespace = ? AND user_id = ? ORDER BY id", namespace.value(), userId.value());
+    }
+
+    @Override
+    public void deleteById(ApiTokenId id) {
+        tokens.deleteById(namespace.value(), id.value());
+    }
+
+    /** An {@code UPDATE}, never the upsert of {@link #save}: a row revoked in between stays gone. */
+    @Override
+    public void recordUse(ApiTokenId id, Instant at) {
+        findById(id).ifPresent(token -> sql.update(
+                "UPDATE " + TABLE + " SET doc = ?, updated_at = now() WHERE namespace = ? AND id = ?",
+                sql.json().jsonb(token.usedAt(at)), namespace.value(), id.value()));
+    }
+}

--- a/agents/adapter/postgres/mc-user-pg/src/main/java/ai/mindconnect/user/adapter/pg/PgUserRepository.java
+++ b/agents/adapter/postgres/mc-user-pg/src/main/java/ai/mindconnect/user/adapter/pg/PgUserRepository.java
@@ -1,0 +1,59 @@
+package ai.mindconnect.user.adapter.pg;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.jdbc.DocumentTable;
+import ai.mindconnect.jdbc.Sql;
+import ai.mindconnect.user.domain.User;
+import ai.mindconnect.user.port.out.UserRepository;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@link UserRepository} on Postgres. Each user is one row of {@code mc_user},
+ * keyed by {@code (namespace, id)}. The repository is bound to one namespace
+ * and every statement matches it.
+ */
+public class PgUserRepository implements UserRepository {
+
+    private final DocumentTable<User> users;
+    private final Namespace namespace;
+
+    public PgUserRepository(DataSource dataSource, Namespace namespace) {
+        this(Sql.of(dataSource), namespace);
+    }
+
+    /** Share a {@link Sql} — and with it the application's JSON mapper — with the other stores. */
+    public PgUserRepository(Sql sql, Namespace namespace) {
+        this.namespace = Objects.requireNonNull(namespace, "namespace");
+        this.users = DocumentTable.of(User.class)
+                .table("mc_user")
+                .partitionKey("namespace", "TEXT", u -> namespace.value())
+                .id("id", "TEXT", u -> u.id().value())
+                .build(sql);
+    }
+
+    /** Runs the idempotent DDL ({@code CREATE TABLE IF NOT EXISTS …}). */
+    public PgUserRepository initSchema() {
+        users.createSchema();
+        return this;
+    }
+
+    @Override
+    public Optional<User> findById(UserId id) {
+        return users.findById(namespace.value(), id.value());
+    }
+
+    @Override
+    public List<User> findAll() {
+        return users.find("WHERE namespace = ? ORDER BY id", namespace.value());
+    }
+
+    @Override
+    public void save(User user) {
+        users.save(user);
+    }
+}

--- a/agents/adapter/postgres/mc-user-pg/src/test/java/ai/mindconnect/user/adapter/pg/PgApiTokenRepositoryTest.java
+++ b/agents/adapter/postgres/mc-user-pg/src/test/java/ai/mindconnect/user/adapter/pg/PgApiTokenRepositoryTest.java
@@ -1,0 +1,73 @@
+package ai.mindconnect.user.adapter.pg;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.jdbc.Sql;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PgApiTokenRepositoryTest {
+
+    private static final Namespace NS = new Namespace("test");
+    private static final Instant AT = Instant.parse("2026-09-11T12:00:00Z");
+
+    private Sql sql;
+    private PgApiTokenRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        sql = Sql.of(TestDb.require());
+        sql.execute("DROP TABLE IF EXISTS mc_api_token");
+        repo = new PgApiTokenRepository(sql, NS).initSchema();
+    }
+
+    private static ApiToken token(String owner, String hash) {
+        return new ApiToken(ApiTokenId.random(), UserId.of(owner), "ci", hash, "mct_abcdef",
+                AT, AT.plusSeconds(86_400), null);
+    }
+
+    @Test
+    void aTokenIsFoundByIdHashAndOwner() {
+        ApiToken alices = token("alice", "hash-a");
+        ApiToken bobs = token("bob", "hash-b");
+        repo.save(alices);
+        repo.save(bobs);
+
+        assertThat(repo.findById(alices.id())).contains(alices);
+        assertThat(repo.findByHash("hash-b")).contains(bobs);
+        assertThat(repo.findByHash("nope")).isEmpty();
+        assertThat(repo.findByUser(UserId.of("alice"))).containsExactly(alices);
+    }
+
+    @Test
+    void aRepositoryBoundToAnotherNamespaceSeesNothing() {
+        ApiToken alices = token("alice", "hash-a");
+        repo.save(alices);
+        var other = new PgApiTokenRepository(sql, new Namespace("other")).initSchema();
+
+        assertThat(other.findById(alices.id())).isEmpty();
+        assertThat(other.findByHash("hash-a")).isEmpty();
+        assertThat(other.findByUser(UserId.of("alice"))).isEmpty();
+    }
+
+    @Test
+    void recordingAUseUpdatesATokenButNeverBringsARevokedOneBack() {
+        ApiToken alices = token("alice", "hash-a");
+        repo.save(alices);
+
+        Instant used = AT.plusSeconds(60);
+        repo.recordUse(alices.id(), used);
+        assertThat(repo.findById(alices.id())).map(ApiToken::lastUsedAt).contains(used);
+
+        repo.deleteById(alices.id());
+        repo.recordUse(alices.id(), used.plusSeconds(60));
+        assertThat(repo.findById(alices.id())).isEmpty();
+        assertThat(repo.findByHash("hash-a")).isEmpty();
+    }
+}

--- a/agents/adapter/postgres/mc-user-pg/src/test/java/ai/mindconnect/user/adapter/pg/PgUserRepositoryTest.java
+++ b/agents/adapter/postgres/mc-user-pg/src/test/java/ai/mindconnect/user/adapter/pg/PgUserRepositoryTest.java
@@ -1,0 +1,61 @@
+package ai.mindconnect.user.adapter.pg;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.jdbc.Sql;
+import ai.mindconnect.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PgUserRepositoryTest {
+
+    private static final Namespace NS = new Namespace("test");
+
+    private Sql sql;
+    private PgUserRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        sql = Sql.of(TestDb.require());
+        sql.execute("DROP TABLE IF EXISTS mc_user");
+        repo = new PgUserRepository(sql, NS).initSchema();
+    }
+
+    private static User user(String id) {
+        Instant at = Instant.parse("2026-09-11T12:00:00Z");
+        return new User(UserId.of(id), "sub-" + id, "https://auth/realms/mc", "Name " + id, id + "@example.com", at, at);
+    }
+
+    @Test
+    void aUserSurvivesTheRoundTripAndASaveReplacesIt() {
+        User alice = user("Alice.Smith@example.com");
+        repo.save(alice);
+        assertThat(repo.findById(alice.id())).contains(alice);
+
+        User renamed = new User(alice.id(), alice.subject(), alice.issuer(), "Alice", alice.email(),
+                alice.createdAt(), alice.lastLoginAt().plusSeconds(600));
+        repo.save(renamed);
+        assertThat(repo.findById(alice.id())).contains(renamed);
+        assertThat(repo.findAll()).containsExactly(renamed);
+    }
+
+    @Test
+    void aRepositoryBoundToAnotherNamespaceSeesNothing() {
+        repo.save(user("alice"));
+        var other = new PgUserRepository(sql, new Namespace("other")).initSchema();
+
+        assertThat(other.findById(UserId.of("alice"))).isEmpty();
+        assertThat(other.findAll()).isEmpty();
+    }
+
+    @Test
+    void initSchemaIsIdempotent() {
+        repo.save(user("alice"));
+        new PgUserRepository(Sql.of(TestDb.require()), NS).initSchema();
+        assertThat(repo.findAll()).hasSize(1);
+    }
+}

--- a/agents/adapter/postgres/mc-user-pg/src/test/java/ai/mindconnect/user/adapter/pg/TestDb.java
+++ b/agents/adapter/postgres/mc-user-pg/src/test/java/ai/mindconnect/user/adapter/pg/TestDb.java
@@ -1,0 +1,30 @@
+package ai.mindconnect.user.adapter.pg;
+
+import org.postgresql.ds.PGSimpleDataSource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * A real Postgres, or the test is skipped
+ * ({@code podman run -d -p 5433:5432 -e POSTGRES_PASSWORD=test pgvector/pgvector:pg17-trixie}).
+ */
+class TestDb {
+
+    private TestDb() {}
+
+    static DataSource require() {
+        var ds = new PGSimpleDataSource();
+        ds.setUrl(System.getenv().getOrDefault("MC_JDBC_TEST_URL", "jdbc:postgresql://localhost:5433/postgres"));
+        ds.setUser(System.getenv().getOrDefault("MC_JDBC_TEST_USER", "postgres"));
+        ds.setPassword(System.getenv().getOrDefault("MC_JDBC_TEST_PASSWORD", "test"));
+        try (Connection c = ds.getConnection()) {
+            assumeTrue(c.isValid(2));
+        } catch (Exception e) {
+            assumeTrue(false, "no Postgres reachable — skipping");
+        }
+        return ds;
+    }
+}

--- a/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/agentclient/RemoteAgentClient.java
+++ b/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/agentclient/RemoteAgentClient.java
@@ -75,21 +75,23 @@ public class RemoteAgentClient implements AgentClient {
 
     // --- RunSessionUseCase ---
 
+    /**
+     * The server opens the session for the user it authenticated, so
+     * {@code userId} — the owner in local mode — is not sent.
+     */
     @Override
     public AgentSession startSession(AgentId agentDefinitionId, UserId userId) {
-        String body = toJson(Map.of(
-                "agentId", agentDefinitionId.value(),
-                "userId", userId.value()));
+        String body = toJson(Map.of("agentId", agentDefinitionId.value()));
         Request req = new Request.Builder()
                 .url(baseUrl + "/api/sessions")
                 .post(RequestBody.create(body, JSON)).build();
         return execute(req, AgentSession.class);
     }
 
+    /** The authenticated user's sessions; {@code userId} is not sent, as for {@link #startSession}. */
     @Override
     public List<AgentSession> listSessions(AgentId agentDefinitionId, UserId userId) {
-        String url = baseUrl + "/api/sessions?agentId=" + agentDefinitionId.value()
-                + "&userId=" + userId.value();
+        String url = baseUrl + "/api/sessions?agentId=" + agentDefinitionId.value();
         Request req = new Request.Builder().url(url).get().build();
         return execute(req, new TypeReference<>() {
         });

--- a/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/agentclient/RemoteClientFactory.java
+++ b/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/agentclient/RemoteClientFactory.java
@@ -6,6 +6,12 @@ import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+/**
+ * Builds the clients for remote mode. With {@code mindconnect.remote.token}
+ * (or the environment variable {@code MC_REMOTE_TOKEN}) set, every request
+ * carries it as a bearer token: the server takes the user from that, not from
+ * anything the CLI puts in a request.
+ */
 @Component
 public class RemoteClientFactory {
 
@@ -15,10 +21,27 @@ public class RemoteClientFactory {
 
     public RemoteClientFactory(OkHttpClient okHttpClient,
                                ObjectMapper objectMapper,
-                               @Value("${mindconnect.remote.url:}") String remoteUrl) {
-        this.okHttpClient = okHttpClient;
+                               @Value("${mindconnect.remote.url:}") String remoteUrl,
+                               @Value("${mindconnect.remote.token:${MC_REMOTE_TOKEN:}}") String remoteToken) {
+        this.okHttpClient = withBearer(okHttpClient, remoteToken);
         this.objectMapper = objectMapper;
         this.remoteUrl = remoteUrl;
+    }
+
+    /**
+     * The shared client, plus an {@code Authorization} header when there is a
+     * token. A derived client, not the bean itself: the bean also serves the
+     * LLM gateways of local mode, which must not see the token.
+     */
+    static OkHttpClient withBearer(OkHttpClient client, String token) {
+        if (token == null || token.isBlank()) {
+            return client;
+        }
+        String header = "Bearer " + token.trim();
+        return client.newBuilder()
+                .addInterceptor(chain -> chain.proceed(chain.request().newBuilder()
+                        .header("Authorization", header).build()))
+                .build();
     }
 
     public String getRemoteUrl() {

--- a/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/main/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackend.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Backend adapter: the protocol surface implemented against the Mindconnect
@@ -55,6 +56,14 @@ import java.util.function.Consumer;
  * ({@link #sessions()}, {@link #responses()}, {@link #conversations()})
  * because the interfaces' {@code get} methods collide on one class.
  *
+ * <p>Everything is the caller's own. Sessions open for the caller, files are
+ * stored as the caller's, and a session, response or file of someone else's
+ * is not found — the answer a missing one gets. The caller is either fixed
+ * (the {@code String} constructor: an embedding, the CLI) or asked on every
+ * operation (the {@code Supplier} one: a server, whose caller is the current
+ * request's). {@link #conversations()} is not scoped: the runtime cannot map a
+ * conversation back to its session yet, and no served endpoint exposes it.
+ *
  * <p>v1 mapping notes: ids are the runtime's id values as strings; responses are
  * tracked in-memory (a restart forgets them — the conversation keeps the
  * durable truth); {@code Conversations.items} maps the legacy Message format
@@ -66,23 +75,58 @@ public final class AgentRuntimeBackend {
     private final AgentSessionService sessionService;
     private final AgentDefinitionRepository definitions;
     private final ConversationManager conversationManager;
-    private final UserId userId;
+    private final Supplier<UserId> caller;
 
-    private final Map<String, ResponseAssembler> assemblers = new ConcurrentHashMap<>();
-    private final Map<String, ChatTurnHandle> handles = new ConcurrentHashMap<>();
+    private final Map<String, ResponseAssembler> assemblers;
+    private final Map<String, ChatTurnHandle> handles;
+    /**
+     * Whose session each response ran in. A session's owner never changes, so
+     * it is noted once at creation — a stream refreshes its response on every
+     * event, and must not read the session each time to learn this.
+     */
+    private final Map<String, UserId> owners;
 
     private ai.mindconnect.filestore.FileStore fileStore;
     private FileAttacher fileAttacher;
 
 
+    /** A backend that always acts for {@code userId}. */
     public AgentRuntimeBackend(AgentChatService chat, AgentSessionService sessionService,
                                AgentDefinitionRepository definitions,
                                ConversationManager conversationManager, String userId) {
+        this(chat, sessionService, definitions, conversationManager, fixed(UserId.of(userId)));
+    }
+
+    /**
+     * A backend that acts for whoever {@code caller} names, asked on every
+     * operation — a server passes the authenticated user of the current
+     * request. The supplier may throw to refuse a request without one.
+     */
+    public AgentRuntimeBackend(AgentChatService chat, AgentSessionService sessionService,
+                               AgentDefinitionRepository definitions,
+                               ConversationManager conversationManager, Supplier<UserId> caller) {
+        this(chat, sessionService, definitions, conversationManager, caller,
+                new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
+    }
+
+    private AgentRuntimeBackend(AgentChatService chat, AgentSessionService sessionService,
+                                AgentDefinitionRepository definitions,
+                                ConversationManager conversationManager, Supplier<UserId> caller,
+                                Map<String, ResponseAssembler> assemblers,
+                                Map<String, ChatTurnHandle> handles,
+                                Map<String, UserId> owners) {
         this.chat = chat;
         this.sessionService = sessionService;
         this.definitions = definitions;
         this.conversationManager = conversationManager;
-        this.userId = UserId.of(userId);
+        this.caller = caller;
+        this.assemblers = assemblers;
+        this.handles = handles;
+        this.owners = owners;
+    }
+
+    private static Supplier<UserId> fixed(UserId user) {
+        return () -> user;
     }
 
     /**
@@ -95,6 +139,26 @@ public final class AgentRuntimeBackend {
         this.fileStore = fileStore;
         this.fileAttacher = fileAttacher;
         return this;
+    }
+
+    /** Who is calling now, as the caller supplier answers. */
+    public UserId currentUser() {
+        return caller.get();
+    }
+
+    /**
+     * This backend acting for {@code user}, whatever the caller supplier would
+     * say — the same responses, the same files. For work that outlives the
+     * request thread: a stream's callbacks run on the channel's thread, where a
+     * supplier that reads the current request has nobody to answer with. Ask
+     * {@link #currentUser()} on the request thread and give the callbacks this.
+     */
+    public AgentRuntimeBackend actingFor(UserId user) {
+        var view = new AgentRuntimeBackend(chat, sessionService, definitions, conversationManager,
+                fixed(user), assemblers, handles, owners);
+        view.fileStore = fileStore;
+        view.fileAttacher = fileAttacher;
+        return view;
     }
 
     // ── The three protocol surfaces, by composition ─────────────────────────
@@ -111,6 +175,29 @@ public final class AgentRuntimeBackend {
 
     public Response create(ResponseRequest request) { return responsesApi.create(request); }
 
+    /**
+     * The session, if it exists and is the caller's. A session id travels in
+     * URLs and client state, so it opens nothing on its own.
+     */
+    private Optional<AgentSession> ownedSession(String sessionId) {
+        UserId user = caller.get();
+        try {
+            return Optional.of(sessionService.findSession(SessionId.of(sessionId)))
+                    .filter(session -> user.equals(session.userId()));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    /** The response's assembler, if the response ran in one of the caller's sessions. */
+    private Optional<ResponseAssembler> ownedResponse(String responseId) {
+        UserId user = caller.get();
+        if (responseId == null || !user.equals(owners.get(responseId))) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(assemblers.get(responseId));
+    }
+
     private final Sessions sessionsApi = new Sessions() {
 
         @Override
@@ -118,7 +205,7 @@ public final class AgentRuntimeBackend {
             AgentDefinition def = definitions.findByName(agentName)
                     .orElseThrow(() -> new RuntimeBackendException(
                             "No agent named '" + agentName + "'"));
-            AgentSession session = sessionService.openChat(def.id(), userId);
+            AgentSession session = sessionService.openChat(def.id(), caller.get());
             return toProtocol(session, agentName);
         }
 
@@ -131,14 +218,11 @@ public final class AgentRuntimeBackend {
 
         @Override
         public Optional<Session> get(String sessionId) {
-            try {
-                AgentSession session = sessionService.findSession(SessionId.of(sessionId));
+            return ownedSession(sessionId).map(session -> {
                 String agentName = definitions.findById(session.agentDefinitionId())
                         .map(AgentDefinition::name).orElse("unknown");
-                return Optional.of(toProtocol(session, agentName));
-            } catch (Exception e) {
-                return Optional.empty();
-            }
+                return toProtocol(session, agentName);
+            });
         }
 
         private Session toProtocol(AgentSession session, String agentName) {
@@ -155,13 +239,15 @@ public final class AgentRuntimeBackend {
                 throw new RuntimeBackendException("clientTools are not supported by the "
                         + "runtime backend yet — register tools on the agent definition");
             }
-            AgentSession session = sessionService.findSession(SessionId.of(request.sessionId()));
+            AgentSession session = ownedSession(request.sessionId()).orElseThrow(() ->
+                    new RuntimeBackendException("Unknown session " + request.sessionId()));
             String agentName = definitions.findById(session.agentDefinitionId())
                     .map(AgentDefinition::name).orElse("unknown");
 
             String responseId = "resp_" + UUID.randomUUID();
             ResponseAssembler assembler = new ResponseAssembler(responseId,
                     session.conversationId().value(), request.sessionId(), agentName);
+            owners.put(responseId, session.userId());
             assemblers.put(responseId, assembler);
 
             ChatTurnHandle handle = chat.submitChat(
@@ -188,21 +274,22 @@ public final class AgentRuntimeBackend {
 
         @Override
         public Optional<Response> get(String responseId) {
-            return Optional.ofNullable(assemblers.get(responseId)).map(ResponseAssembler::snapshot);
+            return ownedResponse(responseId).map(ResponseAssembler::snapshot);
         }
 
         @Override
         public boolean cancel(String responseId) {
+            if (ownedResponse(responseId).isEmpty()) {
+                return false;
+            }
             ChatTurnHandle handle = handles.get(responseId);
             return handle != null && handle.cancel();
         }
 
         @Override
         public Subscription subscribe(SubscribeRequest request, Consumer<ResponseEvent> consumer) {
-            ResponseAssembler assembler = assemblers.get(request.responseId());
-            if (assembler == null) {
-                throw new RuntimeBackendException("Unknown response " + request.responseId());
-            }
+            ResponseAssembler assembler = ownedResponse(request.responseId()).orElseThrow(() ->
+                    new RuntimeBackendException("Unknown response " + request.responseId()));
             // includeChildren: sub-agent events are folded into the parent's
             // items by the assembler (v1) — nothing separate to merge yet.
             long afterSeq = request.afterSeq() == Long.MAX_VALUE ? Long.MAX_VALUE : request.afterSeq();
@@ -275,24 +362,31 @@ public final class AgentRuntimeBackend {
             return "image-" + UUID.randomUUID().toString().substring(0, 8) + extension;
         }
 
-        /** The stored file behind a media source: looked up (FileId) or stored now (Inline). */
+        /**
+         * The stored file behind a media source: looked up (FileId) or stored
+         * now (Inline). A file the caller may not read is unknown — attaching
+         * it would put its content in front of the caller's model.
+         */
         private ai.mindconnect.filestore.StoredFile resolve(ContentPart.MediaSource source, String name) {
             requireFiles();
+            UserId user = caller.get();
             return switch (source) {
                 case ContentPart.MediaSource.FileId f -> fileStore.find(ai.mindconnect.filestore.FileId.of(f.fileId()))
+                        .filter(stored -> stored.readableBy(user))
                         .orElseThrow(() -> new RuntimeBackendException(
                                 "Unknown file id " + f.fileId() + " — upload via files() first"));
-                case ContentPart.MediaSource.Inline in -> storeInline(name, in);
+                case ContentPart.MediaSource.Inline in -> storeInline(name, in, user);
                 case ContentPart.MediaSource.Url u -> throw new RuntimeBackendException(
                         "Url media sources are not supported by the runtime backend yet");
             };
         }
 
         private ai.mindconnect.filestore.StoredFile storeInline(String name,
-                                                                ContentPart.MediaSource.Inline in) {
+                                                                ContentPart.MediaSource.Inline in,
+                                                                UserId user) {
             try {
                 byte[] bytes = java.util.Base64.getDecoder().decode(in.base64Data());
-                return fileStore.save(name, in.mediaType(), new ByteArrayInputStream(bytes));
+                return fileStore.save(name, in.mediaType(), new ByteArrayInputStream(bytes), user);
             } catch (Exception e) {
                 throw new RuntimeBackendException("Failed to store inline document: " + e.getMessage(), e);
             }
@@ -304,18 +398,23 @@ public final class AgentRuntimeBackend {
         @Override
         public StoredFile upload(String filename, String mediaType, byte[] content) {
             requireFiles();
+            UserId user = caller.get();
             try {
-                var stored = fileStore.save(filename, mediaType, new ByteArrayInputStream(content));
+                var stored = fileStore.save(filename, mediaType, new ByteArrayInputStream(content), user);
                 return toProtocolFile(stored);
             } catch (Exception e) {
                 throw new RuntimeBackendException("Upload failed: " + e.getMessage(), e);
             }
         }
 
+        /** The caller's file — or one stored before creators were recorded, which anyone may read by id. */
         @Override
         public Optional<StoredFile> get(String fileId) {
             requireFiles();
-            return fileStore.find(ai.mindconnect.filestore.FileId.of(fileId)).map(AgentRuntimeBackend::toProtocolFile);
+            UserId user = caller.get();
+            return fileStore.find(ai.mindconnect.filestore.FileId.of(fileId))
+                    .filter(stored -> stored.readableBy(user))
+                    .map(AgentRuntimeBackend::toProtocolFile);
         }
     };
 

--- a/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackendOwnershipTest.java
+++ b/agents/core/mc-agent-protocol-mc-runtime/src/test/java/ai/mindconnect/agent/protocol/runtime/AgentRuntimeBackendOwnershipTest.java
@@ -1,0 +1,121 @@
+package ai.mindconnect.agent.protocol.runtime;
+
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.builder.AgentRuntime;
+import ai.mindconnect.agent.builder.AgentRuntimeBuilder;
+import ai.mindconnect.agent.protocol.Response;
+import ai.mindconnect.agent.protocol.Session;
+import ai.mindconnect.agent.protocol.StoredFile;
+import ai.mindconnect.agent.protocol.api.ResponseRequest;
+import ai.mindconnect.agent.protocol.api.SubscribeRequest;
+import ai.mindconnect.agent.protocol.item.ConversationItem;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigId;
+import ai.mindconnect.llm.domain.LlmConfigType;
+import ai.mindconnect.llm.domain.LlmProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The backend acts for its caller: another user's session, response or file
+ * is not found, the same answer a missing one gets. No model answers here —
+ * the turns fail against an address nothing listens on, which leaves the
+ * responses in place to be asked about.
+ */
+class AgentRuntimeBackendOwnershipTest {
+
+    private static final UserId ALICE = UserId.of("alice");
+    private static final UserId BOB = UserId.of("bob");
+
+    private AgentRuntime runtime;
+    private final AtomicReference<UserId> caller = new AtomicReference<>(ALICE);
+    private AgentRuntimeBackend backend;
+
+    @BeforeEach
+    void setUp() {
+        runtime = AgentRuntimeBuilder.useInMemoryPersistence()
+                .llmConfig(new LlmConfig(LlmConfigId.random(), "chat", LlmProvider.LM_STUDIO, "none",
+                        "http://127.0.0.1:9", "none", 0.2, 256, Map.of(), 8_000,
+                        false, null, null, null, LlmConfigType.CHAT, null))
+                .defaultLlmConfigName("chat")
+                .build();
+        runtime.agentDefinitions().save(AgentDefinition.create("helper", "Helps.", "You help.", null, "chat"));
+        backend = new AgentRuntimeBackend(runtime.chatService(), runtime.sessionService(),
+                runtime.agentDefinitions(), runtime.conversationManager(), caller::get)
+                .withFiles(runtime.fileStore(), runtime::attachStored);
+    }
+
+    @AfterEach
+    void tearDown() {
+        runtime.close();
+    }
+
+    @Test
+    void aSessionOpensForTheCurrentCaller() {
+        caller.set(BOB);
+
+        Session session = backend.open("helper");
+
+        assertThat(runtime.sessionService().findSession(SessionId.of(session.id())).userId()).isEqualTo(BOB);
+    }
+
+    @Test
+    void anotherUsersSessionResponseAndFileAreNotFound() {
+        Session alices = backend.open("helper");
+        Response response = backend.responses().create(new ResponseRequest(alices.id(),
+                List.of(ConversationItem.Message.user("Hello")), true, List.of()));
+        StoredFile alicesFile = backend.files().upload("notes.txt", "text/plain",
+                "private".getBytes(StandardCharsets.UTF_8));
+
+        caller.set(BOB);
+        assertThat(backend.sessions().get(alices.id())).isEmpty();
+        assertThat(backend.responses().get(response.id())).isEmpty();
+        assertThat(backend.responses().cancel(response.id())).isFalse();
+        assertThatThrownBy(() -> backend.responses().subscribe(SubscribeRequest.replay(response.id()), e -> { }))
+                .isInstanceOf(RuntimeBackendException.class);
+        assertThatThrownBy(() -> backend.responses().create(new ResponseRequest(alices.id(),
+                List.of(ConversationItem.Message.user("Me too")), true, List.of())))
+                .isInstanceOf(RuntimeBackendException.class);
+        assertThat(backend.files().get(alicesFile.id())).isEmpty();
+
+        caller.set(ALICE);
+        assertThat(backend.sessions().get(alices.id())).isPresent();
+        assertThat(backend.responses().get(response.id())).isPresent();
+        assertThat(backend.files().get(alicesFile.id())).isPresent();
+    }
+
+    @Test
+    void aBoundViewKeepsActingForItsUserWhateverTheSupplierSays() {
+        Session alices = backend.open("helper");
+        Response response = backend.responses().create(new ResponseRequest(alices.id(),
+                List.of(ConversationItem.Message.user("Hello")), true, List.of()));
+        AgentRuntimeBackend alicesView = backend.actingFor(backend.currentUser());
+
+        caller.set(BOB);
+
+        assertThat(alicesView.responses().get(response.id())).isPresent();
+        assertThat(backend.responses().get(response.id())).isEmpty();
+    }
+
+    @Test
+    void aFileWithoutCreatorStaysReadableById() throws Exception {
+        var old = runtime.fileStore().save("old.txt", "text/plain",
+                new ByteArrayInputStream("old".getBytes(StandardCharsets.UTF_8)));
+
+        caller.set(BOB);
+
+        assertThat(backend.files().get(old.id().value())).isPresent();
+    }
+}

--- a/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/filestore/FileStorePartContentReaderTest.java
+++ b/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/filestore/FileStorePartContentReaderTest.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.runtime.adapter.filestore;
 
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.agent.runtime.port.out.PartContentReader;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
@@ -27,9 +28,10 @@ class FileStorePartContentReaderTest {
         boolean failReads;
 
         @Override
-        public StoredFile save(String name, String contentType, InputStream content) throws IOException {
+        public StoredFile save(String name, String contentType, InputStream content, UserId creator)
+                throws IOException {
             byte[] data = content.readAllBytes();
-            StoredFile file = new StoredFile(FileId.random(), name, contentType, data.length, Instant.now());
+            StoredFile file = new StoredFile(FileId.random(), name, contentType, data.length, Instant.now(), creator);
             files.put(file.id(), file);
             bytes.put(file.id(), data);
             return file;

--- a/agents/core/mc-user-core/pom.xml
+++ b/agents/core/mc-user-core/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-user-core</artifactId>
+    <name>mc-user-core</name>
+    <packaging>jar</packaging>
+    <description>
+        The users of an installation and their personal API tokens: the domain,
+        the ports (UserRepository, ApiTokenRepository) and the services that
+        record logins and issue, check and revoke tokens. No framework and no
+        storage — the adapters live in mc-user (file, memory) and mc-user-pg.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-domain</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/domain/ApiToken.java
+++ b/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/domain/ApiToken.java
@@ -1,0 +1,49 @@
+package ai.mindconnect.user.domain;
+
+import ai.mindconnect.agent.UserId;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A personal API token: a secret its owner hands to a program so that the
+ * program acts as the owner against the REST API. Only the SHA-256 hash of the
+ * secret is stored; the secret itself is shown once, when the token is issued.
+ *
+ * @param id         addresses the token for listing and revoking; never authenticates
+ * @param userId     whose token it is — a request authenticated by it runs as this user
+ * @param name       what the owner called it ("CI", "laptop")
+ * @param tokenHash  hex SHA-256 of the secret
+ * @param hint       the start of the secret, enough to recognise it in a list
+ * @param createdAt  when it was issued
+ * @param expiresAt  from this instant on it no longer authenticates; null = no expiry
+ * @param lastUsedAt the last successful authentication, to the resolution the service
+ *                   records it with; null = never used
+ */
+public record ApiToken(
+        ApiTokenId id,
+        UserId userId,
+        String name,
+        String tokenHash,
+        String hint,
+        Instant createdAt,
+        Instant expiresAt,
+        Instant lastUsedAt
+) {
+
+    public ApiToken {
+        Objects.requireNonNull(id, "An API token needs an id");
+        Objects.requireNonNull(userId, "An API token needs an owner");
+        Objects.requireNonNull(tokenHash, "An API token needs a hash");
+    }
+
+    /** Whether the token no longer authenticates at {@code now}. */
+    public boolean expiredAt(Instant now) {
+        return expiresAt != null && !now.isBefore(expiresAt);
+    }
+
+    /** The same token, last used at {@code at}. */
+    public ApiToken usedAt(Instant at) {
+        return new ApiToken(id, userId, name, tokenHash, hint, createdAt, expiresAt, at);
+    }
+}

--- a/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/domain/ApiTokenId.java
+++ b/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/domain/ApiTokenId.java
@@ -1,0 +1,31 @@
+package ai.mindconnect.user.domain;
+
+import ai.mindconnect.agent.EntityId;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Identifies an API token for listing and revoking. It never authenticates —
+ * that is the secret's job. See {@link EntityId}.
+ */
+public record ApiTokenId(@JsonValue String value) implements EntityId {
+
+    public ApiTokenId {
+        EntityId.check(value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ApiTokenId of(String value) {
+        return new ApiTokenId(value);
+    }
+
+    /** A fresh, unique id. */
+    public static ApiTokenId random() {
+        return new ApiTokenId(EntityId.randomValue());
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/domain/User.java
+++ b/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/domain/User.java
@@ -1,0 +1,44 @@
+package ai.mindconnect.user.domain;
+
+import ai.mindconnect.agent.UserId;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A person who signs in to this installation. The id is the value every
+ * session, workspace and task already carries — the identity provider's
+ * {@code preferred_username} by default — so the record sits beside the
+ * existing data instead of keying it differently.
+ *
+ * <p>Subject and issuer are the provider's stable identity. They are kept so
+ * that a later change of the id claim can map old ids to new ones.
+ *
+ * @param id          the user id, as sessions and workspaces carry it
+ * @param subject     the provider's {@code sub}; null when unknown (the dev user)
+ * @param issuer      the provider's issuer; null when unknown
+ * @param displayName a name to show; null when the provider sent none
+ * @param email       null when the provider sent none
+ * @param createdAt   when the installation first saw the user
+ * @param lastLoginAt when the user last signed in or called the API, to the resolution
+ *                    {@code UserService} records it with
+ */
+public record User(
+        UserId id,
+        String subject,
+        String issuer,
+        String displayName,
+        String email,
+        Instant createdAt,
+        Instant lastLoginAt
+) {
+
+    public User {
+        Objects.requireNonNull(id, "A user needs an id");
+    }
+
+    /** The name to show: the display name, else the id. */
+    public String label() {
+        return displayName != null && !displayName.isBlank() ? displayName : id.value();
+    }
+}

--- a/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/port/out/ApiTokenRepository.java
+++ b/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/port/out/ApiTokenRepository.java
@@ -1,0 +1,37 @@
+package ai.mindconnect.user.port.out;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Issued API tokens, by id and by the hash of their secret. An adapter is
+ * bound to one namespace when it is built; nothing here names it.
+ */
+public interface ApiTokenRepository {
+
+    /** Inserts or replaces the token with this id. */
+    void save(ApiToken token);
+
+    Optional<ApiToken> findById(ApiTokenId id);
+
+    /** The token whose secret hashes to {@code tokenHash}; empty when none does. */
+    Optional<ApiToken> findByHash(String tokenHash);
+
+    /** A user's tokens, in no particular order. */
+    List<ApiToken> findByUser(UserId userId);
+
+    /** Removes the token; a missing id is not an error. */
+    void deleteById(ApiTokenId id);
+
+    /**
+     * Records that the token authenticated at {@code at}. Unlike
+     * {@link #save}, this never creates a token: one revoked while a request
+     * was using it stays revoked.
+     */
+    void recordUse(ApiTokenId id, Instant at);
+}

--- a/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/port/out/UserRepository.java
+++ b/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/port/out/UserRepository.java
@@ -1,0 +1,22 @@
+package ai.mindconnect.user.port.out;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.User;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The users of this installation. An adapter is bound to one namespace when it
+ * is built; nothing here names it.
+ */
+public interface UserRepository {
+
+    Optional<User> findById(UserId id);
+
+    /** Every user, in no particular order. */
+    List<User> findAll();
+
+    /** Inserts or replaces the user with this id. */
+    void save(User user);
+}

--- a/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/service/ApiTokenService.java
+++ b/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/service/ApiTokenService.java
@@ -1,0 +1,154 @@
+package ai.mindconnect.user.service;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+import ai.mindconnect.user.port.out.ApiTokenRepository;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Issues, checks and revokes personal API tokens.
+ *
+ * <p>A secret is {@value #PREFIX} followed by 32 random bytes, base64url. With
+ * that much entropy a plain SHA-256 is the right stored form: nobody can guess
+ * a secret from its hash, and a request is authenticated by one lookup of the
+ * hash — a slow password hash would buy nothing and cost every API call. The
+ * secret leaves this class exactly once, in {@link Issued}.
+ */
+public class ApiTokenService {
+
+    /** Every secret starts with this, so a request can tell an API token from a JWT at a glance. */
+    public static final String PREFIX = "mct_";
+
+    /** {@link ApiToken#lastUsedAt()} is written at most this often per token. */
+    public static final Duration USE_RESOLUTION = Duration.ofMinutes(1);
+
+    /** The longest name a token may have. */
+    public static final int MAX_NAME_LENGTH = 100;
+
+    private static final int SECRET_BYTES = 32;
+    private static final int HINT_LENGTH = PREFIX.length() + 6;
+
+    private final ApiTokenRepository tokens;
+    private final Clock clock;
+    private final SecureRandom random = new SecureRandom();
+
+    /** A freshly issued token and its secret — the only time the secret is available. */
+    public record Issued(ApiToken token, String secret) {}
+
+    public ApiTokenService(ApiTokenRepository tokens) {
+        this(tokens, Clock.systemUTC());
+    }
+
+    public ApiTokenService(ApiTokenRepository tokens, Clock clock) {
+        this.tokens = Objects.requireNonNull(tokens, "tokens");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /**
+     * Issues a token for {@code owner}.
+     *
+     * @param name      what the owner calls it; required, at most {@value #MAX_NAME_LENGTH} characters
+     * @param expiresAt when it stops working; null for never, otherwise in the future
+     * @throws IllegalArgumentException for a blank or overlong name or an expiry that has passed
+     */
+    public Issued issue(UserId owner, String name, Instant expiresAt) {
+        Objects.requireNonNull(owner, "owner");
+        String label = name == null ? "" : name.strip();
+        if (label.isEmpty()) {
+            throw new IllegalArgumentException("A token needs a name");
+        }
+        if (label.length() > MAX_NAME_LENGTH) {
+            throw new IllegalArgumentException("A token name has at most " + MAX_NAME_LENGTH + " characters");
+        }
+        Instant now = clock.instant();
+        if (expiresAt != null && !expiresAt.isAfter(now)) {
+            throw new IllegalArgumentException("A token cannot expire in the past");
+        }
+        byte[] bytes = new byte[SECRET_BYTES];
+        random.nextBytes(bytes);
+        String secret = PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        ApiToken token = new ApiToken(ApiTokenId.random(), owner, label, hash(secret),
+                secret.substring(0, HINT_LENGTH), now, expiresAt, null);
+        tokens.save(token);
+        return new Issued(token, secret);
+    }
+
+    /** The owner's tokens, newest first. */
+    public List<ApiToken> list(UserId owner) {
+        return tokens.findByUser(owner).stream()
+                .sorted(Comparator.comparing(ApiToken::createdAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .toList();
+    }
+
+    /**
+     * Revokes one of the owner's tokens.
+     *
+     * @return false when there is no such token or it belongs to someone else — the two
+     *         are deliberately indistinguishable to the caller
+     */
+    public boolean revoke(UserId owner, ApiTokenId id) {
+        Optional<ApiToken> token = tokens.findById(id);
+        if (token.isEmpty() || !token.get().userId().equals(owner)) {
+            return false;
+        }
+        tokens.deleteById(id);
+        return true;
+    }
+
+    /**
+     * The token a secret belongs to, if the secret is one of ours and has not
+     * expired. Records the use, at most once per {@link #USE_RESOLUTION}.
+     */
+    public Optional<ApiToken> authenticate(String secret) {
+        if (!looksLikeApiToken(secret)) {
+            return Optional.empty();
+        }
+        String hash = hash(secret);
+        Optional<ApiToken> found = tokens.findByHash(hash)
+                .filter(t -> MessageDigest.isEqual(
+                        t.tokenHash().getBytes(StandardCharsets.US_ASCII), hash.getBytes(StandardCharsets.US_ASCII)));
+        if (found.isEmpty()) {
+            return Optional.empty();
+        }
+        Instant now = clock.instant();
+        ApiToken token = found.get();
+        if (token.expiredAt(now)) {
+            return Optional.empty();
+        }
+        if (token.lastUsedAt() == null
+                || Duration.between(token.lastUsedAt(), now).compareTo(USE_RESOLUTION) >= 0) {
+            tokens.recordUse(token.id(), now);
+            token = token.usedAt(now);
+        }
+        return Optional.of(token);
+    }
+
+    /** Whether {@code value} has the shape of one of our secrets — not whether it is valid. */
+    public static boolean looksLikeApiToken(String value) {
+        return value != null && value.startsWith(PREFIX) && value.length() > PREFIX.length();
+    }
+
+    /** Hex SHA-256 of a secret, the form tokens are stored and looked up by. */
+    public static String hash(String secret) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(secret.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+}

--- a/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/service/UserService.java
+++ b/agents/core/mc-user-core/src/main/java/ai/mindconnect/user/service/UserService.java
@@ -1,0 +1,79 @@
+package ai.mindconnect.user.service;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.User;
+import ai.mindconnect.user.port.out.UserRepository;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Keeps the user records in step with who signs in. It is called on every
+ * authenticated request that carries identity details — a browser login, a
+ * bearer JWT — so it writes only when a detail changed or the recorded login
+ * is older than {@link #LOGIN_RESOLUTION}: a busy API client must not turn
+ * every call into a write.
+ */
+public class UserService {
+
+    /** How stale {@link User#lastLoginAt()} may get before a request records a new one. */
+    public static final Duration LOGIN_RESOLUTION = Duration.ofMinutes(5);
+
+    private final UserRepository users;
+    private final Clock clock;
+
+    public UserService(UserRepository users) {
+        this(users, Clock.systemUTC());
+    }
+
+    public UserService(UserRepository users, Clock clock) {
+        this.users = Objects.requireNonNull(users, "users");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /**
+     * Creates the user on first sight, otherwise brings the stored details up
+     * to date. A detail the provider did not send this time (null) keeps its
+     * stored value.
+     *
+     * @return the user as stored after the call
+     */
+    public User recordLogin(UserId id, String subject, String issuer, String displayName, String email) {
+        Objects.requireNonNull(id, "id");
+        Instant now = clock.instant();
+        User existing = users.findById(id).orElse(null);
+        if (existing == null) {
+            User created = new User(id, subject, issuer, displayName, email, now, now);
+            users.save(created);
+            return created;
+        }
+        User merged = new User(id,
+                orElse(subject, existing.subject()),
+                orElse(issuer, existing.issuer()),
+                orElse(displayName, existing.displayName()),
+                orElse(email, existing.email()),
+                existing.createdAt(),
+                existing.lastLoginAt());
+        boolean changed = !merged.equals(existing);
+        boolean stale = existing.lastLoginAt() == null
+                || Duration.between(existing.lastLoginAt(), now).compareTo(LOGIN_RESOLUTION) >= 0;
+        if (!changed && !stale) {
+            return existing;
+        }
+        User updated = new User(id, merged.subject(), merged.issuer(), merged.displayName(), merged.email(),
+                merged.createdAt() != null ? merged.createdAt() : now, now);
+        users.save(updated);
+        return updated;
+    }
+
+    public Optional<User> find(UserId id) {
+        return users.findById(id);
+    }
+
+    private static String orElse(String value, String fallback) {
+        return value != null && !value.isBlank() ? value : fallback;
+    }
+}

--- a/agents/core/mc-user-core/src/test/java/ai/mindconnect/user/service/ApiTokenServiceTest.java
+++ b/agents/core/mc-user-core/src/test/java/ai/mindconnect/user/service/ApiTokenServiceTest.java
@@ -1,0 +1,120 @@
+package ai.mindconnect.user.service;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiToken;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A token is a secret shown once and stored only as its hash; it authenticates
+ * its owner until it expires or the owner revokes it, and nobody else can
+ * revoke it.
+ */
+class ApiTokenServiceTest {
+
+    private static final UserId ALICE = UserId.of("alice");
+    private static final UserId BOB = UserId.of("bob");
+
+    private final MapRepositories.Tokens tokens = new MapRepositories.Tokens();
+    private final MapRepositories.SettableClock clock =
+            new MapRepositories.SettableClock(Instant.parse("2026-09-11T12:00:00Z"));
+    private final ApiTokenService service = new ApiTokenService(tokens, clock);
+
+    @Test
+    void anIssuedSecretAuthenticatesItsOwnerAndIsStoredOnlyAsItsHash() {
+        ApiTokenService.Issued issued = service.issue(ALICE, "  laptop ", null);
+
+        assertThat(issued.secret()).startsWith(ApiTokenService.PREFIX).hasSizeGreaterThan(40);
+        ApiToken stored = tokens.byId.get(issued.token().id());
+        assertThat(stored.name()).isEqualTo("laptop");
+        assertThat(stored.tokenHash()).isEqualTo(ApiTokenService.hash(issued.secret()))
+                .doesNotContain(issued.secret());
+        assertThat(issued.secret()).startsWith(stored.hint());
+        assertThat(stored.hint()).hasSize(ApiTokenService.PREFIX.length() + 6);
+
+        assertThat(service.authenticate(issued.secret())).map(ApiToken::userId).contains(ALICE);
+    }
+
+    @Test
+    void twoTokensNeverShareASecret() {
+        String first = service.issue(ALICE, "a", null).secret();
+        String second = service.issue(ALICE, "b", null).secret();
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    void anythingButAnIssuedSecretAuthenticatesNobody() {
+        String secret = service.issue(ALICE, "laptop", null).secret();
+
+        assertThat(service.authenticate(null)).isEmpty();
+        assertThat(service.authenticate("")).isEmpty();
+        assertThat(service.authenticate(ApiTokenService.PREFIX)).isEmpty();
+        assertThat(service.authenticate("eyJhbGciOiJSUzI1NiJ9.a.b")).isEmpty();
+        assertThat(service.authenticate(secret + "x")).isEmpty();
+        assertThat(service.authenticate(secret.substring(0, secret.length() - 1))).isEmpty();
+    }
+
+    @Test
+    void anExpiredTokenNoLongerAuthenticates() {
+        String secret = service.issue(ALICE, "ci", clock.instant().plus(Duration.ofDays(30))).secret();
+
+        clock.advance(Duration.ofDays(30).minusSeconds(1));
+        assertThat(service.authenticate(secret)).isPresent();
+
+        clock.advance(Duration.ofSeconds(1));
+        assertThat(service.authenticate(secret)).isEmpty();
+    }
+
+    @Test
+    void onlyTheOwnerCanRevoke() {
+        ApiTokenService.Issued issued = service.issue(ALICE, "laptop", null);
+
+        assertThat(service.revoke(BOB, issued.token().id())).isFalse();
+        assertThat(service.authenticate(issued.secret())).isPresent();
+
+        assertThat(service.revoke(ALICE, issued.token().id())).isTrue();
+        assertThat(service.authenticate(issued.secret())).isEmpty();
+        assertThat(service.revoke(ALICE, issued.token().id())).isFalse();
+    }
+
+    @Test
+    void theListShowsOnlyTheOwnersTokensNewestFirst() {
+        service.issue(ALICE, "old", null);
+        clock.advance(Duration.ofMinutes(1));
+        service.issue(ALICE, "new", null);
+        service.issue(BOB, "bobs", null);
+
+        assertThat(service.list(ALICE)).extracting(ApiToken::name).containsExactly("new", "old");
+    }
+
+    @Test
+    void useIsRecordedAtMostOncePerResolution() {
+        String secret = service.issue(ALICE, "ci", null).secret();
+        int afterIssue = tokens.writes;
+
+        service.authenticate(secret);
+        service.authenticate(secret);
+        clock.advance(ApiTokenService.USE_RESOLUTION.minusSeconds(1));
+        service.authenticate(secret);
+        assertThat(tokens.writes).isEqualTo(afterIssue + 1);
+
+        clock.advance(Duration.ofSeconds(1));
+        assertThat(service.authenticate(secret)).map(ApiToken::lastUsedAt).contains(clock.instant());
+        assertThat(tokens.writes).isEqualTo(afterIssue + 2);
+    }
+
+    @Test
+    void aNameIsRequiredAndTheExpiryMustLieAhead() {
+        assertThatThrownBy(() -> service.issue(ALICE, " ", null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.issue(ALICE, "x".repeat(ApiTokenService.MAX_NAME_LENGTH + 1), null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.issue(ALICE, "ci", clock.instant()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(tokens.byId).isEmpty();
+    }
+}

--- a/agents/core/mc-user-core/src/test/java/ai/mindconnect/user/service/MapRepositories.java
+++ b/agents/core/mc-user-core/src/test/java/ai/mindconnect/user/service/MapRepositories.java
@@ -1,0 +1,63 @@
+package ai.mindconnect.user.service;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+import ai.mindconnect.user.domain.User;
+import ai.mindconnect.user.port.out.ApiTokenRepository;
+import ai.mindconnect.user.port.out.UserRepository;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Map-backed ports and a settable clock for the service tests — the real adapters live in mc-user. */
+class MapRepositories {
+
+    private MapRepositories() {}
+
+    static class Users implements UserRepository {
+        final Map<UserId, User> byId = new ConcurrentHashMap<>();
+        int saves;
+
+        @Override public Optional<User> findById(UserId id) { return Optional.ofNullable(byId.get(id)); }
+        @Override public List<User> findAll() { return List.copyOf(byId.values()); }
+        @Override public void save(User user) { saves++; byId.put(user.id(), user); }
+    }
+
+    static class Tokens implements ApiTokenRepository {
+        final Map<ApiTokenId, ApiToken> byId = new ConcurrentHashMap<>();
+        int writes;
+
+        @Override public void save(ApiToken token) { writes++; byId.put(token.id(), token); }
+        @Override public Optional<ApiToken> findById(ApiTokenId id) { return Optional.ofNullable(byId.get(id)); }
+        @Override public Optional<ApiToken> findByHash(String tokenHash) {
+            return byId.values().stream().filter(t -> t.tokenHash().equals(tokenHash)).findFirst();
+        }
+        @Override public List<ApiToken> findByUser(UserId userId) {
+            return byId.values().stream().filter(t -> t.userId().equals(userId)).toList();
+        }
+        @Override public void deleteById(ApiTokenId id) { byId.remove(id); }
+        @Override public void recordUse(ApiTokenId id, Instant at) {
+            writes++;
+            byId.computeIfPresent(id, (k, t) -> t.usedAt(at));
+        }
+    }
+
+    static class SettableClock extends Clock {
+        Instant now;
+
+        SettableClock(Instant now) { this.now = now; }
+
+        void advance(java.time.Duration by) { now = now.plus(by); }
+
+        @Override public ZoneId getZone() { return ZoneOffset.UTC; }
+        @Override public Clock withZone(ZoneId zone) { return this; }
+        @Override public Instant instant() { return now; }
+    }
+}

--- a/agents/core/mc-user-core/src/test/java/ai/mindconnect/user/service/UserServiceTest.java
+++ b/agents/core/mc-user-core/src/test/java/ai/mindconnect/user/service/UserServiceTest.java
@@ -1,0 +1,67 @@
+package ai.mindconnect.user.service;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A login creates the user on first sight and keeps the details current, but
+ * a stream of requests from the same user does not write on every one.
+ */
+class UserServiceTest {
+
+    private static final UserId ALICE = UserId.of("alice");
+
+    private final MapRepositories.Users users = new MapRepositories.Users();
+    private final MapRepositories.SettableClock clock =
+            new MapRepositories.SettableClock(Instant.parse("2026-09-11T12:00:00Z"));
+    private final UserService service = new UserService(users, clock);
+
+    @Test
+    void theFirstLoginCreatesTheUser() {
+        User user = service.recordLogin(ALICE, "sub-1", "https://auth/realms/mc", "Alice", "alice@example.com");
+
+        assertThat(user.createdAt()).isEqualTo(clock.instant());
+        assertThat(user.lastLoginAt()).isEqualTo(clock.instant());
+        assertThat(service.find(ALICE)).contains(user);
+    }
+
+    @Test
+    void repeatedRequestsWithinTheResolutionDoNotWrite() {
+        service.recordLogin(ALICE, "sub-1", "iss", "Alice", "alice@example.com");
+        clock.advance(UserService.LOGIN_RESOLUTION.minusSeconds(1));
+        service.recordLogin(ALICE, "sub-1", "iss", "Alice", "alice@example.com");
+
+        assertThat(users.saves).isEqualTo(1);
+
+        clock.advance(Duration.ofSeconds(1));
+        User later = service.recordLogin(ALICE, "sub-1", "iss", "Alice", "alice@example.com");
+        assertThat(users.saves).isEqualTo(2);
+        assertThat(later.lastLoginAt()).isEqualTo(clock.instant());
+    }
+
+    @Test
+    void aChangedDetailIsWrittenAtOnceAndAMissingOneKeepsTheStoredValue() {
+        Instant first = clock.instant();
+        service.recordLogin(ALICE, "sub-1", "iss", "Alice", "alice@example.com");
+        clock.advance(Duration.ofSeconds(10));
+
+        User renamed = service.recordLogin(ALICE, null, null, "Alice Smith", null);
+
+        assertThat(users.saves).isEqualTo(2);
+        assertThat(renamed.displayName()).isEqualTo("Alice Smith");
+        assertThat(renamed.email()).isEqualTo("alice@example.com");
+        assertThat(renamed.subject()).isEqualTo("sub-1");
+        assertThat(renamed.createdAt()).isEqualTo(first);
+    }
+
+    @Test
+    void theLabelFallsBackToTheId() {
+        assertThat(service.recordLogin(ALICE, null, null, null, null).label()).isEqualTo("alice");
+    }
+}

--- a/agents/core/mc-user/pom.xml
+++ b/agents/core/mc-user/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-user</artifactId>
+    <name>mc-user</name>
+    <packaging>jar</packaging>
+    <description>
+        File and in-memory adapters for the user ports of mc-user-core: one JSON
+        document per user and per API token under
+        &lt;data&gt;/&lt;namespace&gt;/system/.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/file/FileApiTokenRepository.java
+++ b/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/file/FileApiTokenRepository.java
@@ -1,0 +1,70 @@
+package ai.mindconnect.user.adapter.file;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+import ai.mindconnect.user.port.out.ApiTokenRepository;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@link ApiTokenRepository} on the file system: one JSON document per token
+ * under {@code <storageDir>/<namespace>/system/api-tokens/<id>.json}. A lookup
+ * by hash reads the directory — an installation has a handful of tokens per
+ * user, not millions, and the Postgres adapter indexes the hash.
+ *
+ * <p>Writes go through one lock, so that recording a use and revoking the
+ * same token cannot interleave into a revoked token written back.
+ */
+public class FileApiTokenRepository implements ApiTokenRepository {
+
+    private final FileDocuments<ApiToken> tokens;
+    private final Object lock = new Object();
+
+    public FileApiTokenRepository(Path storageDir, Namespace namespace) {
+        Objects.requireNonNull(namespace, "namespace");
+        this.tokens = new FileDocuments<>(
+                storageDir.resolve(namespace.value()).resolve("system").resolve("api-tokens"), ApiToken.class);
+    }
+
+    @Override
+    public void save(ApiToken token) {
+        synchronized (lock) {
+            tokens.write(token.id().value(), token);
+        }
+    }
+
+    @Override
+    public Optional<ApiToken> findById(ApiTokenId id) {
+        return tokens.read(id.value()).filter(token -> token.id().equals(id));
+    }
+
+    @Override
+    public Optional<ApiToken> findByHash(String tokenHash) {
+        return tokens.readAll().stream().filter(token -> token.tokenHash().equals(tokenHash)).findFirst();
+    }
+
+    @Override
+    public List<ApiToken> findByUser(UserId userId) {
+        return tokens.readAll().stream().filter(token -> token.userId().equals(userId)).toList();
+    }
+
+    @Override
+    public void deleteById(ApiTokenId id) {
+        synchronized (lock) {
+            tokens.delete(id.value());
+        }
+    }
+
+    @Override
+    public void recordUse(ApiTokenId id, Instant at) {
+        synchronized (lock) {
+            findById(id).ifPresent(token -> tokens.write(id.value(), token.usedAt(at)));
+        }
+    }
+}

--- a/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/file/FileDocuments.java
+++ b/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/file/FileDocuments.java
@@ -1,0 +1,94 @@
+package ai.mindconnect.user.adapter.file;
+
+import ai.mindconnect.common.util.AtomicFiles;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * One directory of JSON documents of one type: written atomically, read
+ * leniently (unknown fields are ignored, so a document from another version
+ * still loads), and an unreadable file is skipped with a warning instead of
+ * taking every other document down with it.
+ */
+class FileDocuments<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(FileDocuments.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    private final Path dir;
+    private final Class<T> type;
+
+    FileDocuments(Path dir, Class<T> type) {
+        this.dir = dir;
+        this.type = type;
+    }
+
+    Optional<T> read(String key) {
+        Path file = fileFor(key);
+        if (!Files.isRegularFile(file)) {
+            return Optional.empty();
+        }
+        return readFile(file);
+    }
+
+    List<T> readAll() {
+        if (!Files.isDirectory(dir)) {
+            return List.of();
+        }
+        List<T> out = new ArrayList<>();
+        try (var files = Files.list(dir)) {
+            for (Path file : files.filter(f -> f.getFileName().toString().endsWith(".json")).toList()) {
+                readFile(file).ifPresent(out::add);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not list " + dir, e);
+        }
+        return out;
+    }
+
+    void write(String key, T document) {
+        try {
+            AtomicFiles.write(fileFor(key), out -> MAPPER.writeValue(out, document));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not write " + fileFor(key), e);
+        }
+    }
+
+    void delete(String key) {
+        try {
+            Files.deleteIfExists(fileFor(key));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not delete " + fileFor(key), e);
+        }
+    }
+
+    private Optional<T> readFile(Path file) {
+        try {
+            return Optional.of(MAPPER.readValue(file.toFile(), type));
+        } catch (IOException e) {
+            log.warn("Skipping unreadable {}: {}", file, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Path fileFor(String key) {
+        return dir.resolve(key + ".json");
+    }
+}

--- a/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/file/FileUserRepository.java
+++ b/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/file/FileUserRepository.java
@@ -1,0 +1,70 @@
+package ai.mindconnect.user.adapter.file;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.User;
+import ai.mindconnect.user.port.out.UserRepository;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@link UserRepository} on the file system: one JSON document per user under
+ * {@code <storageDir>/<namespace>/system/users/}.
+ *
+ * <p>A user id is whatever the identity provider calls the user — mixed case,
+ * {@code @}, dots — so it is not a file name as it stands. The file is named
+ * by a readable, lower-cased form of the id plus a short hash of the exact id:
+ * {@code Alice} and {@code alice} get two files even on a case-insensitive
+ * file system, and the name still tells a human whose file it is.
+ */
+public class FileUserRepository implements UserRepository {
+
+    private final FileDocuments<User> users;
+
+    public FileUserRepository(Path storageDir, Namespace namespace) {
+        Objects.requireNonNull(namespace, "namespace");
+        this.users = new FileDocuments<>(
+                storageDir.resolve(namespace.value()).resolve("system").resolve("users"), User.class);
+    }
+
+    @Override
+    public Optional<User> findById(UserId id) {
+        return users.read(fileKey(id)).filter(user -> user.id().equals(id));
+    }
+
+    @Override
+    public List<User> findAll() {
+        return users.readAll();
+    }
+
+    @Override
+    public void save(User user) {
+        users.write(fileKey(user.id()), user);
+    }
+
+    /** The file name (without {@code .json}) a user id is stored under. */
+    static String fileKey(UserId id) {
+        String readable = id.value().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9_-]", "_");
+        if (readable.length() > 64) {
+            readable = readable.substring(0, 64);
+        }
+        return readable + "-" + sha256(id.value()).substring(0, 12);
+    }
+
+    private static String sha256(String value) {
+        try {
+            return HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+}

--- a/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/memory/InMemoryApiTokenRepository.java
+++ b/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/memory/InMemoryApiTokenRepository.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.user.adapter.memory;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+import ai.mindconnect.user.port.out.ApiTokenRepository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** {@link ApiTokenRepository} on the heap — for tests and embedders that keep nothing. */
+public class InMemoryApiTokenRepository implements ApiTokenRepository {
+
+    private final Map<ApiTokenId, ApiToken> tokens = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(ApiToken token) {
+        tokens.put(token.id(), token);
+    }
+
+    @Override
+    public Optional<ApiToken> findById(ApiTokenId id) {
+        return Optional.ofNullable(tokens.get(id));
+    }
+
+    @Override
+    public Optional<ApiToken> findByHash(String tokenHash) {
+        return tokens.values().stream().filter(token -> token.tokenHash().equals(tokenHash)).findFirst();
+    }
+
+    @Override
+    public List<ApiToken> findByUser(UserId userId) {
+        return tokens.values().stream().filter(token -> token.userId().equals(userId)).toList();
+    }
+
+    @Override
+    public void deleteById(ApiTokenId id) {
+        tokens.remove(id);
+    }
+
+    @Override
+    public void recordUse(ApiTokenId id, Instant at) {
+        tokens.computeIfPresent(id, (key, token) -> token.usedAt(at));
+    }
+}

--- a/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/memory/InMemoryUserRepository.java
+++ b/agents/core/mc-user/src/main/java/ai/mindconnect/user/adapter/memory/InMemoryUserRepository.java
@@ -1,0 +1,31 @@
+package ai.mindconnect.user.adapter.memory;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.User;
+import ai.mindconnect.user.port.out.UserRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** {@link UserRepository} on the heap — for tests and embedders that keep nothing. */
+public class InMemoryUserRepository implements UserRepository {
+
+    private final Map<UserId, User> users = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<User> findById(UserId id) {
+        return Optional.ofNullable(users.get(id));
+    }
+
+    @Override
+    public List<User> findAll() {
+        return List.copyOf(users.values());
+    }
+
+    @Override
+    public void save(User user) {
+        users.put(user.id(), user);
+    }
+}

--- a/agents/core/mc-user/src/test/java/ai/mindconnect/user/adapter/file/FileApiTokenRepositoryTest.java
+++ b/agents/core/mc-user/src/test/java/ai/mindconnect/user/adapter/file/FileApiTokenRepositoryTest.java
@@ -1,0 +1,66 @@
+package ai.mindconnect.user.adapter.file;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.ApiTokenId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileApiTokenRepositoryTest {
+
+    private static final Instant AT = Instant.parse("2026-09-11T12:00:00Z");
+
+    @TempDir
+    Path dir;
+
+    private static ApiToken token(String owner, String hash) {
+        return new ApiToken(ApiTokenId.random(), UserId.of(owner), "ci", hash, "mct_abcdef", AT, null, null);
+    }
+
+    @Test
+    void aTokenIsFoundByIdHashAndOwner() {
+        var repo = new FileApiTokenRepository(dir, new Namespace("test"));
+        ApiToken alices = token("alice", "hash-a");
+        ApiToken bobs = token("bob", "hash-b");
+        repo.save(alices);
+        repo.save(bobs);
+
+        assertThat(repo.findById(alices.id())).contains(alices);
+        assertThat(repo.findByHash("hash-b")).contains(bobs);
+        assertThat(repo.findByHash("nope")).isEmpty();
+        assertThat(repo.findByUser(UserId.of("alice"))).containsExactly(alices);
+        assertThat(dir.resolve("test/system/api-tokens/" + alices.id().value() + ".json")).exists();
+    }
+
+    @Test
+    void anotherNamespaceSeesNothing() {
+        ApiToken alices = token("alice", "hash-a");
+        new FileApiTokenRepository(dir, new Namespace("test")).save(alices);
+
+        var other = new FileApiTokenRepository(dir, new Namespace("other"));
+        assertThat(other.findById(alices.id())).isEmpty();
+        assertThat(other.findByHash("hash-a")).isEmpty();
+    }
+
+    @Test
+    void recordingAUseUpdatesATokenButNeverBringsARevokedOneBack() {
+        var repo = new FileApiTokenRepository(dir, new Namespace("test"));
+        ApiToken alices = token("alice", "hash-a");
+        repo.save(alices);
+
+        Instant used = AT.plusSeconds(60);
+        repo.recordUse(alices.id(), used);
+        assertThat(repo.findById(alices.id())).map(ApiToken::lastUsedAt).contains(used);
+
+        repo.deleteById(alices.id());
+        repo.recordUse(alices.id(), used.plusSeconds(60));
+        assertThat(repo.findById(alices.id())).isEmpty();
+        assertThat(repo.findByHash("hash-a")).isEmpty();
+    }
+}

--- a/agents/core/mc-user/src/test/java/ai/mindconnect/user/adapter/file/FileUserRepositoryTest.java
+++ b/agents/core/mc-user/src/test/java/ai/mindconnect/user/adapter/file/FileUserRepositoryTest.java
@@ -1,0 +1,68 @@
+package ai.mindconnect.user.adapter.file;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileUserRepositoryTest {
+
+    @TempDir
+    Path dir;
+
+    private static User user(String id) {
+        Instant at = Instant.parse("2026-09-11T12:00:00Z");
+        return new User(UserId.of(id), "sub-" + id, "https://auth/realms/mc", "Name " + id, id + "@example.com", at, at);
+    }
+
+    @Test
+    void aUserSurvivesTheRoundTripInItsNamespacesDirectory() {
+        var repo = new FileUserRepository(dir, new Namespace("test"));
+        User alice = user("alice");
+        repo.save(alice);
+
+        assertThat(repo.findById(UserId.of("alice"))).contains(alice);
+        assertThat(repo.findAll()).containsExactly(alice);
+        assertThat(dir.resolve("test/system/users")).isDirectoryContaining("glob:**alice-*.json");
+    }
+
+    @Test
+    void anotherNamespaceSeesNothing() {
+        new FileUserRepository(dir, new Namespace("test")).save(user("alice"));
+
+        var other = new FileUserRepository(dir, new Namespace("other"));
+        assertThat(other.findById(UserId.of("alice"))).isEmpty();
+        assertThat(other.findAll()).isEmpty();
+    }
+
+    @Test
+    void idsThatAreNoFileNamesAndDifferOnlyInCaseStayApart() {
+        var repo = new FileUserRepository(dir, new Namespace("test"));
+        repo.save(user("Alice"));
+        repo.save(user("alice"));
+        repo.save(user("alice.smith@example.com"));
+        repo.save(user("../../etc/passwd"));
+
+        assertThat(repo.findAll()).hasSize(4);
+        assertThat(repo.findById(UserId.of("Alice"))).map(User::displayName).contains("Name Alice");
+        assertThat(repo.findById(UserId.of("alice"))).map(User::displayName).contains("Name alice");
+        assertThat(repo.findById(UserId.of("../../etc/passwd"))).isPresent();
+        assertThat(Files.exists(dir.resolve("etc"))).isFalse();
+    }
+
+    @Test
+    void anUnreadableFileIsSkipped() throws Exception {
+        var repo = new FileUserRepository(dir, new Namespace("test"));
+        repo.save(user("alice"));
+        Files.writeString(dir.resolve("test/system/users/broken-000000000000.json"), "{not json");
+
+        assertThat(repo.findAll()).extracting(User::id).containsExactly(UserId.of("alice"));
+    }
+}

--- a/agents/doc/manual-tests/api/api-tokens.md
+++ b/agents/doc/manual-tests/api/api-tokens.md
@@ -1,0 +1,78 @@
+---
+id: api-api-tokens
+area: api
+requires: [server-9099-keycloak]
+duration: ~5 min
+last-verified: never
+---
+
+# API tokens: create, use, revoke — and only for their owner
+
+**Goal:** A user creates a personal API token on the profile page, a program
+calls `/api/**` and `/v1/**` with it as that user, the token never shows again,
+another user's resources stay out of reach, and revoking ends it at once.
+
+## Preconditions
+
+- Admin UI of this branch with the `keycloak` profile at http://localhost:9099
+  and two Keycloak users that can sign in (here `alice` and `bob`).
+  Otherwise: SKIPPED.
+- `curl`, `python3`.
+
+## Setup
+
+```bash
+B=http://localhost:9099
+c() { printf '%-28s %s\n' "$1" "$(curl -s -o /dev/null -m 5 -w '%{http_code}' "${@:2}")"; }
+```
+
+## Steps
+
+1. **No credentials.**
+   ```bash
+   c "agents, anonymous" $B/api/agents
+   c "responses, anonymous" -X POST $B/v1/responses -H 'Content-Type: application/json' -d '{"input":"hi"}'
+   ```
+   **Expected:** `401` on both; the response carries `WWW-Authenticate: Bearer`
+   and a JSON body — `curl -s $B/api/agents` prints
+   `{"status":401,"error":"Unauthorized","message":"A bearer token is required: …"}`.
+2. **Create a token as alice.** Sign in as `alice`, click the avatar in the
+   header → the profile page opens at `/admin/profile`. Click **New token**,
+   name `curl`, expiry *in 30 days*, **Create token**.
+   **Expected:** a dialog shows the secret (`mct_…`) and a `curl` example; the
+   table lists `curl` with the first characters of the token, *Last used: never*.
+   Copy the secret into `A=` in the shell.
+3. **The token works as alice and needs no CSRF token.**
+   ```bash
+   c "agents with token" -H "Authorization: Bearer $A" $B/api/agents
+   AG=$(curl -s -H "Authorization: Bearer $A" $B/api/agents | python3 -c 'import sys,json; print(json.load(sys.stdin)[0]["id"])')
+   S=$(curl -s -X POST -H "Authorization: Bearer $A" -H 'Content-Type: application/json' -d "{\"agentId\":\"$AG\",\"userId\":\"bob\"}" $B/api/sessions | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["id"], d["userId"])')
+   echo "$S"
+   ```
+   **Expected:** `200`; the session belongs to `alice` although the body says `bob`.
+4. **The secret is not shown again.** Reload `/admin/profile`.
+   **Expected:** the table shows the token's name and first characters only;
+   *Last used* now has a time. Nothing on the page contains the full secret.
+5. **Bob cannot reach alice's session.** Sign in as `bob` in a private window,
+   create a token `B=` the same way.
+   ```bash
+   SID=${S%% *}
+   c "bob: alice's history" -H "Authorization: Bearer $B" $B/api/sessions/$SID/history
+   c "bob: alice's session list" -H "Authorization: Bearer $B" "$B/api/sessions?agentId=$AG"
+   ```
+   **Expected:** `404` for the history; bob's session list does not contain `$SID`.
+6. **Revoke.** As alice, **Revoke** `curl` on the profile page and confirm.
+   ```bash
+   c "agents with revoked token" -H "Authorization: Bearer $A" $B/api/agents
+   ```
+   **Expected:** toast *Token revoked*; the row is gone; `401`.
+7. **A forged token of the right shape.**
+   ```bash
+   c "forged token" -H "Authorization: Bearer mct_forged" $B/api/agents
+   ```
+   **Expected:** `401`.
+
+## Not covered here
+
+JWT bearer tokens (needs a Keycloak client that hands out access tokens to a
+script) — pinned by `ApiFilterChainTest` in `mc-agent-security`.

--- a/agents/doc/manual-tests/api/api-tokens.md
+++ b/agents/doc/manual-tests/api/api-tokens.md
@@ -3,7 +3,7 @@ id: api-api-tokens
 area: api
 requires: [server-9099-keycloak]
 duration: ~5 min
-last-verified: never
+last-verified: 2026-09-11 (commit d85ccc8, branch feature/api-auth, runs/2026-09-11-api-tokens)
 ---
 
 # API tokens: create, use, revoke — and only for their owner

--- a/agents/mc-agents-parent/pom.xml
+++ b/agents/mc-agents-parent/pom.xml
@@ -83,6 +83,26 @@
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-user-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-user</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-user-pg</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-agent-security</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-task-queue</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/agents/pom.xml
+++ b/agents/pom.xml
@@ -44,6 +44,9 @@
         <module>adapter/postgres/mc-message-repository-pg</module>
         <module>adapter/postgres/mc-agent-runtime-pg</module>
         <module>adapter/postgres/mc-file-store-pg</module>
+        <module>core/mc-user-core</module>
+        <module>core/mc-user</module>
+        <module>adapter/postgres/mc-user-pg</module>
         <module>springstarter/mc-agent-starter-file</module>
         <module>springstarter/mc-agent-starter-postgres</module>
         <module>core/mc-credentials</module>
@@ -65,6 +68,7 @@
         <module>mcp/mc-agent-tools-mcp</module>
         <module>mcp/mc-mcp-gateway-admin-ui-rest</module>
         <module>server/mc-agent-api-rest</module>
+        <module>server/mc-agent-security</module>
         <module>server/mc-agent-api-responses-rest</module>
         <module>server/mc-agent-api-app</module>
         <module>server/mc-agent-chat-ui-rest</module>

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -153,6 +153,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
+        <!-- Bearer authentication of /api/** and /v1/**: Keycloak JWT or personal API token -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-security</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/AdminSameUrlFilter.java
+++ b/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/AdminSameUrlFilter.java
@@ -37,7 +37,7 @@ public class AdminSameUrlFilter extends org.springframework.web.filter.OncePerRe
     /** Sections whose controllers still live under /admin/api/<section>. */
     private static final List<String> LEGACY_SECTIONS = List.of(
             "/admin/agents", "/admin/sessions", "/admin/tools",
-            "/admin/llm-configs", "/admin/migrations", "/admin/api-explorer");
+            "/admin/llm-configs", "/admin/migrations", "/admin/api-explorer", "/admin/profile");
 
     /** The chat lives under its own prefix: /chat/... → /chat/api/... */
     private static final List<String> CHAT_SECTION = List.of("/chat");

--- a/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/SecurityConfig.java
+++ b/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/SecurityConfig.java
@@ -1,5 +1,8 @@
 package ai.mindconnect.adminui;
 
+import ai.mindconnect.agent.security.ApiAuthentication;
+import ai.mindconnect.agent.security.UserRecorder;
+import ai.mindconnect.agent.security.UserRecordingFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -56,18 +60,27 @@ import java.util.List;
  * the previous {@code localStorage}-based resource-server setup was exposed
  * to.
  *
- * <p>Two filter chains:
+ * <p>Filter chains:
  * <ul>
- *   <li><b>auth enabled</b> ({@code mindconnect.auth.enabled=true}): static
- *       assets are public; everything else requires a logged-in session.
- *       Browser navigations to a protected page are redirected to Keycloak,
- *       but {@code fetch} / XHR calls get a clean {@code 401} so the SPA
- *       can decide for itself when to bounce the user through the login
- *       flow. CSRF is on, with the token shipped via a JavaScript-readable
- *       {@code XSRF-TOKEN} cookie so the SPA can echo it back in the
- *       {@code X-XSRF-TOKEN} header on mutating requests.</li>
+ *   <li><b>auth enabled</b> ({@code mindconnect.auth.enabled=true}), two chains:
+ *     <ul>
+ *       <li>the REST APIs ({@code /api/**}, {@code /v1/**}) — bearer tokens
+ *           only, a Keycloak JWT or a personal API token
+ *           ({@link ApiAuthentication}). The browser session does not count
+ *           here, so there is no CSRF token either; the admin UI's own calls
+ *           go to {@code /admin/**} and {@code /chat/**}. No token: 401 with
+ *           {@code WWW-Authenticate: Bearer} and a JSON body saying why.</li>
+ *       <li>everything else — static assets are public; the rest requires a
+ *           logged-in session. Browser navigations to a protected page are
+ *           redirected to the login page, but {@code fetch} / XHR calls get a
+ *           clean {@code 401} so the SPA can decide for itself when to bounce
+ *           the user through the login flow. CSRF is on, with the token
+ *           shipped via a JavaScript-readable {@code XSRF-TOKEN} cookie so the
+ *           SPA can echo it back in the {@code X-XSRF-TOKEN} header on mutating
+ *           requests. A bearer token counts for nothing here.</li>
+ *     </ul></li>
  *   <li><b>auth disabled</b> (default in local dev without Keycloak): all
- *       permitAll, CSRF off, no OIDC wiring.</li>
+ *       permitAll, CSRF off, no OIDC wiring, every request runs as the dev user.</li>
  * </ul>
  */
 @Configuration
@@ -75,17 +88,24 @@ import java.util.List;
 public class SecurityConfig {
 
     @Bean
+    @Order(1)
+    @ConditionalOnProperty(name = "mindconnect.auth.enabled", havingValue = "true")
+    SecurityFilterChain apiFilterChain(HttpSecurity http, ApiAuthentication api) throws Exception {
+        api.apply(http
+            .securityMatcher("/api/**", "/v1/**")
+            .cors(Customizer.withDefaults())
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .headers(headers -> headers.frameOptions(f -> f.sameOrigin())));
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
     @ConditionalOnProperty(name = "mindconnect.auth.enabled", havingValue = "true")
     SecurityFilterChain securedFilterChain(
             HttpSecurity http,
-            ClientRegistrationRepository clientRegistrations) throws Exception {
-
-        // Spring's default CSRF handler hides the raw token behind a
-        // BREACH-mitigation wrapper that JavaScript can't consume. The
-        // attribute-handler below restores the plain-token behaviour
-        // expected by SPAs that read the cookie and echo it as a header.
-        var csrfHandler = new CsrfTokenRequestAttributeHandler();
-        csrfHandler.setCsrfRequestAttributeName(null);
+            ClientRegistrationRepository clientRegistrations,
+            UserRecorder userRecorder) throws Exception {
 
         // Only remember browser navigations (Accept: text/html) as the
         // post-login return target. Without this, an XHR call that 401s —
@@ -96,8 +116,6 @@ public class SecurityConfig {
         htmlOnlyRequestCache.setRequestMatcher(htmlAcceptMatcher());
 
         http
-            // Cross-origin calls to the REST endpoints, as CorsConfig in
-            // mc-agent-api-rest allows them; a preflight passes without a login.
             .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/index.html", "/favicon.ico",
@@ -136,7 +154,7 @@ public class SecurityConfig {
             )
             .csrf(csrf -> csrf
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                .csrfTokenRequestHandler(csrfHandler)
+                .csrfTokenRequestHandler(plainCsrfTokenHandler())
             )
             // Exception handling: for browser navigations (Accept: text/html)
             // we redirect to the Keycloak login URL, for everything else we
@@ -144,7 +162,9 @@ public class SecurityConfig {
             // without having to follow a 302.
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint(htmlOrApiEntryPoint())
-            );
+            )
+            // The user record follows who signs in (profile page, API tokens).
+            .addFilterBefore(new UserRecordingFilter(userRecorder), AuthorizationFilter.class);
 
         // Same-origin framing only: the admin shell embeds its own pages
         // (Swagger UI in the API section); foreign sites still can't frame us.
@@ -156,7 +176,9 @@ public class SecurityConfig {
     @ConditionalOnProperty(name = "mindconnect.auth.enabled", havingValue = "false", matchIfMissing = true)
     SecurityFilterChain openFilterChain(
             HttpSecurity http,
-            @Value("${mindconnect.auth.dev-user:mc_user}") String devUser) throws Exception {
+            @Value("${mindconnect.auth.dev-user:mc_user}") String devUser,
+            UserRecorder userRecorder) throws Exception {
+        OncePerRequestFilter devUserFilter = devUserFilter(devUser);
         http
             .cors(Customizer.withDefaults())
             .csrf(AbstractHttpConfigurer::disable)
@@ -164,11 +186,25 @@ public class SecurityConfig {
             // No Keycloak in this mode, but the rest of the app still expects an
             // authenticated OidcUser principal (controllers read userId from it).
             // Inject a fixed dev user so behaviour matches the secured chain.
-            .addFilterBefore(devUserFilter(devUser), AuthorizationFilter.class);
+            .addFilterBefore(devUserFilter, AuthorizationFilter.class)
+            // The dev user has a user record too — the profile page needs one.
+            .addFilterBefore(new UserRecordingFilter(userRecorder), AuthorizationFilter.class);
         // Same-origin framing only: the admin shell embeds its own pages
         // (Swagger UI in the API section); foreign sites still can't frame us.
         http.headers(headers -> headers.frameOptions(f -> f.sameOrigin()));
         return http.build();
+    }
+
+    /**
+     * Spring's default CSRF handler hides the raw token behind a
+     * BREACH-mitigation wrapper that JavaScript can't consume. The
+     * attribute-handler restores the plain-token behaviour expected by SPAs
+     * that read the cookie and echo it as a header.
+     */
+    private static CsrfTokenRequestAttributeHandler plainCsrfTokenHandler() {
+        var csrfHandler = new CsrfTokenRequestAttributeHandler();
+        csrfHandler.setCsrfRequestAttributeName(null);
+        return csrfHandler;
     }
 
     /**

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
@@ -118,3 +118,9 @@ mindconnect:
   # always has its ClientRegistrationRepository.
   auth:
     enabled: true
+    # Bearer JWTs for /api/** and /v1/** are checked against the same realm the
+    # browser logs in with. MC_JWT_AUDIENCES, when set, additionally requires
+    # one of the listed audiences (needs an audience mapper in Keycloak).
+    jwt:
+      issuer-uri: ${KC_ISSUER_URI:http://localhost:8180/realms/mindconnect}
+      audiences: ${MC_JWT_AUDIENCES:}

--- a/agents/server/mc-agent-admin-ui-rest/pom.xml
+++ b/agents/server/mc-agent-admin-ui-rest/pom.xml
@@ -44,6 +44,16 @@
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-file-store</artifactId>
         </dependency>
+        <!-- The profile page: the signed-in user and their personal API tokens -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Semantic UI (from the standalone mc-semantic-ui repo): core
              (model + default TS renderer) + the JSON-viewer and markdown
              extensions (the former mc-semantic-ui-extensions bundle). -->

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
@@ -135,7 +135,9 @@ public final class AdminLayout {
             header.extra(UiLink.of("logout", "/admin/logout", "Logout"));
         }
 
-        header.user(UiHeader.User.of(userName, initials(userName), null));
+        // The avatar leads to the user's own page: who they are signed in as,
+        // and the API tokens they issued.
+        header.user(UiHeader.User.of(userName, initials(userName), "/admin/profile"));
         return header;
     }
 

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/ProfileUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/ProfileUiController.java
@@ -1,0 +1,163 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.adminui.ui.page.ProfilePage;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.chatui.service.SessionOwnership;
+import ai.mindconnect.chatui.ui.controller.FormBody;
+import ai.mindconnect.ui.model.UiDialog;
+import ai.mindconnect.ui.model.UiNode;
+import ai.mindconnect.ui.model.UiPage;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiToast;
+import ai.mindconnect.user.domain.ApiTokenId;
+import ai.mindconnect.user.service.ApiTokenService;
+import ai.mindconnect.user.service.UserService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * The profile page behind the header avatar, and the dialogs that issue and
+ * revoke the signed-in user's API tokens. Everything here acts on the caller's
+ * own tokens only — the token id in a revoke is checked against the owner, and
+ * a foreign id is answered like a missing one.
+ */
+@RestController
+@RequestMapping("/admin/api/profile")
+public class ProfileUiController {
+
+    static final String CREATE_DIALOG_ID = "api-token-create-dialog";
+    static final String SECRET_DIALOG_ID = "api-token-secret-dialog";
+
+    private static final Duration DEFAULT_LIFETIME = Duration.ofDays(90);
+
+    private final ApiTokenService tokens;
+    private final UserService users;
+    private final Clock clock;
+    private final boolean authEnabled;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public ProfileUiController(ApiTokenService tokens, UserService users,
+                               @org.springframework.beans.factory.annotation.Value("${mindconnect.auth.enabled:false}")
+                               boolean authEnabled) {
+        this(tokens, users, Clock.systemUTC(), authEnabled);
+    }
+
+    ProfileUiController(ApiTokenService tokens, UserService users, Clock clock, boolean authEnabled) {
+        this.tokens = tokens;
+        this.users = users;
+        this.clock = clock;
+        this.authEnabled = authEnabled;
+    }
+
+    @GetMapping
+    public UiPage profile(@AuthenticationPrincipal OidcUser user) {
+        UserId id = userId(user);
+        return new ProfilePage(id, users.find(id).orElse(null),
+                user == null ? null : user.getFullName(),
+                user == null ? null : user.getEmail(),
+                tokens.list(id), authEnabled).render();
+    }
+
+    /** Opens the "New token" dialog. */
+    @GetMapping("/tokens/new")
+    public UiPatch newToken() {
+        return dialog(CREATE_DIALOG_ID, "New API token", ProfilePage.newTokenForm(null));
+    }
+
+    /**
+     * Issues the token, refreshes the list, and swaps the form dialog for the
+     * one that shows the secret. A refused name or expiry keeps the form open
+     * with the reason.
+     */
+    @PostMapping("/tokens")
+    public UiPatch create(@AuthenticationPrincipal OidcUser user, @RequestBody Map<String, Object> raw) {
+        UserId id = userId(user);
+        FormBody body = new FormBody(raw);
+        ApiTokenService.Issued issued;
+        try {
+            issued = tokens.issue(id, body.str("name"), expiry(body.str("expiresIn")));
+        } catch (IllegalArgumentException e) {
+            return dialog(CREATE_DIALOG_ID, "New API token", ProfilePage.newTokenForm(e.getMessage()));
+        }
+        return dialog(SECRET_DIALOG_ID, "API token \"" + issued.token().name() + "\" created",
+                        ProfilePage.secretView(issued.secret(), baseUrl(), authEnabled))
+                .patch(UiPatch.Operation.remove(CREATE_DIALOG_ID))
+                .patch(UiPatch.Operation.replace(ProfilePage.TOKENS_ID, ProfilePage.tokenTable(tokens.list(id))));
+    }
+
+    /** Closes whichever token dialog is open; the page behind stays as it is. */
+    @PostMapping("/tokens/dialog/close")
+    public UiPatch closeDialog() {
+        return UiPatch.of()
+                .patch(UiPatch.Operation.remove(CREATE_DIALOG_ID))
+                .patch(UiPatch.Operation.remove(SECRET_DIALOG_ID));
+    }
+
+    @DeleteMapping("/tokens/{id}")
+    public UiPatch revoke(@AuthenticationPrincipal OidcUser user, @PathVariable("id") String tokenId) {
+        UserId id = userId(user);
+        boolean revoked;
+        try {
+            revoked = tokens.revoke(id, ApiTokenId.of(tokenId));
+        } catch (IllegalArgumentException e) {
+            revoked = false;
+        }
+        return UiPatch.of()
+                .patch(UiPatch.Operation.replace(ProfilePage.TOKENS_ID, ProfilePage.tokenTable(tokens.list(id))))
+                .toast(revoked
+                        ? UiToast.success("Programs using it can no longer sign in.").title("Token revoked")
+                        : UiToast.error("There is no such token of yours.").title("Nothing revoked"));
+    }
+
+    /** {@code never} → no expiry; a number of days; anything else → the default lifetime. */
+    Instant expiry(String choice) {
+        if ("never".equals(choice)) {
+            return null;
+        }
+        Duration lifetime = DEFAULT_LIFETIME;
+        try {
+            int days = Integer.parseInt(choice);
+            if (days > 0) {
+                lifetime = Duration.ofDays(days);
+            }
+        } catch (NumberFormatException ignored) {
+            // an unknown choice gets the default
+        }
+        return clock.instant().plus(lifetime);
+    }
+
+    private static UserId userId(OidcUser user) {
+        return UserId.of(SessionOwnership.userIdOf(user));
+    }
+
+    /** Where the example request in the secret dialog points: this installation, as the browser reached it. */
+    private static String baseUrl() {
+        try {
+            return ServletUriComponentsBuilder.fromCurrentContextPath().toUriString();
+        } catch (IllegalStateException outsideARequest) {
+            return "https://<host>";
+        }
+    }
+
+    /** A dialog as a remove+append patch on the body-level dialog host, so a re-render replaces it in place. */
+    private static UiPatch dialog(String id, String title, UiNode body) {
+        UiDialog dialog = UiDialog.of(title, null, body);
+        dialog.setId(id);
+        return UiPatch.of()
+                .patch(UiPatch.Operation.remove(id))
+                .patch(UiPatch.Operation.append("sui-dialogs", dialog));
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
@@ -137,7 +137,7 @@ public class VectorStoreUiController {
                 .column(UiTable.Column.text("size", "Size"))
                 .column(UiTable.Column.text("created", "Uploaded"))
                 .rowAction(UiAction.secondary("download", "Download").icon("download")
-                        .onClick(ai.mindconnect.ui.model.UiTrigger.openInTab("/api/files/{id}/content")))
+                        .onClick(ai.mindconnect.ui.model.UiTrigger.openInTab(BASE + "/files/{id}/content")))
                 .rowAction(UiAction.danger("delete", "Delete").icon("delete")
                         .confirm("Delete this file from the file store? (Already-ingested chunks stay.)")
                         .dispatch("DELETE", "/admin/vector-stores/files/{id}"));
@@ -231,17 +231,50 @@ public class VectorStoreUiController {
         return String.format("%.1f MB", bytes / (1024.0 * 1024));
     }
 
+    /** The uploads are stored as the signed-in user's files — the file store records who put them there. */
     @PostMapping(value = "/files/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public UiPage uploadFiles(@org.springframework.web.bind.annotation.RequestParam("vs-files-upload")
-                              List<org.springframework.web.multipart.MultipartFile> uploads) {
+                              List<org.springframework.web.multipart.MultipartFile> uploads,
+                              @org.springframework.security.core.annotation.AuthenticationPrincipal
+                              org.springframework.security.oauth2.core.oidc.user.OidcUser user) {
+        String userId = ai.mindconnect.chatui.service.SessionOwnership.userIdOf(user);
+        ai.mindconnect.agent.UserId creator = userId == null || userId.isBlank()
+                ? null : ai.mindconnect.agent.UserId.of(userId);
         for (var upload : uploads) {
             try (var content = upload.getInputStream()) {
-                fileStore.save(upload.getOriginalFilename(), upload.getContentType(), content);
+                fileStore.save(upload.getOriginalFilename(), upload.getContentType(), content, creator);
             } catch (java.io.IOException e) {
                 throw new IllegalStateException("Upload failed: " + e.getMessage(), e);
             }
         }
         return list("files");
+    }
+
+    /**
+     * The files tab's Download button. The Files API takes bearer tokens only,
+     * so the browser downloads here, with its session — and gets what the Files
+     * API would give the signed-in user: their own files and those stored
+     * before creators were recorded; anything else is 404.
+     */
+    @GetMapping("/files/{id}/content")
+    public org.springframework.http.ResponseEntity<org.springframework.core.io.InputStreamResource> downloadStoredFile(
+            @PathVariable String id,
+            @org.springframework.security.core.annotation.AuthenticationPrincipal
+            org.springframework.security.oauth2.core.oidc.user.OidcUser user) throws java.io.IOException {
+        String userId = ai.mindconnect.chatui.service.SessionOwnership.userIdOf(user);
+        ai.mindconnect.agent.UserId caller = userId == null || userId.isBlank()
+                ? null : ai.mindconnect.agent.UserId.of(userId);
+        var file = fileStore.find(ai.mindconnect.filestore.FileId.of(id))
+                .filter(f -> f.readableBy(caller)).orElse(null);
+        if (file == null) {
+            return org.springframework.http.ResponseEntity.notFound().build();
+        }
+        return org.springframework.http.ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"" + file.name() + "\"")
+                .contentType(file.contentType() != null
+                        ? MediaType.parseMediaType(file.contentType())
+                        : MediaType.APPLICATION_OCTET_STREAM)
+                .body(new org.springframework.core.io.InputStreamResource(fileStore.content(file.id())));
     }
 
     @DeleteMapping("/files/{id}")

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
@@ -40,6 +40,12 @@ import java.util.Set;
  * config, ingestion workflow) and the store instances created from them.
  * Uses the same {@link VectorStores} resolution the knowledge tools use, so
  * what the UI shows is exactly what the tools do.
+ *
+ * <p>Templates and knowledge bases are shared configuration. A chat's upload
+ * store is its user's alone ({@link ai.mindconnect.agentrest.auth.VectorStoreAccess}):
+ * another user neither sees it listed nor opens, searches, fills or deletes
+ * it. The files tab shows what the Files API gives the signed-in user, and
+ * only a file's uploader deletes it.
  */
 @RestController
 @RequestMapping("/admin/vector-stores")
@@ -51,14 +57,20 @@ public class VectorStoreUiController {
     private final LlmConfigRepository llmConfigs;
     private final ai.mindconnect.filestore.FileStore fileStore;
     private final ai.mindconnect.agentrest.service.VectorStoreService vectorStoreService;
+    private final ai.mindconnect.agentrest.auth.CurrentUsers currentUsers;
+    private final ai.mindconnect.agentrest.auth.VectorStoreAccess storeAccess;
 
     public VectorStoreUiController(VectorStores stores, LlmConfigRepository llmConfigs,
                                       ai.mindconnect.filestore.FileStore fileStore,
-                                      ai.mindconnect.agentrest.service.VectorStoreService vectorStoreService) {
+                                      ai.mindconnect.agentrest.service.VectorStoreService vectorStoreService,
+                                      ai.mindconnect.agentrest.auth.CurrentUsers currentUsers,
+                                      ai.mindconnect.agentrest.auth.VectorStoreAccess storeAccess) {
         this.stores = stores;
         this.llmConfigs = llmConfigs;
         this.fileStore = fileStore;
         this.vectorStoreService = vectorStoreService;
+        this.currentUsers = currentUsers;
+        this.storeAccess = storeAccess;
     }
 
     // ── overview page ──────────────────────────────────────────────────────
@@ -102,9 +114,12 @@ public class VectorStoreUiController {
                 .rowAction(UiAction.danger("delete", "Delete").icon("delete")
                         .confirm("Delete this store registration? (Data files stay on the backend.)")
                         .dispatch("DELETE", "/admin/vector-stores/stores/{id}"));
+        ai.mindconnect.agent.UserId caller = currentUsers.require();
         Set<String> registered = new LinkedHashSet<>();
         for (VectorStoreInstance i : stores.registry().instances()) {
             registered.add(i.name());
+            // A chat's upload store is its user's: nobody else sees it listed.
+            if (!storeAccess.reachable(i, caller)) continue;
             instances.row(Map.of(
                     "id", i.name(),
                     "name", i.name(),
@@ -117,7 +132,7 @@ public class VectorStoreUiController {
         // era, or created outside the tools) — shown as implicit defaults.
         for (String discovered : stores.discoverStores(
                 stores.templates().get(0).backend(), Map.of())) {
-            if (registered.contains(discovered)) continue;
+            if (registered.contains(discovered) || !storeAccess.reachable(discovered, null, caller)) continue;
             VectorStoreInstance implicit = stores.settingsFor(discovered);
             instances.row(Map.of(
                     "id", discovered,
@@ -141,7 +156,10 @@ public class VectorStoreUiController {
                 .rowAction(UiAction.danger("delete", "Delete").icon("delete")
                         .confirm("Delete this file from the file store? (Already-ingested chunks stay.)")
                         .dispatch("DELETE", "/admin/vector-stores/files/{id}"));
+        // What the Files API gives the caller by id: their own files and those
+        // stored before creators were recorded — nobody else's names and ids.
         for (ai.mindconnect.filestore.StoredFile f : fileStore.list()) {
+            if (!f.readableBy(caller)) continue;
             files.row(Map.of(
                     "id", f.id().value(),
                     "fid", f.id().value(),
@@ -234,12 +252,8 @@ public class VectorStoreUiController {
     /** The uploads are stored as the signed-in user's files — the file store records who put them there. */
     @PostMapping(value = "/files/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public UiPage uploadFiles(@org.springframework.web.bind.annotation.RequestParam("vs-files-upload")
-                              List<org.springframework.web.multipart.MultipartFile> uploads,
-                              @org.springframework.security.core.annotation.AuthenticationPrincipal
-                              org.springframework.security.oauth2.core.oidc.user.OidcUser user) {
-        String userId = ai.mindconnect.chatui.service.SessionOwnership.userIdOf(user);
-        ai.mindconnect.agent.UserId creator = userId == null || userId.isBlank()
-                ? null : ai.mindconnect.agent.UserId.of(userId);
+                              List<org.springframework.web.multipart.MultipartFile> uploads) {
+        ai.mindconnect.agent.UserId creator = currentUsers.require();
         for (var upload : uploads) {
             try (var content = upload.getInputStream()) {
                 fileStore.save(upload.getOriginalFilename(), upload.getContentType(), content, creator);
@@ -258,12 +272,8 @@ public class VectorStoreUiController {
      */
     @GetMapping("/files/{id}/content")
     public org.springframework.http.ResponseEntity<org.springframework.core.io.InputStreamResource> downloadStoredFile(
-            @PathVariable String id,
-            @org.springframework.security.core.annotation.AuthenticationPrincipal
-            org.springframework.security.oauth2.core.oidc.user.OidcUser user) throws java.io.IOException {
-        String userId = ai.mindconnect.chatui.service.SessionOwnership.userIdOf(user);
-        ai.mindconnect.agent.UserId caller = userId == null || userId.isBlank()
-                ? null : ai.mindconnect.agent.UserId.of(userId);
+            @PathVariable String id) throws java.io.IOException {
+        ai.mindconnect.agent.UserId caller = currentUsers.require();
         var file = fileStore.find(ai.mindconnect.filestore.FileId.of(id))
                 .filter(f -> f.readableBy(caller)).orElse(null);
         if (file == null) {
@@ -277,9 +287,14 @@ public class VectorStoreUiController {
                 .body(new org.springframework.core.io.InputStreamResource(fileStore.content(file.id())));
     }
 
+    /** Only the uploader deletes a file — the Files API's rule; a file without a creator stays. */
     @DeleteMapping("/files/{id}")
     public UiPage deleteStoredFile(@PathVariable String id) throws java.io.IOException {
-        fileStore.delete(ai.mindconnect.filestore.FileId.of(id));
+        var fileId = ai.mindconnect.filestore.FileId.of(id);
+        if (fileStore.find(fileId).filter(f -> f.createdBy(currentUsers.require())).isEmpty()) {
+            return list("files").toast(UiToast.error("Only the user who uploaded a file can delete it."));
+        }
+        fileStore.delete(fileId);
         return list("files");
     }
 
@@ -446,6 +461,9 @@ public class VectorStoreUiController {
     public UiPage createStore(@RequestBody Map<String, Object> raw) {
         var body = new FormBody(raw);
         String name = body.str("name");
+        if (ai.mindconnect.agentrest.auth.VectorStoreAccess.isChatStoreName(name)) {
+            return list("stores").toast(UiToast.error(ai.mindconnect.agentrest.auth.VectorStoreAccess.RESERVED_NAME));
+        }
         if (name != null && !name.isBlank()) {
             stores.open(name.trim(), body.str("template"), VectorStoreInstance.Scope.GLOBAL, null);
         }
@@ -454,7 +472,8 @@ public class VectorStoreUiController {
 
     @GetMapping("/stores/{name}")
     public UiPage storeDetail(@PathVariable String name) {
-        return storeDetail(name, null, null, null);
+        UiPage refused = refuseForeignStore(name);
+        return refused != null ? refused : storeDetail(name, null, null, null);
     }
 
     private UiPage storeDetail(String name, String lastQuery, UiNode searchResult) {
@@ -535,6 +554,8 @@ public class VectorStoreUiController {
     public UiPage upload(@PathVariable String name,
                          @org.springframework.web.bind.annotation.RequestParam("vs-upload")
                          List<org.springframework.web.multipart.MultipartFile> files) {
+        UiPage refused = refuseForeignStore(name);
+        if (refused != null) return refused;
         StringBuilder message = new StringBuilder();
         for (var file : files) {
             String fileName = file.getOriginalFilename() == null ? "upload.bin" : file.getOriginalFilename();
@@ -549,6 +570,8 @@ public class VectorStoreUiController {
 
     @PostMapping("/stores/{name}/search")
     public UiPage search(@PathVariable String name, @RequestBody Map<String, Object> raw) {
+        UiPage refused = refuseForeignStore(name);
+        if (refused != null) return refused;
         var body = new FormBody(raw);
         String query = body.str("query");
         if (query == null || query.isBlank()) {
@@ -607,14 +630,29 @@ public class VectorStoreUiController {
     @DeleteMapping("/stores/{name}/files")
     public UiPage deleteFile(@PathVariable String name,
                              @org.springframework.web.bind.annotation.RequestParam("file") String fileId) {
+        UiPage refused = refuseForeignStore(name);
+        if (refused != null) return refused;
         stores.openWith(stores.settingsFor(name)).deleteFile(fileId);
         return storeDetail(name, null, (UiNode) null);
     }
 
     @DeleteMapping("/stores/{name}")
     public UiPage deleteStore(@PathVariable String name) {
+        UiPage refused = refuseForeignStore(name);
+        if (refused != null) return refused;
         stores.registry().deleteInstance(name);
         return list("stores");
+    }
+
+    /**
+     * The store overview with a "no such store" note when {@code name} is
+     * another user's chat upload store; null when the caller may reach it.
+     */
+    private UiPage refuseForeignStore(String name) {
+        if (storeAccess.reachable(name, stores.registry().instance(name).orElse(null), currentUsers.require())) {
+            return null;
+        }
+        return list("stores").toast(UiToast.error("There is no store '" + name + "'."));
     }
 
     // ── helpers ────────────────────────────────────────────────────────────

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/page/ProfilePage.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/page/ProfilePage.java
@@ -1,0 +1,185 @@
+package ai.mindconnect.adminui.ui.page;
+
+import ai.mindconnect.adminui.ui.AdminPage;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiDetail;
+import ai.mindconnect.ui.model.UiField;
+import ai.mindconnect.ui.model.UiForm;
+import ai.mindconnect.ui.model.UiNode;
+import ai.mindconnect.ui.model.UiPage;
+import ai.mindconnect.ui.model.UiStack;
+import ai.mindconnect.ui.model.UiTable;
+import ai.mindconnect.ui.model.UiText;
+import ai.mindconnect.ui.model.UiTrigger;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.domain.User;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The signed-in user's own page at {@code /admin/profile}, reached from the
+ * avatar in the header: who they are signed in as, and the personal API
+ * tokens they issued — the way a program calls the REST API as them.
+ *
+ * <p>A token's secret never appears here. It is shown once, in the dialog
+ * that follows its creation ({@link #secretView}); the list knows only the
+ * start of it, enough to tell two tokens apart.
+ *
+ * <p>On an installation without authentication the API answers everyone as
+ * the dev user, token or not. The page says so, because a token that seems to
+ * work there proves nothing about the installation it is meant for.
+ */
+public class ProfilePage extends AdminPage {
+
+    /** The token table — replaced in place after a token is created or revoked. */
+    public static final String TOKENS_ID = "api-tokens";
+
+    /** What a user of an installation without authentication has to know before trusting a token to protect anything. */
+    public static final String AUTH_OFF_NOTE = "Authentication is off on this installation: the API answers every "
+            + "request as the dev user, with or without a token. A token only protects anything where "
+            + "authentication is on (mindconnect.auth.enabled).";
+
+    static final String API = "/admin/api/profile";
+    static final String NEW_TOKEN_FORM_ID = "api-token-form";
+
+    private static final DateTimeFormatter TIME =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'").withZone(ZoneOffset.UTC);
+
+    private final UserId userId;
+    private final User user;
+    private final String displayName;
+    private final String email;
+    private final List<ApiToken> tokens;
+    private final boolean authEnabled;
+
+    /**
+     * @param user        the stored user record; null before it was first recorded
+     * @param displayName the name the login carries; null to fall back to the record
+     * @param email       the e-mail the login carries; null to fall back to the record
+     * @param authEnabled whether this installation checks tokens at all
+     */
+    public ProfilePage(UserId userId, User user, String displayName, String email, List<ApiToken> tokens,
+                       boolean authEnabled) {
+        this.userId = userId;
+        this.user = user;
+        this.displayName = displayName;
+        this.email = email;
+        this.tokens = tokens;
+        this.authEnabled = authEnabled;
+    }
+
+    @Override
+    public UiPage render() {
+        UiDetail details = UiDetail.of("profile-user", title()).icon("user-round")
+                .field(UiField.text("userId", "User id", userId.value()))
+                .field(UiField.text("email", "E-mail", orDash(email != null ? email : user == null ? null : user.email())))
+                .field(UiField.text("since", "Known since", user == null ? "—" : time(user.createdAt())));
+        UiText help = UiText.of("profile-token-help",
+                "A program calls the REST API (/api/…, /v1/…) as you with one of your tokens, sent as the "
+                + "header \"Authorization: Bearer <token>\". A token's secret is shown once, when it is "
+                + "created. Revoke a token you no longer need — programs using it stop working at once.");
+        UiStack page = UiStack.of("profile").gap(20);
+        if (!authEnabled) {
+            page.child(authOffNote("profile-auth-off"));
+        }
+        page.child(details)
+                .child(tokenTable(tokens))
+                .child(help);
+        return UiPage.of("/admin/profile", page);
+    }
+
+    /** The user's tokens, newest first as given, with a revoke action per row. */
+    public static UiTable tokenTable(List<ApiToken> tokens) {
+        UiTable table = UiTable.of(TOKENS_ID, "API tokens").icon("key-round")
+                .column(UiTable.Column.text("name", "Name"))
+                .column(UiTable.Column.text("hint", "Token"))
+                .column(UiTable.Column.text("created", "Created"))
+                .column(UiTable.Column.text("lastUsed", "Last used"))
+                .column(UiTable.Column.text("expires", "Expires"))
+                .action(UiAction.primary("new-token", "New token").icon("add")
+                        .dispatch("GET", API + "/tokens/new"))
+                .rowAction(UiAction.danger("revoke", "Revoke").icon("delete")
+                        .confirm("Revoke this token? Programs using it stop working at once.")
+                        .dispatch("DELETE", API + "/tokens/{id}"));
+        for (ApiToken token : tokens) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("id", token.id().value());
+            row.put("name", orDash(token.name()));
+            row.put("hint", token.hint() == null ? "—" : token.hint() + "…");
+            row.put("created", time(token.createdAt()));
+            row.put("lastUsed", token.lastUsedAt() == null ? "never" : time(token.lastUsedAt()));
+            row.put("expires", token.expiresAt() == null ? "never" : time(token.expiresAt()));
+            table.row(row);
+        }
+        return table;
+    }
+
+    /** The form of the "New token" dialog; {@code error} is shown above the fields when set. */
+    public static UiForm newTokenForm(String error) {
+        UiForm form = UiForm.of(NEW_TOKEN_FORM_ID, null)
+                .field(UiField.text("name", "Name", null).asEditable().asRequired()
+                        .placeholder("e.g. laptop, CI")
+                        .hint("What the token is for — it names the token in the list."))
+                .field(UiField.select("expiresIn", "Expires", "90", List.of(
+                                UiField.Option.of("30", "in 30 days"),
+                                UiField.Option.of("90", "in 90 days"),
+                                UiField.Option.of("365", "in a year"),
+                                UiField.Option.of("never", "never")))
+                        .asEditable())
+                .action(UiAction.primary("create", "Create token").icon("key-round")
+                        .dispatch("POST", API + "/tokens", NEW_TOKEN_FORM_ID))
+                .action(UiAction.secondary("cancel", "Cancel")
+                        .dispatch("POST", API + "/tokens/dialog/close"));
+        if (error != null) {
+            form.error(error);
+        }
+        return form;
+    }
+
+    /**
+     * The one view of a new token's secret: the value to copy, and a request
+     * that uses it against this installation — with the warning that the
+     * request proves nothing while authentication is off.
+     */
+    public static UiNode secretView(String secret, String baseUrl, boolean authEnabled) {
+        // An input rather than text, so the value can be selected and copied by
+        // hand; the Copy button beside it puts it on the clipboard in one click
+        // (the browser-side "mc-copy-field" handler — semantic-ui has no
+        // clipboard behaviour of its own).
+        UiForm form = UiForm.of("api-token-secret", null)
+                .field(UiField.text("secret", "Your new token", secret).asEditable()
+                        .trailing(UiAction.secondary("copy-secret", "Copy").icon("copy")
+                                .onClick(UiTrigger.invoke("mc-copy-field")))
+                        .hint("Copy it now. It is shown only this once and cannot be displayed again."))
+                .content(UiText.of("api-token-example",
+                        "curl -H \"Authorization: Bearer " + secret + "\" " + baseUrl + "/api/agents"));
+        if (!authEnabled) {
+            form.content(authOffNote("api-token-auth-off"));
+        }
+        return form.action(UiAction.primary("done", "Done")
+                .dispatch("POST", API + "/tokens/dialog/close"));
+    }
+
+    private static UiNode authOffNote(String id) {
+        return UiText.of(id, "⚠ " + AUTH_OFF_NOTE).withCssClass("task-card-body");
+    }
+
+    private String title() {
+        if (displayName != null && !displayName.isBlank()) return displayName;
+        return user != null ? user.label() : userId.value();
+    }
+
+    private static String time(Instant instant) {
+        return instant == null ? "—" : TIME.format(instant);
+    }
+
+    private static String orDash(String value) {
+        return value == null || value.isBlank() ? "—" : value;
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/app.js
@@ -10,6 +10,7 @@ import { install as installMarkdown }   from "/sui-ext/markdown/extension.js";
 import { install as installDiagram }    from "/sui-ext/diagram/extension.js";
 import { watchConnectionBudget }        from "/js/connection-budget.js";
 import { installAudioRecorder }         from "/js/audio-recorder.js";
+import { installCopyField }             from "/js/copy-field.js";
 
 // ── Renderer + extensions ────────────────────────────────────────────────────
 
@@ -77,6 +78,9 @@ watchConnectionBudget(bus);
 // dialog. Browser-only: the handler records and posts, the server never knows
 // it was not an upload.
 installAudioRecorder(bus);
+
+// "Copy" beside a field, e.g. a new API token's secret on the profile page.
+installCopyField(bus);
 
 // Console hook. `mc.streams()` lists the server-sent streams this tab holds
 // (a chat page should show `user-stream` and one `msg-list-…`, nothing

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/copy-field.js
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/js/copy-field.js
@@ -1,0 +1,45 @@
+// "Copy" beside a field: puts the field's value on the clipboard.
+//
+// semantic-ui has no clipboard behaviour, so the server gives the field a
+// trailing action with UiTrigger.invoke("mc-copy-field") and this handler does
+// the rest in the browser. It copies the input of the field the clicked button
+// belongs to — no id to pass — and selects the text as well, so the value is
+// still at hand where the clipboard API is not available (plain http on a
+// host other than localhost).
+
+/** Registers the "mc-copy-field" client handler on the event bus. */
+export function installCopyField(bus) {
+    bus.registerClientHandler("mc-copy-field", async (ctx) => {
+        const input = ctx.sourceElement?.closest(".sui-field")?.querySelector("input, textarea");
+        if (!input) {
+            console.warn("mc-copy-field: no field around the clicked element", ctx.sourceElement);
+            return null;
+        }
+        input.focus();
+        input.select();
+
+        let copied = false;
+        if (navigator.clipboard && window.isSecureContext) {
+            try {
+                await navigator.clipboard.writeText(input.value);
+                copied = true;
+            } catch {
+                // denied or unavailable: fall back below
+            }
+        }
+        if (!copied) {
+            try {
+                copied = document.execCommand("copy");
+            } catch {
+                copied = false;
+            }
+        }
+
+        return {
+            patches: [],
+            toasts: [copied
+                ? { level: "SUCCESS", title: "Copied", message: "The value is on the clipboard.", durationMs: 2500 }
+                : { level: "WARN", title: "Not copied", message: "The browser refused — the value is selected, copy it with Ctrl+C / ⌘C.", durationMs: 5000 }],
+        };
+    });
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/ProfileUiControllerTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/ProfileUiControllerTest.java
@@ -1,0 +1,127 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.adminui.ui.page.ProfilePage;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.adapter.memory.InMemoryApiTokenRepository;
+import ai.mindconnect.user.adapter.memory.InMemoryUserRepository;
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.service.ApiTokenService;
+import ai.mindconnect.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The profile page issues a token's secret exactly once, never lists it, and
+ * lets a user revoke only their own tokens. Without authentication it says
+ * that a token protects nothing there.
+ */
+class ProfileUiControllerTest {
+
+    private static final Instant NOW = Instant.parse("2026-09-11T12:00:00Z");
+    private static final Pattern SECRET = Pattern.compile("mct_[A-Za-z0-9_-]{43}");
+
+    private final ApiTokenService tokens = new ApiTokenService(new InMemoryApiTokenRepository(),
+            Clock.fixed(NOW, ZoneOffset.UTC));
+    private final ProfileUiController controller = controller(true);
+
+    private ProfileUiController controller(boolean authEnabled) {
+        return new ProfileUiController(tokens, new UserService(new InMemoryUserRepository()),
+                Clock.fixed(NOW, ZoneOffset.UTC), authEnabled);
+    }
+
+    @Test
+    void aCreatedTokenIsShownOnceAndListedWithoutItsSecret() throws Exception {
+        String created = json(controller.create(user("alice"), Map.of("name", "laptop", "expiresIn", "30")));
+
+        Matcher secret = SECRET.matcher(created);
+        assertThat(secret.find()).as("the dialog shows the secret").isTrue();
+        assertThat(created).contains("mc-copy-field");
+        assertThat(tokens.authenticate(secret.group())).map(ApiToken::userId).contains(UserId.of("alice"));
+
+        List<ApiToken> listed = tokens.list(UserId.of("alice"));
+        assertThat(listed).singleElement().satisfies(token -> {
+            assertThat(token.name()).isEqualTo("laptop");
+            assertThat(token.expiresAt()).isEqualTo(NOW.plus(Duration.ofDays(30)));
+        });
+
+        String page = json(controller.profile(user("alice")));
+        assertThat(page).contains("laptop").contains(listed.get(0).hint())
+                .doesNotContain(secret.group()).doesNotContain(listed.get(0).tokenHash());
+    }
+
+    @Test
+    void withoutAuthenticationThePageAndTheDialogSayATokenProtectsNothing() throws Exception {
+        ProfileUiController open = controller(false);
+
+        assertThat(json(open.profile(user("alice")))).contains(ProfilePage.AUTH_OFF_NOTE);
+        assertThat(json(open.create(user("alice"), Map.of("name", "curl", "expiresIn", "30"))))
+                .contains(ProfilePage.AUTH_OFF_NOTE);
+
+        assertThat(json(controller.profile(user("alice")))).doesNotContain(ProfilePage.AUTH_OFF_NOTE);
+    }
+
+    @Test
+    void neverMeansNoExpiryAndAnUnknownChoiceTheDefault() {
+        assertThat(controller.expiry("never")).isNull();
+        assertThat(controller.expiry("365")).isEqualTo(NOW.plus(Duration.ofDays(365)));
+        assertThat(controller.expiry("soon")).isEqualTo(NOW.plus(Duration.ofDays(90)));
+    }
+
+    @Test
+    void aTokenWithoutANameIsRefusedInTheDialog() throws Exception {
+        String answer = json(controller.create(user("alice"), Map.of("name", " ", "expiresIn", "never")));
+
+        assertThat(answer).contains("A token needs a name");
+        assertThat(tokens.list(UserId.of("alice"))).isEmpty();
+    }
+
+    @Test
+    void onlyTheOwnerCanRevokeAToken() throws Exception {
+        String secret = tokens.issue(UserId.of("alice"), "ci", null).secret();
+        String tokenId = tokens.list(UserId.of("alice")).get(0).id().value();
+
+        String bobs = json(controller.revoke(user("bob"), tokenId));
+        assertThat(bobs).contains("Nothing revoked");
+        assertThat(tokens.authenticate(secret)).isPresent();
+
+        String alices = json(controller.revoke(user("alice"), tokenId));
+        assertThat(alices).contains("Token revoked");
+        assertThat(tokens.authenticate(secret)).isEmpty();
+
+        assertThat(json(controller.revoke(user("alice"), "Not An Id"))).contains("Nothing revoked");
+    }
+
+    @Test
+    void theListShowsOnlyTheSignedInUsersTokens() throws Exception {
+        tokens.issue(UserId.of("bob"), "bobs-token", null);
+
+        assertThat(json(controller.profile(user("alice")))).doesNotContain("bobs-token");
+    }
+
+    private static OidcUser user(String name) {
+        OidcIdToken idToken = OidcIdToken.withTokenValue("id").subject("sub-" + name)
+                .claim(StandardClaimNames.PREFERRED_USERNAME, name)
+                .issuedAt(NOW).expiresAt(NOW.plusSeconds(60)).build();
+        return new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken);
+    }
+
+    private static String json(Object node) throws Exception {
+        return new ObjectMapper().findAndRegisterModules().writeValueAsString(node);
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/VectorStoreFileDownloadTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/VectorStoreFileDownloadTest.java
@@ -2,24 +2,23 @@ package ai.mindconnect.adminui.ui.controller;
 
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUserResolver;
+import ai.mindconnect.agentrest.auth.CurrentUsers;
 import ai.mindconnect.filestore.StoredFile;
 import ai.mindconnect.filestore.filesystem.FilesystemFileStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
-import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
-import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,25 +33,38 @@ class VectorStoreFileDownloadTest {
     @TempDir
     Path dir;
 
+    private final AtomicReference<UserId> caller = new AtomicReference<>();
+
     @Test
     void theSignedInUserDownloadsTheirOwnFilesButNotSomebodyElses() throws Exception {
         FilesystemFileStore store = new FilesystemFileStore(dir, new Namespace("test"));
-        VectorStoreUiController controller = new VectorStoreUiController(null, null, store, null);
+        VectorStoreUiController controller = new VectorStoreUiController(null, null, store, null, currentUsers(), null);
         StoredFile alices = store.save("notes.txt", "text/plain", text("hello"), UserId.of("alice"));
         StoredFile legacy = store.save("old.txt", "text/plain", text("before creators"), null);
 
-        ResponseEntity<InputStreamResource> own = controller.downloadStoredFile(alices.id().value(), user("alice"));
+        actAs("alice");
+        ResponseEntity<InputStreamResource> own = controller.downloadStoredFile(alices.id().value());
         assertThat(own.getStatusCode().value()).isEqualTo(200);
         assertThat(own.getHeaders().getFirst("Content-Disposition")).contains("notes.txt");
         assertThat(body(own)).isEqualTo("hello");
-
-        assertThat(controller.downloadStoredFile(alices.id().value(), user("bob")).getStatusCode().value())
+        assertThat(controller.downloadStoredFile(UUID.randomUUID().toString()).getStatusCode().value())
                 .isEqualTo(404);
-        ResponseEntity<InputStreamResource> old = controller.downloadStoredFile(legacy.id().value(), user("bob"));
+
+        actAs("bob");
+        assertThat(controller.downloadStoredFile(alices.id().value()).getStatusCode().value()).isEqualTo(404);
+        ResponseEntity<InputStreamResource> old = controller.downloadStoredFile(legacy.id().value());
         assertThat(old.getStatusCode().value()).isEqualTo(200);
         assertThat(body(old)).isEqualTo("before creators");
-        assertThat(controller.downloadStoredFile(UUID.randomUUID().toString(), user("alice")).getStatusCode().value())
-                .isEqualTo(404);
+    }
+
+    private void actAs(String user) {
+        caller.set(UserId.of(user));
+    }
+
+    private CurrentUsers currentUsers() {
+        var beans = new StaticListableBeanFactory();
+        beans.addBean("resolver", (CurrentUserResolver) () -> Optional.ofNullable(caller.get()));
+        return new CurrentUsers(beans.getBeanProvider(CurrentUserResolver.class), true, "dev");
     }
 
     private static InputStream text(String content) {
@@ -63,13 +75,5 @@ class VectorStoreFileDownloadTest {
         try (InputStream in = response.getBody().getInputStream()) {
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }
-    }
-
-    private static OidcUser user(String name) {
-        Instant now = Instant.now();
-        OidcIdToken idToken = OidcIdToken.withTokenValue("id").subject("sub-" + name)
-                .claim(StandardClaimNames.PREFERRED_USERNAME, name)
-                .issuedAt(now).expiresAt(now.plusSeconds(60)).build();
-        return new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken);
     }
 }

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/VectorStoreFileDownloadTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/VectorStoreFileDownloadTest.java
@@ -1,0 +1,75 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.filestore.StoredFile;
+import ai.mindconnect.filestore.filesystem.FilesystemFileStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Download button of the vector-store files tab runs on the browser
+ * session, since the Files API takes bearer tokens only — and hands the
+ * signed-in user exactly what the Files API would: their own files and those
+ * stored before creators were recorded, nobody else's.
+ */
+class VectorStoreFileDownloadTest {
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void theSignedInUserDownloadsTheirOwnFilesButNotSomebodyElses() throws Exception {
+        FilesystemFileStore store = new FilesystemFileStore(dir, new Namespace("test"));
+        VectorStoreUiController controller = new VectorStoreUiController(null, null, store, null);
+        StoredFile alices = store.save("notes.txt", "text/plain", text("hello"), UserId.of("alice"));
+        StoredFile legacy = store.save("old.txt", "text/plain", text("before creators"), null);
+
+        ResponseEntity<InputStreamResource> own = controller.downloadStoredFile(alices.id().value(), user("alice"));
+        assertThat(own.getStatusCode().value()).isEqualTo(200);
+        assertThat(own.getHeaders().getFirst("Content-Disposition")).contains("notes.txt");
+        assertThat(body(own)).isEqualTo("hello");
+
+        assertThat(controller.downloadStoredFile(alices.id().value(), user("bob")).getStatusCode().value())
+                .isEqualTo(404);
+        ResponseEntity<InputStreamResource> old = controller.downloadStoredFile(legacy.id().value(), user("bob"));
+        assertThat(old.getStatusCode().value()).isEqualTo(200);
+        assertThat(body(old)).isEqualTo("before creators");
+        assertThat(controller.downloadStoredFile(UUID.randomUUID().toString(), user("alice")).getStatusCode().value())
+                .isEqualTo(404);
+    }
+
+    private static InputStream text(String content) {
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String body(ResponseEntity<InputStreamResource> response) throws Exception {
+        try (InputStream in = response.getBody().getInputStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static OidcUser user(String name) {
+        Instant now = Instant.now();
+        OidcIdToken idToken = OidcIdToken.withTokenValue("id").subject("sub-" + name)
+                .claim(StandardClaimNames.PREFERRED_USERNAME, name)
+                .issuedAt(now).expiresAt(now.plusSeconds(60)).build();
+        return new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken);
+    }
+}

--- a/agents/server/mc-agent-api-app/pom.xml
+++ b/agents/server/mc-agent-api-app/pom.xml
@@ -21,6 +21,11 @@
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-agent-api-rest</artifactId>
         </dependency>
+        <!-- bearer authentication of the REST API: Keycloak JWT or personal API token -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-security</artifactId>
+        </dependency>
         <!-- persistence: one starter per backend, mindconnect.persistence picks -->
         <dependency>
             <groupId>ai.mindconnect</groupId>

--- a/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/SecurityConfig.java
+++ b/agents/server/mc-agent-api-app/src/main/java/ai/mindconnect/agentapp/SecurityConfig.java
@@ -1,0 +1,62 @@
+package ai.mindconnect.agentapp;
+
+import ai.mindconnect.agent.security.ApiAuthentication;
+import ai.mindconnect.agent.security.DevUserFilter;
+import ai.mindconnect.agent.security.UserRecorder;
+import ai.mindconnect.agent.security.UserRecordingFilter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+/**
+ * The agent server serves the REST API to programs, so its security has no
+ * browser in it: no login page, no session, no CSRF token.
+ *
+ * <ul>
+ *   <li><b>auth enabled</b> ({@code mindconnect.auth.enabled=true}): every
+ *       request carries a bearer token — a JWT of the configured issuer
+ *       ({@code mindconnect.auth.jwt.issuer-uri}) or a personal API token
+ *       created in the admin UI of an installation sharing this server's data.
+ *       Without one: 401 with {@code WWW-Authenticate: Bearer} and a JSON body
+ *       saying why. The OpenAPI
+ *       description and Swagger UI stay readable.</li>
+ *   <li><b>auth disabled</b> (the default): every request runs as the dev user
+ *       ({@code mindconnect.auth.dev-user}).</li>
+ * </ul>
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "mindconnect.auth.enabled", havingValue = "true")
+    SecurityFilterChain securedFilterChain(HttpSecurity http, ApiAuthentication api) throws Exception {
+        api.apply(http
+            .cors(Customizer.withDefaults())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/error").permitAll()
+                .anyRequest().authenticated()));
+        return http.build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "mindconnect.auth.enabled", havingValue = "false", matchIfMissing = true)
+    SecurityFilterChain openFilterChain(HttpSecurity http,
+                                        @Value("${mindconnect.auth.dev-user:mc_user}") String devUser,
+                                        UserRecorder userRecorder) throws Exception {
+        http
+            .cors(Customizer.withDefaults())
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .addFilterBefore(new DevUserFilter(devUser), AuthorizationFilter.class)
+            .addFilterBefore(new UserRecordingFilter(userRecorder), AuthorizationFilter.class);
+        return http.build();
+    }
+}

--- a/agents/server/mc-agent-api-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-api-app/src/main/resources/application.yaml
@@ -25,6 +25,17 @@ mindconnect:
   # The namespace this process runs in: file data under data.base-dir/<namespace>,
   # a namespace key column in Postgres. One process serves one namespace.
   namespace: ${MC_NAMESPACE:local}
+  # Authentication of the REST API. Off by default: every request runs as the
+  # dev user. On: every request needs a bearer token — a JWT of the issuer
+  # below (Keycloak) or a personal API token created in the admin UI, which
+  # works here when both apps share their data (same data directory or
+  # database, same namespace).
+  auth:
+    enabled: ${MC_AUTH_ENABLED:false}
+    dev-user: ${MC_DEV_USER:mc_user}
+    jwt:
+      issuer-uri: ${KC_ISSUER_URI:}
+      audiences: ${MC_JWT_AUDIENCES:}
   postgres:
     url: ${MC_POSTGRES_URL:jdbc:postgresql://localhost:5432/mindconnect}
     username: ${MC_POSTGRES_USER:}

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/config/ResponsesApiConfiguration.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/config/ResponsesApiConfiguration.java
@@ -7,6 +7,7 @@ import ai.mindconnect.agent.responses.ResponsesMapper;
 import ai.mindconnect.agent.responses.SessionBinder;
 import ai.mindconnect.agent.runtime.service.AgentChatService;
 import ai.mindconnect.agent.runtime.service.AgentSessionService;
+import ai.mindconnect.agentrest.auth.CurrentUsers;
 import ai.mindconnect.llm.port.out.LlmConfigRepository;
 import ai.mindconnect.message.port.in.ConversationManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,19 +34,13 @@ public class ResponsesApiConfiguration {
     private String defaultAgent;
 
     /**
-     * Every request runs as this user until authentication is wired up.
-     * Stated as a property rather than hidden in a constant, so an operator
-     * can see what the API acts as before exposing it.
-     */
-    @Value("${mindconnect.responses.user-id:mc_user}")
-    private String userId;
-
-    /**
-     * The backend, with file support when the host has a file store and the
-     * chat's attach service: an {@code input_file} or {@code input_image}
-     * part lands in the store and on the session the way a chat upload
-     * does — a document is ingested for {@code vector_search}, an image or
-     * PDF goes to the model with the message.
+     * The backend, acting for the authenticated caller of each request
+     * ({@link CurrentUsers}): sessions, responses and files are the caller's
+     * own. With file support when the host has a file store and the chat's
+     * attach service: an {@code input_file} or {@code input_image} part lands
+     * in the store and on the session the way a chat upload does — a document
+     * is ingested for {@code vector_search}, an image or PDF goes to the model
+     * with the message.
      */
     @Bean
     @ConditionalOnMissingBean
@@ -53,9 +48,10 @@ public class ResponsesApiConfiguration {
                                                        AgentSessionService sessions,
                                                        AgentDefinitionRepository agents,
                                                        ConversationManager conversations,
+                                                       CurrentUsers currentUsers,
                                                        org.springframework.beans.factory.ObjectProvider<ai.mindconnect.filestore.FileStore> fileStore,
                                                        org.springframework.beans.factory.ObjectProvider<ai.mindconnect.agentrest.service.SessionFileService> sessionFiles) {
-        var backend = new AgentRuntimeBackend(chat, sessions, agents, conversations, userId);
+        var backend = new AgentRuntimeBackend(chat, sessions, agents, conversations, currentUsers::require);
         var store = fileStore.getIfAvailable();
         var attach = sessionFiles.getIfAvailable();
         if (store != null && attach != null) {

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/FilesController.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/FilesController.java
@@ -28,6 +28,10 @@ import java.util.Map;
  * {@code input_image} part of any number of requests. The file lands in the
  * runtime's file store — the same one the chat's uploads use — and is
  * attached to a session only when a request references it.
+ *
+ * <p>An upload is the caller's file. Reading one by id goes through the
+ * backend, which answers only the caller's files (and files stored before
+ * creators were recorded); anything else is not found.
  */
 @RestController
 @RequestMapping("/v1")
@@ -58,7 +62,7 @@ public class FilesController {
 
     @GetMapping(value = "/files/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> get(@PathVariable String id) {
-        return backend.files().get(id)
+        return readable(id)
                 .map(f -> ResponseEntity.ok(toDto(f, null)))
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(ResponsesController.error("not_found", "No file with id '" + id + "'.")));
@@ -70,30 +74,32 @@ public class FilesController {
         if (store == null) {
             throw new IllegalStateException("File support is not wired on this server");
         }
-        var stored = fileId(id).flatMap(store::find).orElse(null);
+        // The backend decides whether the caller may read the file; the store only serves the bytes.
+        StoredFile stored = readable(id).orElse(null);
         if (stored == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(ResponsesController.error("not_found", "No file with id '" + id + "'."));
         }
         MediaType type = MediaType.APPLICATION_OCTET_STREAM;
         try {
-            if (stored.contentType() != null) type = MediaType.parseMediaType(stored.contentType());
+            if (stored.mediaType() != null) type = MediaType.parseMediaType(stored.mediaType());
         } catch (RuntimeException ignore) {
             // an odd content type on the record; octet-stream will do
         }
         return ResponseEntity.ok()
                 .contentType(type)
-                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + stored.name() + "\"")
-                .body(new InputStreamResource(store.content(stored.id())));
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + stored.filename() + "\"")
+                .body(new InputStreamResource(store.content(FileId.of(stored.id()))));
     }
 
-    /** The file id, or empty for a value no file id can have — simply not found. */
-    private java.util.Optional<FileId> fileId(String id) {
+    /** The caller's file by id; empty for someone else's, a missing one, or a value no file id can have. */
+    private java.util.Optional<StoredFile> readable(String id) {
         try {
-            return java.util.Optional.of(FileId.of(id));
+            FileId.of(id);
         } catch (IllegalArgumentException e) {
             return java.util.Optional.empty();
         }
+        return backend.files().get(id);
     }
 
     /** OpenAI's file object: {@code id, object, bytes, created_at, filename, purpose}. */

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesController.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesController.java
@@ -38,7 +38,9 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <p>This class translates and delegates; it holds no agent logic. The
  * protocol surface it calls is the same one the OpenAI backend implements in
- * the other direction, which is what makes the two interchangeable.
+ * the other direction, which is what makes the two interchangeable. That
+ * surface acts for the authenticated caller, so a response of someone else's
+ * answers exactly like one that does not exist.
  */
 @RestController
 @RequestMapping("/v1")
@@ -81,6 +83,11 @@ public class ResponsesController {
     private SseEmitter stream(CreateResponseRequest request) {
         SseEmitter emitter = new SseEmitter(0L);        // a turn can take minutes
 
+        // The subscription's callbacks run on the channel's thread, where the
+        // request's caller can no longer be asked — so the backend they use
+        // is bound to the caller here, on the request thread.
+        AgentRuntimeBackend callers = backend.actingFor(backend.currentUser());
+
         ModelResolver.Resolution resolution = models.resolve(request.model());
         Session session = sessions.bind(request, resolution);
 
@@ -90,16 +97,16 @@ public class ResponsesController {
         AtomicReference<ResponseDto> current = new AtomicReference<>();
         StreamEvents events = new StreamEvents(current::get, mapper);
 
-        Response created = backend.responses().create(new ResponseRequest(
+        Response created = callers.responses().create(new ResponseRequest(
                 session.id(), mapper.toItems(request.input()), true, java.util.List.of()));
         current.set(mapper.toDto(created, request.model()));
 
-        var subscription = backend.responses().subscribe(
+        var subscription = callers.responses().subscribe(
                 SubscribeRequest.replay(created.id()),
                 event -> {
                     // Refresh before writing: a lifecycle frame must not
                     // announce "completed" while carrying the queued object.
-                    backend.responses().get(created.id())
+                    callers.responses().get(created.id())
                             .ifPresent(r -> current.set(mapper.toDto(r, request.model())));
                     // One protocol event can be several frames — an item that
                     // opens or closes brings its content part with it.

--- a/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesErrors.java
+++ b/agents/server/mc-agent-api-responses-rest/src/main/java/ai/mindconnect/agent/responses/controller/ResponsesErrors.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Map;
 
@@ -32,6 +33,22 @@ public class ResponsesErrors {
     public ResponseEntity<Map<String, Object>> unknownModel(ModelResolver.UnknownModelException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(error("invalid_request_error", e.getMessage(), "model"));
+    }
+
+    /**
+     * A status the request already carries — above all the 401 of a request
+     * without an authenticated caller, which the catch-all below would report
+     * as a server error.
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> status(ResponseStatusException e) {
+        String type = switch (e.getStatusCode().value()) {
+            case 401 -> "authentication_error";
+            case 404 -> "not_found";
+            default -> e.getStatusCode().is5xxServerError() ? "server_error" : "invalid_request_error";
+        };
+        String message = e.getReason() != null ? e.getReason() : e.getStatusCode().toString();
+        return ResponseEntity.status(e.getStatusCode()).body(error(type, message, null));
     }
 
     /** A request this server understands but cannot accept as sent. */

--- a/agents/server/mc-agent-api-rest/pom.xml
+++ b/agents/server/mc-agent-api-rest/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- In-memory conversations, so controller tests run on the real session service. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-message-repository</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUser.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUser.java
@@ -1,0 +1,20 @@
+package ai.mindconnect.agentrest.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link ai.mindconnect.agent.UserId} controller parameter as the
+ * authenticated caller of the request. The value never comes from the client:
+ * it is what the security layer established (see {@link CurrentUsers}). A
+ * request without an authenticated caller does not reach the method — it is
+ * answered with 401.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser {
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUserResolver.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUserResolver.java
@@ -1,0 +1,18 @@
+package ai.mindconnect.agentrest.auth;
+
+import ai.mindconnect.agent.UserId;
+
+import java.util.Optional;
+
+/**
+ * Who is calling. The REST layer asks this and nothing else; the host's
+ * security layer answers it — {@code mc-agent-security} reads it from the
+ * authenticated principal (a browser login, a bearer JWT, a personal API
+ * token). This module has no security dependency of its own.
+ */
+@FunctionalInterface
+public interface CurrentUserResolver {
+
+    /** The authenticated caller of the current request; empty when the request is not authenticated. */
+    Optional<UserId> currentUser();
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUserWebConfig.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUserWebConfig.java
@@ -1,0 +1,59 @@
+package ai.mindconnect.agentrest.auth;
+
+import ai.mindconnect.agent.UserId;
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+/**
+ * Resolves {@link CurrentUser} parameters from {@link CurrentUsers}, and keeps
+ * them out of the OpenAPI description — a client does not send the caller, it
+ * authenticates as the caller.
+ */
+@Configuration
+public class CurrentUserWebConfig implements WebMvcConfigurer {
+
+    static {
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(CurrentUser.class);
+    }
+
+    private final CurrentUsers currentUsers;
+
+    public CurrentUserWebConfig(CurrentUsers currentUsers) {
+        this.currentUsers = currentUsers;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new Resolver(currentUsers));
+    }
+
+    /** Public for standalone MockMvc setups, which register argument resolvers by hand. */
+    public static class Resolver implements HandlerMethodArgumentResolver {
+
+        private final CurrentUsers currentUsers;
+
+        public Resolver(CurrentUsers currentUsers) {
+            this.currentUsers = currentUsers;
+        }
+
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(CurrentUser.class)
+                    && UserId.class.equals(parameter.getParameterType());
+        }
+
+        @Override
+        public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+            return currentUsers.require();
+        }
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUsers.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/CurrentUsers.java
@@ -1,0 +1,51 @@
+package ai.mindconnect.agentrest.auth;
+
+import ai.mindconnect.agent.UserId;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+/**
+ * The caller of the current request, for controllers ({@link CurrentUser})
+ * and for services that act on the caller's behalf.
+ *
+ * <p>The host's {@link CurrentUserResolver} decides. A host without one gets
+ * the fixed dev user ({@code mindconnect.auth.dev-user}) while authentication
+ * is off — the behaviour of an installation without login — and nobody at all
+ * once {@code mindconnect.auth.enabled=true}: switching authentication on
+ * without a way to tell who is calling must close the API, not open it to a
+ * default user.
+ */
+@Component
+public class CurrentUsers {
+
+    private final ObjectProvider<CurrentUserResolver> resolver;
+    private final boolean authEnabled;
+    private final UserId devUser;
+
+    public CurrentUsers(ObjectProvider<CurrentUserResolver> resolver,
+                        @Value("${mindconnect.auth.enabled:false}") boolean authEnabled,
+                        @Value("${mindconnect.auth.dev-user:mc_user}") String devUser) {
+        this.resolver = resolver;
+        this.authEnabled = authEnabled;
+        this.devUser = UserId.of(devUser);
+    }
+
+    /** The authenticated caller; empty when there is none. */
+    public Optional<UserId> current() {
+        CurrentUserResolver host = resolver.getIfAvailable();
+        if (host != null) {
+            return host.currentUser();
+        }
+        return authEnabled ? Optional.empty() : Optional.of(devUser);
+    }
+
+    /** The authenticated caller, or a 401 for the request. */
+    public UserId require() {
+        return current().orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/SessionAccess.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/SessionAccess.java
@@ -1,0 +1,39 @@
+package ai.mindconnect.agentrest.auth;
+
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.domain.AgentSession;
+import ai.mindconnect.agent.runtime.port.out.AgentSessionRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+/**
+ * The one question every session-addressed REST endpoint asks before it does
+ * anything: is this the caller's session? A session id is not a secret — it
+ * travels in URLs, logs and client state — so the id alone must not open a
+ * session. A session that belongs to someone else is reported exactly like
+ * one that does not exist.
+ */
+@Component
+public class SessionAccess {
+
+    private final AgentSessionRepository sessions;
+
+    public SessionAccess(AgentSessionRepository sessions) {
+        this.sessions = sessions;
+    }
+
+    /** The session, if it exists and belongs to {@code caller}. */
+    public Optional<AgentSession> owned(SessionId sessionId, UserId caller) {
+        return sessions.findById(sessionId).filter(session -> caller.equals(session.userId()));
+    }
+
+    /** The session, or a 404 for the request when it does not exist or is not the caller's. */
+    public AgentSession requireOwned(SessionId sessionId, UserId caller) {
+        return owned(sessionId, caller)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No such session"));
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/VectorStoreAccess.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/auth/VectorStoreAccess.java
@@ -1,0 +1,78 @@
+package ai.mindconnect.agentrest.auth;
+
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.vectorstore.tools.VectorStoreInstance;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Who may reach a vector store. A knowledge base — a {@code GLOBAL} or
+ * {@code AGENT} store — is shared configuration, open to every authenticated
+ * caller. A chat's upload store holds what one user attached to one chat, so
+ * it answers only to the user the chat belongs to; for anyone else it does
+ * not exist.
+ *
+ * <p>Two things make a store a chat's upload store: a registration with scope
+ * {@code SESSION}, whose {@code scopeRef} is the session id, and the
+ * {@value #CHAT_STORE_PREFIX} name the upload pipeline gives it. The name
+ * counts for a store that is not registered yet, or somebody could create
+ * {@code session-<someone else's session>} and read what lands there later —
+ * which is also why nobody may create a store under such a name by hand.
+ */
+@Component
+public class VectorStoreAccess {
+
+    /** The name prefix of a chat's upload store: {@code session-<sessionId>}. */
+    public static final String CHAT_STORE_PREFIX = "session-";
+
+    /** Why a store cannot be created under a chat upload store's name. */
+    public static final String RESERVED_NAME =
+            "Store names starting with '" + CHAT_STORE_PREFIX + "' belong to chat upload stores — choose another name.";
+
+    private final SessionAccess sessions;
+
+    public VectorStoreAccess(SessionAccess sessions) {
+        this.sessions = sessions;
+    }
+
+    /** Whether {@code caller} may reach the registered store {@code instance}. */
+    public boolean reachable(VectorStoreInstance instance, UserId caller) {
+        return reachable(instance.name(), instance, caller);
+    }
+
+    /**
+     * Whether {@code caller} may reach the store {@code name}.
+     *
+     * @param registered the store's registration; null when it has none
+     */
+    public boolean reachable(String name, VectorStoreInstance registered, UserId caller) {
+        Optional<String> chat = chatSessionOf(name, registered);
+        return chat.isEmpty() || ownsSession(chat.get(), caller);
+    }
+
+    /** Whether {@code name} is reserved for chat upload stores. */
+    public static boolean isChatStoreName(String name) {
+        return name != null && name.strip().startsWith(CHAT_STORE_PREFIX);
+    }
+
+    /** The session a chat upload store belongs to; empty for a knowledge base. */
+    static Optional<String> chatSessionOf(String name, VectorStoreInstance registered) {
+        if (registered != null && registered.scope() == VectorStoreInstance.Scope.SESSION) {
+            return Optional.of(registered.scopeRef() == null ? "" : registered.scopeRef());
+        }
+        if (isChatStoreName(name)) {
+            return Optional.of(name.strip().substring(CHAT_STORE_PREFIX.length()));
+        }
+        return Optional.empty();
+    }
+
+    private boolean ownsSession(String sessionId, UserId caller) {
+        try {
+            return sessions.owned(SessionId.of(sessionId), caller).isPresent();
+        } catch (IllegalArgumentException notASessionId) {
+            return false;
+        }
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
@@ -11,6 +11,8 @@ import ai.mindconnect.agent.runtime.service.AgentRegistryService;
 import ai.mindconnect.agent.runtime.service.AgentSessionService;
 import ai.mindconnect.agent.runtime.service.approval.ApprovalScope;
 import ai.mindconnect.agent.runtime.service.approval.ToolApproval;
+import ai.mindconnect.agentrest.auth.CurrentUser;
+import ai.mindconnect.agentrest.auth.SessionAccess;
 import ai.mindconnect.agentrest.dto.CreateAgentRequest;
 import ai.mindconnect.agentrest.dto.StartSessionRequest;
 import ai.mindconnect.agentrest.dto.AttachedFrame;
@@ -41,6 +43,13 @@ import java.util.Map;
  * lifecycle, chat streaming, history and working memory. Delegates to the
  * same use-case services the admin UI runs on ({@link AgentRegistryService},
  * {@link AgentSessionService}, {@link AgentChatService}).
+ *
+ * <p>Sessions belong to the authenticated caller ({@link CurrentUser}): one is
+ * opened for the caller and listed for the caller, and every
+ * {@code /sessions/{sessionId}/…} endpoint asks {@link SessionAccess} before
+ * it does anything — someone else's session answers 404, exactly like one
+ * that does not exist. Agents are operator configuration and stay open to
+ * every authenticated caller.
  */
 @RestController
 @RequestMapping("/api")
@@ -53,6 +62,7 @@ public class AgentApiController {
     private final AgentChatService chatService;
     private final ai.mindconnect.filestore.FileStore fileStore;
     private final UserChannels userChannels;
+    private final SessionAccess sessionAccess;
     private final ObjectMapper compactMapper;
 
     public AgentApiController(AgentRegistryService registryService,
@@ -60,12 +70,14 @@ public class AgentApiController {
                             AgentChatService chatService,
                             ai.mindconnect.filestore.FileStore fileStore,
                             UserChannels userChannels,
+                            SessionAccess sessionAccess,
                             ObjectMapper objectMapper) {
         this.registryService = registryService;
         this.sessionService = sessionService;
         this.chatService = chatService;
         this.fileStore = fileStore;
         this.userChannels = userChannels;
+        this.sessionAccess = sessionAccess;
         this.compactMapper = objectMapper.copy().disable(
                 com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT);
     }
@@ -168,25 +180,22 @@ public class AgentApiController {
     // ── Sessions ────────────────────────────────────────────────────────────
 
     @Operation(tags = "Sessions", summary = "Start a chat session",
-            description = "Opens a new session for the agent; the returned id addresses chat, "
-                    + "history, memory and file endpoints.")
+            description = "Opens a new session for the agent, owned by the authenticated caller; "
+                    + "the returned id addresses chat, history, memory and file endpoints. Body "
+                    + "{agentId} — a userId still sent by an older client is ignored.")
     @PostMapping("/sessions")
-    public AgentSession startSession(@RequestBody StartSessionRequest req) {
-        log.info("POST /api/sessions agentId={} userId={}", req.agentId(), req.userId());
-        AgentSession session = sessionService.openChat(
-                AgentId.of(req.agentId()), UserId.of(req.userId()));
+    public AgentSession startSession(@RequestBody StartSessionRequest req, @CurrentUser UserId caller) {
+        log.info("POST /api/sessions agentId={} user={}", req.agentId(), caller);
+        AgentSession session = sessionService.openChat(AgentId.of(req.agentId()), caller);
         log.info("Session started: {}", session.id());
         return session;
     }
 
-    @Operation(tags = "Sessions", summary = "List a user's sessions for an agent")
+    @Operation(tags = "Sessions", summary = "List the caller's sessions for an agent")
     @GetMapping("/sessions")
-    public List<AgentSession> listSessions(
-            @RequestParam String agentId,
-            @RequestParam String userId) {
-        log.info("GET /api/sessions agentId={} userId={}", agentId, userId);
-        List<AgentSession> sessions = sessionService.listSessions(
-                AgentId.of(agentId), UserId.of(userId));
+    public List<AgentSession> listSessions(@RequestParam String agentId, @CurrentUser UserId caller) {
+        log.info("GET /api/sessions agentId={} user={}", agentId, caller);
+        List<AgentSession> sessions = sessionService.listSessions(AgentId.of(agentId), caller);
         log.info("Found {} session(s)", sessions.size());
         return sessions;
     }
@@ -198,11 +207,12 @@ public class AgentApiController {
                     + "Server-Sent Events: token deltas, tool calls, task updates, then a final "
                     + "Done frame. The stream closes when the turn completes or fails.")
     @PostMapping(value = "/sessions/{sessionId}/chat", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter streaming(@PathVariable String sessionId, @RequestBody String message) {
+    public SseEmitter streaming(@PathVariable String sessionId, @RequestBody String message,
+                                @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         log.info("POST /api/sessions/{}/chat message=\"{}\"", sessionId,
                 message.length() > 80 ? message.substring(0, 80) + "…" : message);
-        return streamTurn(SessionId.of(sessionId),
-                ai.mindconnect.message.domain.ContentPart.text(message));
+        return streamTurn(id, ai.mindconnect.message.domain.ContentPart.text(message));
     }
 
     /**
@@ -221,7 +231,9 @@ public class AgentApiController {
     @PostMapping(value = "/sessions/{sessionId}/chat", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter streamingWithParts(@PathVariable String sessionId,
-                                         @RequestBody ai.mindconnect.agentrest.dto.ChatRequest request) {
+                                         @RequestBody ai.mindconnect.agentrest.dto.ChatRequest request,
+                                         @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         String message = request.message() == null ? "" : request.message();
         log.info("POST /api/sessions/{}/chat (json) message=\"{}\" parts={}", sessionId,
                 message.length() > 80 ? message.substring(0, 80) + "…" : message,
@@ -230,21 +242,28 @@ public class AgentApiController {
         parts.add(new ai.mindconnect.message.domain.ContentPart.Text(message));
         for (var part : request.parts() == null ? List.<ai.mindconnect.agentrest.dto.ChatRequest.Part>of()
                 : request.parts()) {
-            parts.add(toPart(part));
+            parts.add(toPart(part, caller));
         }
         if (message.isBlank() && parts.size() == 1) {
             throw new IllegalArgumentException("A chat message needs text or at least one part");
         }
-        return streamTurn(SessionId.of(sessionId), parts);
+        return streamTurn(id, parts);
     }
 
-    /** A requested part as a domain part — the file's name, type and size from the store. */
-    private ai.mindconnect.message.domain.ContentPart toPart(ai.mindconnect.agentrest.dto.ChatRequest.Part part) {
+    /**
+     * A requested part as a domain part — the file's name, type and size from
+     * the store. A file the caller may not read is unknown here, like an id
+     * that was never uploaded: sending it to the model would hand its content
+     * to the caller.
+     */
+    private ai.mindconnect.message.domain.ContentPart toPart(ai.mindconnect.agentrest.dto.ChatRequest.Part part,
+                                                              UserId caller) {
         if (part.fileId() == null || part.fileId().isBlank()) {
             throw new IllegalArgumentException("A part needs a fileId — upload via POST /api/files first");
         }
-        ai.mindconnect.filestore.StoredFile stored = fileStore.find(FileId.of(part.fileId())).orElseThrow(() ->
-                new IllegalArgumentException("Unknown fileId '" + part.fileId()
+        ai.mindconnect.filestore.StoredFile stored = fileStore.find(FileId.of(part.fileId()))
+                .filter(file -> file.readableBy(caller))
+                .orElseThrow(() -> new IllegalArgumentException("Unknown fileId '" + part.fileId()
                         + "' — upload via POST /api/files first"));
         String kind = part.kind() == null ? "" : part.kind().toLowerCase(java.util.Locale.ROOT);
         return switch (kind) {
@@ -295,24 +314,27 @@ public class AgentApiController {
         return emitter;
     }
 
-    @Operation(tags = "Sessions", summary = "Attach to a user's event stream",
-            description = "The coarse feed across all of a user's sessions: session_started, "
-                    + "session_titled, turn_started, turn_finished, approval_requested and "
-                    + "approval_answered — what a session list or a notification needs, "
-                    + "without attaching to any session. Same reconnect story as the session "
-                    + "stream: the first frame is {type:'attached'} with the buffer bounds, "
-                    + "then every buffered event after afterSeq replays and the stream "
+    @Operation(tags = "Sessions", summary = "Attach to the caller's event stream",
+            description = "The path names the caller — their own user id or 'me'; any other user "
+                    + "answers 404. The coarse feed across all of the caller's sessions: "
+                    + "session_started, session_titled, turn_started, turn_finished, "
+                    + "approval_requested and approval_answered — what a session list or a "
+                    + "notification needs, without attaching to any session. Same reconnect story "
+                    + "as the session stream: the first frame is {type:'attached'} with the buffer "
+                    + "bounds, then every buffered event after afterSeq replays and the stream "
                     + "continues live; each frame carries seq, the cursor for the next "
                     + "reconnect. The tokens of a turn are not here — attach to the session's "
                     + "own stream for those.")
     @GetMapping(value = "/users/{userId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter userStream(@PathVariable String userId,
-                                 @RequestParam(defaultValue = "0") long afterSeq) {
-        log.info("GET /api/users/{}/stream afterSeq={}", userId, afterSeq);
+                                 @RequestParam(defaultValue = "0") long afterSeq,
+                                 @CurrentUser UserId caller) {
+        UserId user = UserPaths.requireSelf(userId, caller);
+        log.info("GET /api/users/{}/stream afterSeq={}", user, afterSeq);
         SseEmitter emitter = new SseEmitter(120_000L);
 
         var attachedSent = new java.util.concurrent.CountDownLatch(1);
-        ai.mindconnect.channel.Subscription subscription = userChannels.subscribe(UserId.of(userId), afterSeq, event -> {
+        ai.mindconnect.channel.Subscription subscription = userChannels.subscribe(user, afterSeq, event -> {
             try {
                 attachedSent.await();
                 emitter.send(SseEmitter.event().data(
@@ -326,7 +348,7 @@ public class AgentApiController {
         try {
             emitter.send(SseEmitter.event().data(
                     compactMapper.writeValueAsString(UserEventFrame.Attached.of(
-                            userChannels.earliestBufferedSeq(UserId.of(userId)), userChannels.lastSeq(UserId.of(userId)))),
+                            userChannels.earliestBufferedSeq(user), userChannels.lastSeq(user))),
                     MediaType.APPLICATION_JSON));
         } catch (Exception e) {
             subscription.close();
@@ -346,8 +368,8 @@ public class AgentApiController {
                     + "running. The SSE stream still ends with its normal Done event once the "
                     + "loop reaches the next cancel-check point.")
     @DeleteMapping("/sessions/{sessionId}/chat")
-    public ResponseEntity<Void> cancelChat(@PathVariable String sessionId) {
-        boolean cancelled = chatService.cancelChat(SessionId.of(sessionId));
+    public ResponseEntity<Void> cancelChat(@PathVariable String sessionId, @CurrentUser UserId caller) {
+        boolean cancelled = chatService.cancelChat(owned(sessionId, caller));
         log.info("DELETE /api/sessions/{}/chat → cancelled={}", sessionId, cancelled);
         return cancelled ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
     }
@@ -364,14 +386,16 @@ public class AgentApiController {
                     + "reattaching with the last seen seq is the intended loop.")
     @GetMapping(value = "/sessions/{sessionId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter sessionStream(@PathVariable String sessionId,
-                                    @RequestParam(defaultValue = "0") long afterSeq) {
+                                    @RequestParam(defaultValue = "0") long afterSeq,
+                                    @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         log.info("GET /api/sessions/{}/stream afterSeq={}", sessionId, afterSeq);
         SseEmitter emitter = new SseEmitter(120_000L);
 
         // The replay runs on the channel's drain thread and could outrun the
         // attached frame below — the latch holds event frames until it is out.
         var attachedSent = new java.util.concurrent.CountDownLatch(1);
-        AgentChatService.Attachment attachment = chatService.attach(SessionId.of(sessionId), afterSeq, event -> {
+        AgentChatService.Attachment attachment = chatService.attach(id, afterSeq, event -> {
             try {
                 attachedSent.await();
                 emitter.send(SseEmitter.event().data(
@@ -408,18 +432,20 @@ public class AgentApiController {
 
     @Operation(tags = "Sessions", summary = "Load the session's message history")
     @GetMapping("/sessions/{sessionId}/history")
-    public List<Message> loadHistory(@PathVariable String sessionId) {
+    public List<Message> loadHistory(@PathVariable String sessionId, @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         log.info("GET /api/sessions/{}/history", sessionId);
-        List<Message> history = sessionService.loadHistory(SessionId.of(sessionId));
+        List<Message> history = sessionService.loadHistory(id);
         log.info("Returning {} message(s) for session {}", history.size(), sessionId);
         return history;
     }
 
     @Operation(tags = "Sessions", summary = "Delete a session")
     @DeleteMapping("/sessions/{sessionId}")
-    public ResponseEntity<Void> deleteSession(@PathVariable String sessionId) {
+    public ResponseEntity<Void> deleteSession(@PathVariable String sessionId, @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         log.info("DELETE /api/sessions/{}", sessionId);
-        sessionService.deleteSession(SessionId.of(sessionId));
+        sessionService.deleteSession(id);
         return ResponseEntity.noContent().build();
     }
 
@@ -429,9 +455,11 @@ public class AgentApiController {
     @DeleteMapping("/sessions/{sessionId}/messages")
     public ResponseEntity<Map<String, Object>> deleteMessages(@PathVariable String sessionId,
                                                                @RequestParam int fromSeq,
-                                                               @RequestParam int toSeq) {
+                                                               @RequestParam int toSeq,
+                                                               @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         log.info("DELETE /api/sessions/{}/messages fromSeq={} toSeq={}", sessionId, fromSeq, toSeq);
-        int deleted = sessionService.deleteMessages(SessionId.of(sessionId), fromSeq, toSeq);
+        int deleted = sessionService.deleteMessages(id, fromSeq, toSeq);
         return ResponseEntity.ok(Map.of(
                 "sessionId", sessionId,
                 "deletedMessages", deleted));
@@ -441,18 +469,21 @@ public class AgentApiController {
             description = "The prompt-assembly view: which messages are live, compressed or "
                     + "truncated, plus token accounting.")
     @GetMapping("/sessions/{sessionId}/memory")
-    public WorkingMemory getWorkingMemory(@PathVariable String sessionId) {
+    public WorkingMemory getWorkingMemory(@PathVariable String sessionId, @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         log.info("GET /api/sessions/{}/memory", sessionId);
-        return chatService.memorySnapshot(SessionId.of(sessionId));
+        return chatService.memorySnapshot(id);
     }
 
     @Operation(tags = "Sessions", summary = "Compress the session's working memory",
             description = "Summarises older turns to reclaim context window; returns how many "
                     + "messages were compressed.")
     @PostMapping("/sessions/{sessionId}/compress")
-    public ResponseEntity<Map<String, Object>> compressMemory(@PathVariable String sessionId) {
+    public ResponseEntity<Map<String, Object>> compressMemory(@PathVariable String sessionId,
+                                                              @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         log.info("POST /api/sessions/{}/compress", sessionId);
-        int compressed = chatService.compressMemory(SessionId.of(sessionId));
+        int compressed = chatService.compressMemory(id);
         return ResponseEntity.ok(Map.of(
                 "sessionId", sessionId,
                 "compressedMessages", compressed));
@@ -467,8 +498,8 @@ public class AgentApiController {
                     + "that connects later (or reattaches after a restart) rebuilds its cards "
                     + "from here. Each entry's content is the call JSON the card shows.")
     @GetMapping("/sessions/{sessionId}/approvals")
-    public List<ToolApproval> openApprovals(@PathVariable String sessionId) {
-        List<ToolApproval> open = chatService.openApprovals(SessionId.of(sessionId));
+    public List<ToolApproval> openApprovals(@PathVariable String sessionId, @CurrentUser UserId caller) {
+        List<ToolApproval> open = chatService.openApprovals(owned(sessionId, caller));
         log.info("GET /api/sessions/{}/approvals → {} open", sessionId, open.size());
         return open;
     }
@@ -483,11 +514,20 @@ public class AgentApiController {
     public ResponseEntity<Void> answerApproval(@PathVariable String sessionId,
                                                @PathVariable String callId,
                                                @RequestParam boolean approved,
-                                               @RequestParam(defaultValue = "once") String scope) {
+                                               @RequestParam(defaultValue = "once") String scope,
+                                               @CurrentUser UserId caller) {
         boolean delivered = chatService.answerApproval(
-                SessionId.of(sessionId), callId, approved, ApprovalScope.fromParam(scope));
+                owned(sessionId, caller), callId, approved, ApprovalScope.fromParam(scope));
         log.info("POST /api/sessions/{}/approvals/{} approved={} scope={} → delivered={}",
                 sessionId, callId, approved, scope, delivered);
         return delivered ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    /**
+     * The session's id, once it is known to be the caller's — a 404 for the
+     * request otherwise, whether the session is someone else's or missing.
+     */
+    private SessionId owned(String sessionId, UserId caller) {
+        return sessionAccess.requireOwned(SessionId.of(sessionId), caller).id();
     }
 }

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/FilesApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/FilesApiController.java
@@ -1,5 +1,7 @@
 package ai.mindconnect.agentrest.controller;
 
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUser;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,14 +21,30 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Files API, OpenAI-style: upload once, reference the returned id from chats
  * and vector stores. Pure storage — associations (which session, which store)
  * live at their own endpoints.
+ *
+ * <p>A file belongs to the caller who uploaded it, its
+ * {@link StoredFile#creator() creator}:
+ * <ul>
+ *   <li>the list holds the caller's own files and nothing else;</li>
+ *   <li>metadata and content by id answer the creator — and, for a file
+ *       stored before creators were recorded, whoever holds its id
+ *       ({@link StoredFile#readableBy}), because chats and transcripts still
+ *       reference those by id; such a file is never listed;</li>
+ *   <li>only the creator deletes, so a file without a creator is no longer
+ *       deleted through this API.</li>
+ * </ul>
+ * Anything else — someone else's file, an id that does not exist — answers
+ * 404, and the two are indistinguishable on purpose.
  */
 @Tag(name = "Files", description = "File storage, OpenAI-style: upload once, reference "
-        + "the returned id from chat sessions and vector stores.")
+        + "the returned id from chat sessions and vector stores. A file belongs to the caller "
+        + "who uploaded it.")
 @RestController
 @RequestMapping("/api/files")
 public class FilesApiController {
@@ -38,35 +56,35 @@ public class FilesApiController {
     }
 
     @Operation(summary = "Upload a file",
-            description = "Stores the file and returns its metadata; the id is the handle "
-                    + "for chat attach (POST /api/sessions/{id}/files) and vector-store "
+            description = "Stores the file as the caller's and returns its metadata; the id is "
+                    + "the handle for chat attach (POST /api/sessions/{id}/files) and vector-store "
                     + "ingestion (POST /api/vector-stores/stores/{name}/ingest).")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public StoredFile upload(@RequestParam("file") MultipartFile file) throws IOException {
+    public StoredFile upload(@RequestParam("file") MultipartFile file, @CurrentUser UserId caller)
+            throws IOException {
         try (var content = file.getInputStream()) {
-            return fileStore.save(file.getOriginalFilename(), file.getContentType(), content);
+            return fileStore.save(file.getOriginalFilename(), file.getContentType(), content, caller);
         }
     }
 
-    @Operation(summary = "List stored files")
+    @Operation(summary = "List the caller's files")
     @GetMapping
-    public List<StoredFile> list() {
-        return fileStore.list().stream().toList();
+    public List<StoredFile> list(@CurrentUser UserId caller) {
+        return fileStore.list().stream().filter(file -> file.createdBy(caller)).toList();
     }
 
     @Operation(summary = "Get file metadata")
     @GetMapping("/{id}")
-    public ResponseEntity<StoredFile> find(@PathVariable String id) {
-        return fileStore.find(FileId.of(id)).map(ResponseEntity::ok)
+    public ResponseEntity<StoredFile> find(@PathVariable String id, @CurrentUser UserId caller) {
+        return readable(id, caller).map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @Operation(summary = "Download the file content")
     @GetMapping("/{id}/content")
-    public ResponseEntity<InputStreamResource> content(@PathVariable String id)
+    public ResponseEntity<InputStreamResource> content(@PathVariable String id, @CurrentUser UserId caller)
             throws IOException {
-        FileId fileId = FileId.of(id);
-        var file = fileStore.find(fileId).orElse(null);
+        var file = readable(id, caller).orElse(null);
         if (file == null) {
             return ResponseEntity.notFound().build();
         }
@@ -75,15 +93,23 @@ public class FilesApiController {
                 .contentType(file.contentType() != null
                         ? MediaType.parseMediaType(file.contentType())
                         : MediaType.APPLICATION_OCTET_STREAM)
-                .body(new InputStreamResource(fileStore.content(fileId)));
+                .body(new InputStreamResource(fileStore.content(file.id())));
     }
 
     @Operation(summary = "Delete a file",
-            description = "Removes the stored file. Chunks already ingested into vector "
-                    + "stores stay.")
+            description = "Removes the caller's stored file; 404 for a file the caller did not "
+                    + "upload. Chunks already ingested into vector stores stay.")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable String id) throws IOException {
-        fileStore.delete(FileId.of(id));
+    public ResponseEntity<Void> delete(@PathVariable String id, @CurrentUser UserId caller) throws IOException {
+        FileId fileId = FileId.of(id);
+        if (fileStore.find(fileId).filter(file -> file.createdBy(caller)).isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        fileStore.delete(fileId);
         return ResponseEntity.noContent().build();
+    }
+
+    private Optional<StoredFile> readable(String id, UserId caller) {
+        return fileStore.find(FileId.of(id)).filter(file -> file.readableBy(caller));
     }
 }

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/SessionFilesApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/SessionFilesApiController.java
@@ -1,6 +1,9 @@
 package ai.mindconnect.agentrest.controller;
 
 import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUser;
+import ai.mindconnect.agentrest.auth.SessionAccess;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,6 +39,11 @@ import java.util.Map;
  * the store. The heavy lifting (template, scoped store, ingestion workflow,
  * vector_search activation) lives in {@link ai.mindconnect.agentrest.service.SessionFileService},
  * shared with the chat UI.
+ *
+ * <p>Every endpoint answers only the session's owner — someone else's session
+ * is a 404, like a missing one ({@link SessionAccess}). An upload is stored as
+ * the caller's file, and a file attached by id must be one the caller may
+ * read: attaching puts its content in front of the caller's model.
  */
 @RestController
 @RequestMapping("/api/sessions/{sessionId}/files")
@@ -43,11 +51,14 @@ public class SessionFilesApiController {
 
     private final FileStore fileStore;
     private final ai.mindconnect.agentrest.service.SessionFileService sessionFiles;
+    private final SessionAccess sessionAccess;
 
     public SessionFilesApiController(FileStore fileStore,
-                                  ai.mindconnect.agentrest.service.SessionFileService sessionFiles) {
+                                  ai.mindconnect.agentrest.service.SessionFileService sessionFiles,
+                                  SessionAccess sessionAccess) {
         this.fileStore = fileStore;
         this.sessionFiles = sessionFiles;
+        this.sessionAccess = sessionAccess;
     }
 
     /** Upload + attach in one call (multipart {@code file}). */
@@ -57,13 +68,15 @@ public class SessionFilesApiController {
                     + "Responses-API-style.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Map<String, Object>> uploadAndAttach(@PathVariable String sessionId,
-                                                               @RequestParam("file") MultipartFile file)
+                                                               @RequestParam("file") MultipartFile file,
+                                                               @CurrentUser UserId caller)
             throws IOException {
+        SessionId id = owned(sessionId, caller);
         StoredFile stored;
         try (InputStream content = file.getInputStream()) {
-            stored = fileStore.save(file.getOriginalFilename(), file.getContentType(), content);
+            stored = fileStore.save(file.getOriginalFilename(), file.getContentType(), content, caller);
         }
-        return ResponseEntity.ok(toResponse(sessionFiles.attach(SessionId.of(sessionId), stored)));
+        return ResponseEntity.ok(toResponse(sessionFiles.attach(id, stored)));
     }
 
     /** Attach a previously uploaded file by id ({@code {"fileId": "file-…"}}). */
@@ -72,14 +85,17 @@ public class SessionFilesApiController {
                     + "store: body {\"fileId\": \"file-…\"}.")
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> attachExisting(@PathVariable String sessionId,
-                                                              @RequestBody Map<String, String> body) {
+                                                              @RequestBody Map<String, String> body,
+                                                              @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         String fileId = body.get("fileId");
-        StoredFile stored = fileId == null ? null : fileStore.find(FileId.of(fileId)).orElse(null);
+        StoredFile stored = fileId == null ? null
+                : fileStore.find(FileId.of(fileId)).filter(file -> file.readableBy(caller)).orElse(null);
         if (stored == null) {
             return ResponseEntity.badRequest().body(Map.of("error",
                     "Unknown fileId '" + fileId + "' — upload via POST /api/files first."));
         }
-        return ResponseEntity.ok(toResponse(sessionFiles.attach(SessionId.of(sessionId), stored)));
+        return ResponseEntity.ok(toResponse(sessionFiles.attach(id, stored)));
     }
 
     /**
@@ -93,11 +109,13 @@ public class SessionFilesApiController {
                     + "sizeBytes and chunks (searchable chunks; 0 for an image, which goes to "
                     + "the model with the next message instead of into the vector store).")
     @GetMapping
-    public ResponseEntity<List<Map<String, Object>>> listAttachments(@PathVariable String sessionId) {
+    public ResponseEntity<List<Map<String, Object>>> listAttachments(@PathVariable String sessionId,
+                                                                     @CurrentUser UserId caller) {
+        SessionId id = owned(sessionId, caller);
         Map<String, Long> chunksByName = new java.util.HashMap<>();
-        sessionFiles.listAttachments(SessionId.of(sessionId)).forEach((ingestedId, chunks) ->
+        sessionFiles.listAttachments(id).forEach((ingestedId, chunks) ->
                 chunksByName.merge(java.nio.file.Path.of(ingestedId).getFileName().toString(), chunks, Long::sum));
-        var files = sessionFiles.attachments(SessionId.of(sessionId)).stream()
+        var files = sessionFiles.attachments(id).stream()
                 .map(f -> {
                     Map<String, Object> entry = new java.util.LinkedHashMap<>();
                     entry.put("fileId", f.id());
@@ -114,7 +132,7 @@ public class SessionFilesApiController {
     /**
      * Detaches a file from the chat: its chunks leave the session's vector
      * store, so the agent can no longer search it, and the spooled copy goes
-     * with them. The original in the file store is untouched \u2014 it may be
+     * with them. The original in the file store is untouched — it may be
      * attached to other sessions.
      */
     @Operation(tags = "Sessions", summary = "Detach a file from the chat",
@@ -122,9 +140,15 @@ public class SessionFilesApiController {
                     + "spooled copy. The file itself stays in the file store.")
     @DeleteMapping
     public ResponseEntity<Void> detach(@PathVariable String sessionId,
-                                       @RequestParam("file") String fileIdOrName) {
-        sessionFiles.deleteAttachment(SessionId.of(sessionId), fileIdOrName);
+                                       @RequestParam("file") String fileIdOrName,
+                                       @CurrentUser UserId caller) {
+        sessionFiles.deleteAttachment(owned(sessionId, caller), fileIdOrName);
         return ResponseEntity.noContent().build();
+    }
+
+    /** The session's id, once it is known to be the caller's; a 404 for the request otherwise. */
+    private SessionId owned(String sessionId, UserId caller) {
+        return sessionAccess.requireOwned(SessionId.of(sessionId), caller).id();
     }
 
     private static Map<String, Object> toResponse(

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/TranscriptionApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/TranscriptionApiController.java
@@ -1,5 +1,7 @@
 package ai.mindconnect.agentrest.controller;
 
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUser;
 import ai.mindconnect.agentrest.dto.TranscriptionJobResponse;
 import ai.mindconnect.agentrest.dto.TranscriptionJobResult;
 import ai.mindconnect.agentrest.service.TranscriptionChannels;
@@ -26,7 +28,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.security.Principal;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -77,13 +78,13 @@ public class TranscriptionApiController {
             @RequestParam(value = "model", required = false) String model,
             @RequestParam(value = "language", required = false) String language,
             @RequestParam(value = "prompt", required = false) String prompt,
-            Principal user) throws IOException {
+            @CurrentUser UserId caller) throws IOException {
         if (file.isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
         String filename = file.getOriginalFilename() == null ? "recording.webm" : file.getOriginalFilename();
         TranscriptionJobService.Job job = jobs.submit(file.getBytes(), filename, file.getContentType(),
-                model, language, prompt, user == null ? null : user.getName());
+                model, language, prompt, caller);
 
         log.info("POST /api/transcriptions file=\"{}\" ({} bytes) → job {}, recording {}",
                 filename, file.getSize(), job.taskId(), job.fileId());
@@ -103,14 +104,14 @@ public class TranscriptionApiController {
     public ResponseEntity<TranscriptionJobResult> result(
             @PathVariable String taskId,
             @RequestParam(value = "wait", required = false) Integer wait,
-            Principal user) {
+            @CurrentUser UserId caller) {
         Optional<TaskRecord> found = wait == null || wait <= 0
                 ? jobs.find(taskId)
                 : jobs.await(taskId, Duration.ofSeconds(Math.min(wait, MAX_WAIT_SECONDS)));
         if (found.isEmpty()) return ResponseEntity.notFound().build();
 
         TaskRecord task = found.get();
-        if (!mayRead(task, user)) return ResponseEntity.notFound().build();
+        if (!mayRead(task, caller)) return ResponseEntity.notFound().build();
         return ResponseEntity.ok(describe(task));
     }
 
@@ -123,9 +124,9 @@ public class TranscriptionApiController {
     public ResponseEntity<SseEmitter> events(
             @PathVariable String taskId,
             @RequestParam(value = "afterSeq", required = false) Long afterSeq,
-            Principal user) {
+            @CurrentUser UserId caller) {
         Optional<TaskRecord> found = jobs.find(taskId);
-        if (found.isEmpty() || !mayRead(found.get(), user)) {
+        if (found.isEmpty() || !mayRead(found.get(), caller)) {
             return ResponseEntity.notFound().build();
         }
 
@@ -155,15 +156,12 @@ public class TranscriptionApiController {
     // ── Helpers ────────────────────────────────────────────────────────────
 
     /**
-     * A job recorded a requester when the request carried one. Then only that
-     * requester reads it — an id is a name, not a permission. A job submitted
-     * without a principal (an installation with no login) is readable by
-     * whoever can reach the endpoint, like the rest of this API.
+     * Only the requester reads a job — an id is a name, not a permission. A
+     * job without a recorded requester, submitted on nobody's behalf, stays
+     * readable by whoever can reach the endpoint.
      */
-    private static boolean mayRead(TaskRecord task, Principal user) {
-        Optional<String> requester = TranscriptionJobService.requesterOf(task);
-        if (requester.isEmpty()) return true;
-        return user != null && requester.get().equals(user.getName());
+    private static boolean mayRead(TaskRecord task, UserId caller) {
+        return TranscriptionJobService.requesterOf(task).map(caller::equals).orElse(true);
     }
 
     private TranscriptionJobResult describe(TaskRecord task) {

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/UserPaths.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/UserPaths.java
@@ -1,0 +1,30 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.UserId;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * A path that names a user — {@code /api/users/{userId}/…},
+ * {@code /api/workspaces/user/{userId}/…} — leads to the caller's own data
+ * and nobody else's. The segment is the caller's id or {@code me}, for a
+ * client that does not know which id its login maps to. Any other user is
+ * answered like a user that does not exist: a 404, where a 403 would confirm
+ * that the id is someone's.
+ */
+class UserPaths {
+
+    /** The path segment that always means the caller. */
+    static final String ME = "me";
+
+    private UserPaths() {
+    }
+
+    /** The caller, when {@code pathUserId} names them; a 404 for the request otherwise. */
+    static UserId requireSelf(String pathUserId, UserId caller) {
+        if (ME.equals(pathUserId) || caller.value().equals(pathUserId)) {
+            return caller;
+        }
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No such user");
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/VectorStoreApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/VectorStoreApiController.java
@@ -1,5 +1,8 @@
 package ai.mindconnect.agentrest.controller;
 
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUser;
+import ai.mindconnect.agentrest.auth.VectorStoreAccess;
 import ai.mindconnect.agentrest.service.NotConfiguredException;
 import ai.mindconnect.agentrest.service.VectorStoreService;
 import ai.mindconnect.vectorstore.tools.VectorStoreInstance;
@@ -7,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import ai.mindconnect.vectorstore.tools.VectorStoreTemplate;
 import ai.mindconnect.vectorstore.tools.VectorStores;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.util.List;
@@ -25,10 +30,17 @@ import java.util.Map;
  * External REST API for vector stores — a thin shell over
  * {@link VectorStoreService}, which the admin UI uses too: template and store
  * CRUD, text search, chunk upsert, and document ingestion.
+ *
+ * <p>Templates and knowledge bases are shared configuration, open to every
+ * authenticated caller. A chat's upload store is its user's alone
+ * ({@link VectorStoreAccess}): for anyone else it is not listed, and reading,
+ * filling, searching or deleting it answers 404 — like a store that does not
+ * exist. Ingestion takes only a file the caller may read.
  */
 @Tag(name = "Vector Stores", description = "Templates (backend + embedding policy), store "
-        + "instances, document ingestion, chunk upsert and semantic search. 503 when "
-        + "vector stores are not configured in this application.")
+        + "instances, document ingestion, chunk upsert and semantic search. A chat's upload "
+        + "store (session-…) answers only to the chat's user. 503 when vector stores are not "
+        + "configured in this application.")
 @RestController
 @RequestMapping("/api/vector-stores")
 public class VectorStoreApiController {
@@ -45,9 +57,11 @@ public class VectorStoreApiController {
                                      String text, Map<String, String> metadata) {}
 
     private final VectorStoreService service;
+    private final VectorStoreAccess access;
 
-    public VectorStoreApiController(VectorStoreService service) {
+    public VectorStoreApiController(VectorStoreService service, VectorStoreAccess access) {
         this.service = service;
+        this.access = access;
     }
 
     /** The capability isn't configured in this host application. */
@@ -89,16 +103,18 @@ public class VectorStoreApiController {
 
     // ── Stores ─────────────────────────────────────────────────────────────
 
-    @Operation(summary = "List store instances")
+    @Operation(summary = "List store instances",
+            description = "The knowledge bases, and of the chat upload stores only the caller's own.")
     @GetMapping("/stores")
-    public List<VectorStoreInstance> listStores() {
-        return service.instances();
+    public List<VectorStoreInstance> listStores(@CurrentUser UserId caller) {
+        return service.instances().stream().filter(store -> access.reachable(store, caller)).toList();
     }
 
     @Operation(summary = "Get a store instance")
     @GetMapping("/stores/{name}")
-    public ResponseEntity<VectorStoreInstance> getStore(@PathVariable String name) {
+    public ResponseEntity<VectorStoreInstance> getStore(@PathVariable String name, @CurrentUser UserId caller) {
         return service.instance(name)
+                .filter(store -> access.reachable(store, caller))
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -106,10 +122,12 @@ public class VectorStoreApiController {
     /** Registers (and creates on first use) a GLOBAL store from a template. */
     @Operation(summary = "Create a store",
             description = "Registers (and creates on first use) a GLOBAL store from a "
-                    + "template; the template's settings are copied onto the store.")
+                    + "template; the template's settings are copied onto the store. Names starting "
+                    + "with session- belong to chat upload stores and are refused (400).")
     @PostMapping("/stores")
     public ResponseEntity<VectorStoreInstance> createStore(@RequestBody CreateStoreRequest request) {
-        if (request.name() == null || request.name().isBlank()) {
+        if (request.name() == null || request.name().isBlank()
+                || VectorStoreAccess.isChatStoreName(request.name())) {
             return ResponseEntity.badRequest().build();
         }
         return service.createStore(request.name(), request.template())
@@ -121,7 +139,8 @@ public class VectorStoreApiController {
     @Operation(summary = "Delete a store registration",
             description = "Removes the registration; data files stay on the backend.")
     @DeleteMapping("/stores/{name}")
-    public ResponseEntity<Void> deleteStore(@PathVariable String name) {
+    public ResponseEntity<Void> deleteStore(@PathVariable String name, @CurrentUser UserId caller) {
+        requireReachable(name, caller);
         service.deleteStore(name);
         return ResponseEntity.noContent().build();
     }
@@ -138,15 +157,18 @@ public class VectorStoreApiController {
             description = "Pushes a file from the file store (see POST /api/files) through "
                     + "the store's ingestion path — the template's ingestion workflow when "
                     + "configured, built-in extraction + chunking otherwise. Same path as "
-                    + "the admin UI's store-page upload.")
+                    + "the admin UI's store-page upload. The file must be one the caller may "
+                    + "read; any other id answers 404.")
     @PostMapping("/stores/{name}/ingest")
     public ResponseEntity<IngestResult> ingest(@PathVariable String name,
-                                               @RequestBody IngestRequest request) throws IOException {
+                                               @RequestBody IngestRequest request,
+                                               @CurrentUser UserId caller) throws IOException {
         if (request.fileId() == null || request.fileId().isBlank()) {
             return ResponseEntity.badRequest().build();
         }
+        requireReachable(name, caller);
         try {
-            String summary = service.ingestStoredFile(name, request.fileId());
+            String summary = service.ingestStoredFile(name, request.fileId(), caller);
             return ResponseEntity.ok(new IngestResult(request.fileId(), summary));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
@@ -159,10 +181,11 @@ public class VectorStoreApiController {
                     + "as one chunk; id defaults to \"{fileId}:{uuid}\".")
     @PostMapping("/stores/{name}/chunks")
     public ResponseEntity<VectorStoreService.UpsertedChunk> upsertChunk(
-            @PathVariable String name, @RequestBody UpsertChunkRequest request) {
+            @PathVariable String name, @RequestBody UpsertChunkRequest request, @CurrentUser UserId caller) {
         if (request.text() == null || request.text().isBlank()) {
             return ResponseEntity.badRequest().build();
         }
+        requireReachable(name, caller);
         return ResponseEntity.ok(service.upsertChunk(name, request.id(), request.fileId(),
                 request.ordinal(), request.text(), request.metadata()));
     }
@@ -175,11 +198,20 @@ public class VectorStoreApiController {
                     + "the topK most similar chunks with scores (cosine similarity).")
     @PostMapping("/stores/{name}/search")
     public ResponseEntity<List<VectorStoreService.Hit>> search(@PathVariable String name,
-                                                               @RequestBody SearchRequest request) {
+                                                               @RequestBody SearchRequest request,
+                                                               @CurrentUser UserId caller) {
         if (request.query() == null || request.query().isBlank()) {
             return ResponseEntity.badRequest().build();
         }
+        requireReachable(name, caller);
         int topK = request.topK() == null || request.topK() <= 0 ? 5 : request.topK();
         return ResponseEntity.ok(service.search(name, request.query(), topK, 0));
+    }
+
+    /** A 404 for the request when the store is a chat's upload store that is not the caller's. */
+    private void requireReachable(String name, UserId caller) {
+        if (!access.reachable(name, service.instance(name).orElse(null), caller)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No such store");
+        }
     }
 }

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/WorkspaceApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/WorkspaceApiController.java
@@ -4,9 +4,10 @@ import ai.mindconnect.agent.AgentId;
 import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.UserId;
 import ai.mindconnect.agent.runtime.domain.AgentSession;
-import ai.mindconnect.agent.runtime.service.AgentSessionService;
 import ai.mindconnect.agent.runtime.tools.workspace.WorkspaceScope;
 import ai.mindconnect.agent.runtime.tools.workspace.WorkspaceStore;
+import ai.mindconnect.agentrest.auth.CurrentUser;
+import ai.mindconnect.agentrest.auth.SessionAccess;
 import io.swagger.v3.oas.annotations.Operation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -34,6 +34,11 @@ import java.util.List;
  * identifiers the request even needs: a session workspace is addressed by its
  * session (agent and user follow from it), an agent workspace by agent and
  * user, and the user workspace by the user alone.
+ *
+ * <p>Every workspace read here is the caller's. A session workspace opens only
+ * for the session's owner, and a path that names a user takes the caller's own
+ * id or {@code me}; another user's workspace answers 404, like one that does
+ * not exist.
  */
 @RestController
 @RequestMapping("/api/workspaces")
@@ -45,66 +50,71 @@ public class WorkspaceApiController {
     public record WorkspaceFile(String name, long size) {}
 
     private final WorkspaceStore store;
-    private final AgentSessionService sessionService;
+    private final SessionAccess sessionAccess;
 
-    public WorkspaceApiController(WorkspaceStore store, AgentSessionService sessionService) {
+    public WorkspaceApiController(WorkspaceStore store, SessionAccess sessionAccess) {
         this.store = store;
-        this.sessionService = sessionService;
+        this.sessionAccess = sessionAccess;
     }
 
     // ── Session scope ───────────────────────────────────────────────────────
 
     @Operation(tags = "Workspaces", summary = "Files in a session's workspace",
-            description = "The scratch space of one conversation — what the agent wrote while "
-                    + "answering. Agent and user are taken from the session.")
+            description = "The scratch space of one of the caller's conversations — what the agent "
+                    + "wrote while answering. Agent and user are taken from the session.")
     @GetMapping("/session/{sessionId}/files")
-    public List<WorkspaceFile> sessionFiles(@PathVariable String sessionId) {
-        return list(sessionScope(SessionId.of(sessionId)));
+    public List<WorkspaceFile> sessionFiles(@PathVariable String sessionId, @CurrentUser UserId caller) {
+        return list(sessionScope(sessionId, caller));
     }
 
     @Operation(tags = "Workspaces", summary = "Read a file from a session's workspace")
     @GetMapping(value = "/session/{sessionId}/files/{name}", produces = MediaType.TEXT_PLAIN_VALUE)
     public ResponseEntity<String> sessionFile(@PathVariable String sessionId,
-                                              @PathVariable String name) {
-        return read(sessionScope(SessionId.of(sessionId)), name);
+                                              @PathVariable String name,
+                                              @CurrentUser UserId caller) {
+        return read(sessionScope(sessionId, caller), name);
     }
 
     // ── Agent + user scope ──────────────────────────────────────────────────
 
-    @Operation(tags = "Workspaces", summary = "Files in an agent's workspace for one user",
-            description = "What this agent keeps about this user across conversations.")
+    @Operation(tags = "Workspaces", summary = "Files in an agent's workspace for the caller",
+            description = "What this agent keeps about the caller across conversations. The user "
+                    + "in the path is the caller's own id or 'me'; any other user answers 404.")
     @GetMapping("/agent/{agentId}/user/{userId}/files")
-    public List<WorkspaceFile> agentFiles(@PathVariable String agentId, @PathVariable String userId) {
-        return list(WorkspaceScope.agentUser(AgentId.of(agentId), UserId.of(userId)));
+    public List<WorkspaceFile> agentFiles(@PathVariable String agentId, @PathVariable String userId,
+                                          @CurrentUser UserId caller) {
+        return list(WorkspaceScope.agentUser(AgentId.of(agentId), UserPaths.requireSelf(userId, caller)));
     }
 
-    @Operation(tags = "Workspaces", summary = "Read a file from an agent's workspace")
+    @Operation(tags = "Workspaces", summary = "Read a file from an agent's workspace for the caller")
     @GetMapping(value = "/agent/{agentId}/user/{userId}/files/{name}",
             produces = MediaType.TEXT_PLAIN_VALUE)
     public ResponseEntity<String> agentFile(@PathVariable String agentId, @PathVariable String userId,
-                                            @PathVariable String name) {
-        return read(WorkspaceScope.agentUser(AgentId.of(agentId), UserId.of(userId)), name);
+                                            @PathVariable String name, @CurrentUser UserId caller) {
+        return read(WorkspaceScope.agentUser(AgentId.of(agentId), UserPaths.requireSelf(userId, caller)), name);
     }
 
     // ── User scope ──────────────────────────────────────────────────────────
 
-    @Operation(tags = "Workspaces", summary = "Files in a user's own workspace",
-            description = "The user's space, shared by every agent that works for them.")
+    @Operation(tags = "Workspaces", summary = "Files in the caller's own workspace",
+            description = "The caller's space, shared by every agent that works for them. The user "
+                    + "in the path is the caller's own id or 'me'; any other user answers 404.")
     @GetMapping("/user/{userId}/files")
-    public List<WorkspaceFile> userFiles(@PathVariable String userId) {
-        return list(WorkspaceScope.user(UserId.of(userId)));
+    public List<WorkspaceFile> userFiles(@PathVariable String userId, @CurrentUser UserId caller) {
+        return list(WorkspaceScope.user(UserPaths.requireSelf(userId, caller)));
     }
 
-    @Operation(tags = "Workspaces", summary = "Read a file from a user's workspace")
+    @Operation(tags = "Workspaces", summary = "Read a file from the caller's own workspace")
     @GetMapping(value = "/user/{userId}/files/{name}", produces = MediaType.TEXT_PLAIN_VALUE)
-    public ResponseEntity<String> userFile(@PathVariable String userId, @PathVariable String name) {
-        return read(WorkspaceScope.user(UserId.of(userId)), name);
+    public ResponseEntity<String> userFile(@PathVariable String userId, @PathVariable String name,
+                                           @CurrentUser UserId caller) {
+        return read(WorkspaceScope.user(UserPaths.requireSelf(userId, caller)), name);
     }
 
     // ── The two things every scope does ─────────────────────────────────────
 
-    private WorkspaceScope sessionScope(SessionId sessionId) {
-        AgentSession session = sessionService.findSession(sessionId);
+    private WorkspaceScope sessionScope(String sessionId, UserId caller) {
+        AgentSession session = sessionAccess.requireOwned(SessionId.of(sessionId), caller);
         return WorkspaceScope.session(session.agentDefinitionId(), session.userId(), session.id());
     }
 

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/StartSessionRequest.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/dto/StartSessionRequest.java
@@ -1,3 +1,12 @@
 package ai.mindconnect.agentrest.dto;
 
-public record StartSessionRequest(String agentId, String userId) {}
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Body of {@code POST /api/sessions}. The session belongs to the authenticated
+ * caller, so there is no user in it; a {@code userId} an older client still
+ * sends is ignored rather than refused — whatever the host's mapper is set to
+ * do with unknown fields.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record StartSessionRequest(String agentId) {}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/TranscriptionJobService.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agentrest.service;
 
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
 import ai.mindconnect.filestore.StoredFile;
@@ -97,16 +98,17 @@ public class TranscriptionJobService {
      *
      * @param configName the LLM config to transcribe with, or {@code null} for
      *                   the default name — an alias is followed
-     * @param userId     who asked, when the request carried a principal;
-     *                   {@code null} on an installation without login
+     * @param requester  who asked: recorded on the job for the owner check and
+     *                   as the creator of the stored recording; {@code null}
+     *                   submits on nobody's behalf, a job anyone may read
      * @return the queued task's id
      */
     public Job submit(byte[] audio, String filename, String contentType,
-                      String configName, String language, String prompt, String userId)
+                      String configName, String language, String prompt, UserId requester)
             throws IOException {
         StoredFile stored;
         try (InputStream content = new java.io.ByteArrayInputStream(audio)) {
-            stored = fileStore.save(filename, contentType, content);
+            stored = fileStore.save(filename, contentType, content, requester);
         }
 
         Map<String, Object> payload = new LinkedHashMap<>();
@@ -116,7 +118,7 @@ public class TranscriptionJobService {
         if (configName != null) payload.put("configName", configName);
         if (language != null) payload.put("language", language);
         if (prompt != null) payload.put("prompt", prompt);
-        if (userId != null) payload.put("userId", userId);
+        if (requester != null) payload.put("userId", requester.value());
 
         // The id is ours before the queue has it, so "queued" is on the
         // channel before a worker can publish "running". Submitting first and
@@ -174,10 +176,10 @@ public class TranscriptionJobService {
         return fileId == null ? Optional.empty() : Optional.of(String.valueOf(fileId));
     }
 
-    /** Who asked for this job, when the request carried a principal. */
-    public static Optional<String> requesterOf(TaskRecord task) {
+    /** Who asked for this job; empty for a job submitted on nobody's behalf. */
+    public static Optional<UserId> requesterOf(TaskRecord task) {
         Object userId = task.payload().get("userId");
-        return userId == null ? Optional.empty() : Optional.of(String.valueOf(userId));
+        return userId == null ? Optional.empty() : Optional.of(UserId.of(String.valueOf(userId)));
     }
 
     // ── The worker ─────────────────────────────────────────────────────────

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/VectorStoreService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/VectorStoreService.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agentrest.service;
 
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
 import ai.mindconnect.filestore.StoredFile;
@@ -164,11 +165,16 @@ public class VectorStoreService {
         return DirectIngestion.ingest(vs, vs.openWith(instance), storeName, safeName, text);
     }
 
-    /** Like {@link #ingestUpload}, for a file already in the {@link FileStore}. */
-    public String ingestStoredFile(String storeName, String fileId) throws IOException {
+    /**
+     * Like {@link #ingestUpload}, for a file already in the {@link FileStore}
+     * that {@code reader} may read ({@link StoredFile#readableBy}). Anyone
+     * else's file is reported like a missing one: ingesting it would put its
+     * content into a store the reader can search.
+     */
+    public String ingestStoredFile(String storeName, String fileId, UserId reader) throws IOException {
         FileStore fs = fileStoreProvider.getIfAvailable();
         if (fs == null) throw new NotConfiguredException("File store");
-        StoredFile stored = fs.find(FileId.of(fileId)).orElseThrow(() ->
+        StoredFile stored = fs.find(FileId.of(fileId)).filter(file -> file.readableBy(reader)).orElseThrow(() ->
                 new IllegalArgumentException("No such file: " + fileId));
         try (InputStream content = fs.content(stored.id())) {
             return ingestUpload(storeName, stored.name(), content);

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/auth/CurrentUsersTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/auth/CurrentUsersTest.java
@@ -1,0 +1,65 @@
+package ai.mindconnect.agentrest.auth;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.runtime.domain.AgentSession;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The caller comes from the host's resolver; without one there is a dev user
+ * only while authentication is off. Sessions open only for their owner.
+ */
+class CurrentUsersTest {
+
+    private static CurrentUsers currentUsers(CurrentUserResolver resolver, boolean authEnabled) {
+        var beans = new StaticListableBeanFactory();
+        if (resolver != null) {
+            beans.addBean("resolver", resolver);
+        }
+        return new CurrentUsers(beans.getBeanProvider(CurrentUserResolver.class), authEnabled, "dev");
+    }
+
+    @Test
+    void theHostsResolverDecides() {
+        assertThat(currentUsers(() -> Optional.of(UserId.of("alice")), true).current())
+                .contains(UserId.of("alice"));
+        assertThat(currentUsers(Optional::empty, false).current()).isEmpty();
+    }
+
+    @Test
+    void withoutAResolverTheDevUserExistsOnlyWhileAuthenticationIsOff() {
+        assertThat(currentUsers(null, false).require()).isEqualTo(UserId.of("dev"));
+
+        CurrentUsers closed = currentUsers(null, true);
+        assertThat(closed.current()).isEmpty();
+        assertThatThrownBy(closed::require)
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED));
+    }
+
+    @Test
+    void aSessionOpensOnlyForItsOwner() {
+        var repo = new InMemoryAgentSessionRepository();
+        AgentSession alices = repo.save(AgentSession.start(AgentId.of("default-chat"), UserId.of("alice"),
+                ConversationId.random()));
+        var access = new SessionAccess(repo);
+
+        assertThat(access.requireOwned(alices.id(), UserId.of("alice"))).isEqualTo(alices);
+        assertThat(access.owned(alices.id(), UserId.of("bob"))).isEmpty();
+        assertThatThrownBy(() -> access.requireOwned(alices.id(), UserId.of("bob")))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
+        assertThat(access.owned(SessionId.random(), UserId.of("alice"))).isEmpty();
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/AgentApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/AgentApiControllerOwnershipTest.java
@@ -1,0 +1,221 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentDefinitionRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryConversationSummaryRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryTodoListRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryWorkingMemoryRepository;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.agent.runtime.domain.StreamEvent;
+import ai.mindconnect.agent.runtime.memory.domain.WorkingMemory;
+import ai.mindconnect.agent.runtime.port.in.ChatTurnHandle;
+import ai.mindconnect.agent.runtime.service.AgentChatService;
+import ai.mindconnect.agent.runtime.service.AgentRegistryService;
+import ai.mindconnect.agent.runtime.service.AgentSessionService;
+import ai.mindconnect.agent.runtime.service.approval.ApprovalScope;
+import ai.mindconnect.agent.runtime.service.approval.ToolApproval;
+import ai.mindconnect.agent.runtime.service.approval.ToolApprovalStore;
+import ai.mindconnect.agent.runtime.service.stream.UserChannels;
+import ai.mindconnect.agentrest.auth.SessionAccess;
+import ai.mindconnect.filestore.filesystem.FilesystemFileStore;
+import ai.mindconnect.message.adapter.memory.InMemoryMessageStore;
+import ai.mindconnect.message.domain.ContentPart;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Sessions are the caller's: opened for the caller, listed for the caller, and
+ * every session-addressed endpoint answers someone else's session exactly like
+ * a missing one — before anything reaches the chat service.
+ */
+class AgentApiControllerOwnershipTest {
+
+    @TempDir
+    Path dir;
+
+    private final TestCallers callers = new TestCallers();
+    private final InMemoryAgentSessionRepository sessions = new InMemoryAgentSessionRepository();
+    private final InMemoryAgentDefinitionRepository definitions = new InMemoryAgentDefinitionRepository();
+    private final UserChannels userChannels = new UserChannels();
+
+    private AgentSessionService sessionService;
+    private RecordingChatService chat;
+    private AgentDefinition agent;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        sessionService = new AgentSessionService(definitions, sessions,
+                new InMemoryMessageStore().conversationManager(), new InMemoryWorkingMemoryRepository(),
+                new InMemoryConversationSummaryRepository(), new InMemoryTodoListRepository(),
+                new ToolApprovalStore(), userChannels);
+        chat = new RecordingChatService(sessionService);
+        agent = definitions.save(AgentDefinition.create("helper", "Helps.", "You help.", null, "chat"));
+        AgentApiController controller = new AgentApiController(new AgentRegistryService(definitions),
+                sessionService, chat, new FilesystemFileStore(dir, new Namespace("test")), userChannels,
+                new SessionAccess(sessions), new ObjectMapper());
+        mvc = MockMvcBuilders.standaloneSetup(controller).setCustomArgumentResolvers(callers.resolver()).build();
+    }
+
+    @Test
+    void aSessionStartsForTheCallerWhateverTheBodySays() throws Exception {
+        callers.actAs("alice");
+
+        mvc.perform(post("/api/sessions").contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"agentId\":\"" + agent.id().value() + "\",\"userId\":\"mallory\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value("alice"));
+
+        assertThat(sessionService.listSessions(agent.id(), UserId.of("alice"))).hasSize(1);
+        assertThat(sessionService.listSessions(agent.id(), UserId.of("mallory"))).isEmpty();
+    }
+
+    @Test
+    void theSessionListHoldsOnlyTheCallersSessions() throws Exception {
+        String alices = sessionService.openChat(agent.id(), UserId.of("alice")).id().value();
+        sessionService.openChat(agent.id(), UserId.of("bob"));
+        callers.actAs("alice");
+
+        // A userId parameter from an older client changes nothing.
+        mvc.perform(get("/api/sessions").param("agentId", agent.id().value()).param("userId", "bob"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(alices));
+    }
+
+    @Test
+    void someoneElsesSessionIsNotFoundOnEveryEndpoint() throws Exception {
+        String bobs = sessionService.openChat(agent.id(), UserId.of("bob")).id().value();
+        callers.actAs("alice");
+
+        for (MockHttpServletRequestBuilder request : sessionEndpoints(bobs)) {
+            mvc.perform(request).andExpect(status().isNotFound());
+        }
+
+        assertThat(chat.calls).as("nothing reached the chat service").isEmpty();
+        assertThat(sessions.findById(SessionId.of(bobs))).as("the session was not deleted").isPresent();
+    }
+
+    @Test
+    void aMissingSessionAnswersTheSame() throws Exception {
+        callers.actAs("alice");
+
+        for (MockHttpServletRequestBuilder request : sessionEndpoints(SessionId.random().value())) {
+            mvc.perform(request).andExpect(status().isNotFound());
+        }
+    }
+
+    @Test
+    void theOwnerReachesTheirSession() throws Exception {
+        String alices = sessionService.openChat(agent.id(), UserId.of("alice")).id().value();
+        callers.actAs("alice");
+
+        mvc.perform(get("/api/sessions/{id}/history", alices))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+        mvc.perform(get("/api/sessions/{id}/approvals", alices)).andExpect(status().isOk());
+        mvc.perform(post("/api/sessions/{id}/compress", alices))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.compressedMessages").value(0));
+        mvc.perform(delete("/api/sessions/{id}", alices)).andExpect(status().isNoContent());
+
+        assertThat(chat.calls).containsExactly("openApprovals " + alices, "compressMemory " + alices);
+        assertThat(sessions.findById(SessionId.of(alices))).isEmpty();
+    }
+
+    @Test
+    void theUserStreamIsTheCallersOnly() throws Exception {
+        callers.actAs("alice");
+
+        mvc.perform(get("/api/users/bob/stream")).andExpect(status().isNotFound());
+        mvc.perform(get("/api/users/me/stream")).andExpect(request().asyncStarted());
+        mvc.perform(get("/api/users/alice/stream")).andExpect(request().asyncStarted());
+    }
+
+    /** One request for every endpoint under {@code /api/sessions/{sessionId}}. */
+    private static List<MockHttpServletRequestBuilder> sessionEndpoints(String sessionId) {
+        return List.of(
+                post("/api/sessions/{id}/chat", sessionId).contentType(MediaType.TEXT_PLAIN).content("Hello"),
+                post("/api/sessions/{id}/chat", sessionId).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"Hello\"}"),
+                delete("/api/sessions/{id}/chat", sessionId),
+                get("/api/sessions/{id}/stream", sessionId),
+                get("/api/sessions/{id}/history", sessionId),
+                delete("/api/sessions/{id}/messages", sessionId).param("fromSeq", "1").param("toSeq", "2"),
+                get("/api/sessions/{id}/memory", sessionId),
+                post("/api/sessions/{id}/compress", sessionId),
+                get("/api/sessions/{id}/approvals", sessionId),
+                post("/api/sessions/{id}/approvals/{callId}", sessionId, "call-1").param("approved", "true"),
+                delete("/api/sessions/{id}", sessionId));
+    }
+
+    /** A chat service that only records what reaches it — no turn runs in these tests. */
+    static class RecordingChatService extends AgentChatService {
+
+        final List<String> calls = new CopyOnWriteArrayList<>();
+
+        RecordingChatService(AgentSessionService sessions) {
+            super(sessions, null, null, null, null, null, null, null, null, null, null, null);
+        }
+
+        @Override
+        public ChatTurnHandle submitChat(SessionId sessionId, List<ContentPart> parts,
+                                         Consumer<StreamEvent> eventHandler) {
+            calls.add("submitChat " + sessionId.value());
+            throw new IllegalStateException("No turn runs in this test");
+        }
+
+        @Override
+        public boolean cancelChat(SessionId sessionId) {
+            calls.add("cancelChat " + sessionId.value());
+            return false;
+        }
+
+        @Override
+        public WorkingMemory memorySnapshot(SessionId sessionId) {
+            calls.add("memorySnapshot " + sessionId.value());
+            throw new IllegalStateException("No memory in this test");
+        }
+
+        @Override
+        public int compressMemory(SessionId sessionId) {
+            calls.add("compressMemory " + sessionId.value());
+            return 0;
+        }
+
+        @Override
+        public List<ToolApproval> openApprovals(SessionId rootSessionId) {
+            calls.add("openApprovals " + rootSessionId.value());
+            return List.of();
+        }
+
+        @Override
+        public boolean answerApproval(SessionId rootSessionId, String callId, boolean approved,
+                                      ApprovalScope scope) {
+            calls.add("answerApproval " + rootSessionId.value());
+            return false;
+        }
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/FilesApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/FilesApiControllerOwnershipTest.java
@@ -1,0 +1,126 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.filestore.FileStore;
+import ai.mindconnect.filestore.StoredFile;
+import ai.mindconnect.filestore.filesystem.FilesystemFileStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * A file is its uploader's: listed for them, read and deleted by them. A file
+ * stored before uploaders were recorded stays readable by id, but is neither
+ * listed nor deletable.
+ */
+class FilesApiControllerOwnershipTest {
+
+    @TempDir
+    Path dir;
+
+    private final TestCallers callers = new TestCallers();
+    private FileStore store;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        store = new FilesystemFileStore(dir, new Namespace("test"));
+        mvc = MockMvcBuilders.standaloneSetup(new FilesApiController(store))
+                .setCustomArgumentResolvers(callers.resolver()).build();
+    }
+
+    @Test
+    void anUploadIsTheCallersAndTheListHoldsOnlyTheirOwn() throws Exception {
+        callers.actAs("alice");
+        mvc.perform(multipart("/api/files").file(
+                        new MockMultipartFile("file", "a.txt", "text/plain", bytes("a"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.creator").value("alice"));
+        StoredFile bobs = store.save("b.txt", "text/plain", in("b"), UserId.of("bob"));
+        store.save("old.txt", "text/plain", in("old"));
+
+        mvc.perform(get("/api/files"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("a.txt"));
+
+        callers.actAs("bob");
+        mvc.perform(get("/api/files"))
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(bobs.id().value()));
+    }
+
+    @Test
+    void someoneElsesFileIsNotFound() throws Exception {
+        StoredFile bobs = store.save("b.txt", "text/plain", in("b"), UserId.of("bob"));
+        String id = bobs.id().value();
+
+        callers.actAs("alice");
+        mvc.perform(get("/api/files/{id}", id)).andExpect(status().isNotFound());
+        mvc.perform(get("/api/files/{id}/content", id)).andExpect(status().isNotFound());
+        mvc.perform(delete("/api/files/{id}", id)).andExpect(status().isNotFound());
+        assertThat(store.find(bobs.id())).isPresent();
+
+        callers.actAs("bob");
+        mvc.perform(get("/api/files/{id}/content", id))
+                .andExpect(status().isOk())
+                .andExpect(content().string("b"));
+        mvc.perform(delete("/api/files/{id}", id)).andExpect(status().isNoContent());
+        assertThat(store.find(bobs.id())).isEmpty();
+    }
+
+    @Test
+    void aFileFromBeforeCreatorsIsReadableByIdButNeitherListedNorDeletable() throws Exception {
+        StoredFile old = store.save("old.txt", "text/plain", in("old"));
+        String id = old.id().value();
+
+        callers.actAs("alice");
+        mvc.perform(get("/api/files/{id}", id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("old.txt"));
+        mvc.perform(get("/api/files/{id}/content", id))
+                .andExpect(status().isOk())
+                .andExpect(content().string("old"));
+        mvc.perform(get("/api/files")).andExpect(jsonPath("$").isEmpty());
+        mvc.perform(delete("/api/files/{id}", id)).andExpect(status().isNotFound());
+        assertThat(store.find(old.id())).isPresent();
+    }
+
+    @Test
+    void anUnknownIdIsNotFound() throws Exception {
+        callers.actAs("alice");
+
+        mvc.perform(get("/api/files/{id}", "file-0123456789abcdef0123")).andExpect(status().isNotFound());
+        mvc.perform(delete("/api/files/{id}", "file-0123456789abcdef0123")).andExpect(status().isNotFound());
+    }
+
+    private static byte[] bytes(String text) {
+        return text.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static InputStream in(String text) {
+        return new ByteArrayInputStream(bytes(text));
+    }
+
+    static StoredFile saved(FileStore store, String name, String owner) throws IOException {
+        return store.save(name, "text/plain", in(name), UserId.of(owner));
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SessionFilesApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SessionFilesApiControllerOwnershipTest.java
@@ -1,0 +1,91 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.runtime.domain.AgentSession;
+import ai.mindconnect.agentrest.auth.SessionAccess;
+import ai.mindconnect.filestore.FileStore;
+import ai.mindconnect.filestore.StoredFile;
+import ai.mindconnect.filestore.filesystem.FilesystemFileStore;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Session files open only for the session's owner, and a file attached by id
+ * must be one the caller may read. The checks come before the attach service,
+ * which is why none is wired here.
+ */
+class SessionFilesApiControllerOwnershipTest {
+
+    @TempDir
+    Path dir;
+
+    private final TestCallers callers = new TestCallers();
+    private final InMemoryAgentSessionRepository sessions = new InMemoryAgentSessionRepository();
+    private FileStore store;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        store = new FilesystemFileStore(dir, new Namespace("test"));
+        var controller = new SessionFilesApiController(store, null, new SessionAccess(sessions));
+        mvc = MockMvcBuilders.standaloneSetup(controller).setCustomArgumentResolvers(callers.resolver()).build();
+    }
+
+    @Test
+    void someoneElsesSessionIsNotFoundAndNothingIsStored() throws Exception {
+        String bobs = session("bob");
+        StoredFile alicesFile = FilesApiControllerOwnershipTest.saved(store, "a.txt", "alice");
+        callers.actAs("alice");
+
+        mvc.perform(get("/api/sessions/{id}/files", bobs)).andExpect(status().isNotFound());
+        mvc.perform(delete("/api/sessions/{id}/files", bobs).param("file", "a.txt"))
+                .andExpect(status().isNotFound());
+        mvc.perform(post("/api/sessions/{id}/files", bobs).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"fileId\":\"" + alicesFile.id().value() + "\"}"))
+                .andExpect(status().isNotFound());
+        mvc.perform(multipart("/api/sessions/{id}/files", bobs).file(new MockMultipartFile(
+                        "file", "planted.txt", "text/plain", "x".getBytes(StandardCharsets.UTF_8))))
+                .andExpect(status().isNotFound());
+
+        assertThat(store.list()).containsExactly(alicesFile);
+    }
+
+    @Test
+    void onlyAFileTheCallerMayReadIsAttachedById() throws Exception {
+        String alices = session("alice");
+        StoredFile bobsFile = FilesApiControllerOwnershipTest.saved(store, "b.txt", "bob");
+        callers.actAs("alice");
+
+        mvc.perform(post("/api/sessions/{id}/files", alices).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"fileId\":\"" + bobsFile.id().value() + "\"}"))
+                .andExpect(status().isBadRequest());
+        mvc.perform(post("/api/sessions/{id}/files", alices).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"fileId\":\"file-0123456789abcdef0123\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private String session(String owner) {
+        AgentSession session = sessions.save(AgentSession.start(AgentId.of("default-chat"), UserId.of(owner),
+                ConversationId.random()));
+        return session.id().value();
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/TestCallers.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/TestCallers.java
@@ -1,0 +1,32 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUserResolver;
+import ai.mindconnect.agentrest.auth.CurrentUserWebConfig;
+import ai.mindconnect.agentrest.auth.CurrentUsers;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The authenticated caller of standalone MockMvc requests, switchable between
+ * requests — what the host's security layer establishes in the running app.
+ */
+class TestCallers {
+
+    private final AtomicReference<UserId> current = new AtomicReference<>();
+
+    void actAs(String user) {
+        current.set(UserId.of(user));
+    }
+
+    /** The {@code @CurrentUser} resolver, answering with whoever {@link #actAs} named last. */
+    HandlerMethodArgumentResolver resolver() {
+        var beans = new StaticListableBeanFactory();
+        beans.addBean("resolver", (CurrentUserResolver) () -> Optional.ofNullable(current.get()));
+        return new CurrentUserWebConfig.Resolver(
+                new CurrentUsers(beans.getBeanProvider(CurrentUserResolver.class), true, "dev"));
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/VectorStoreApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/VectorStoreApiControllerOwnershipTest.java
@@ -1,0 +1,175 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentDefinitionRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryConversationSummaryRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryTodoListRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryWorkingMemoryRepository;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.agent.runtime.service.AgentSessionService;
+import ai.mindconnect.agent.runtime.service.approval.ToolApprovalStore;
+import ai.mindconnect.agent.runtime.service.stream.UserChannels;
+import ai.mindconnect.agentrest.auth.SessionAccess;
+import ai.mindconnect.agentrest.auth.VectorStoreAccess;
+import ai.mindconnect.agentrest.service.VectorStoreService;
+import ai.mindconnect.message.adapter.memory.InMemoryMessageStore;
+import ai.mindconnect.vectorstore.tools.VectorStoreInstance;
+import ai.mindconnect.vectorstore.tools.VectorStoreTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * A knowledge base is shared; a chat's upload store answers only to the
+ * chat's user. Nobody else sees it listed, and every store-addressed endpoint
+ * answers 404 before the service is asked — for a registered store and for
+ * one that only carries the name. Ingestion hands the caller on, so the
+ * service reads only a file the caller may read.
+ */
+class VectorStoreApiControllerOwnershipTest {
+
+    private static final VectorStoreTemplate TEMPLATE =
+            new VectorStoreTemplate("default", "memory", Map.of(), "embeddings", null, Map.of());
+
+    private final TestCallers callers = new TestCallers();
+    private final InMemoryAgentSessionRepository sessions = new InMemoryAgentSessionRepository();
+    private final InMemoryAgentDefinitionRepository definitions = new InMemoryAgentDefinitionRepository();
+    private final VectorStoreService service = mock(VectorStoreService.class);
+
+    private AgentSessionService sessionService;
+    private AgentDefinition agent;
+    private String alicesStore;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        sessionService = new AgentSessionService(definitions, sessions,
+                new InMemoryMessageStore().conversationManager(), new InMemoryWorkingMemoryRepository(),
+                new InMemoryConversationSummaryRepository(), new InMemoryTodoListRepository(),
+                new ToolApprovalStore(), new UserChannels());
+        agent = definitions.save(AgentDefinition.create("helper", "Helps.", "You help.", null, "chat"));
+        String alicesSession = sessionService.openChat(agent.id(), UserId.of("alice")).id().value();
+        alicesStore = VectorStoreAccess.CHAT_STORE_PREFIX + alicesSession;
+
+        VectorStoreInstance chatStore = VectorStoreInstance.fromTemplate(
+                alicesStore, TEMPLATE, VectorStoreInstance.Scope.SESSION, alicesSession);
+        VectorStoreInstance knowledgeBase = VectorStoreInstance.fromTemplate(
+                "handbook", TEMPLATE, VectorStoreInstance.Scope.GLOBAL, null);
+        when(service.instances()).thenReturn(List.of(chatStore, knowledgeBase));
+        when(service.instance(alicesStore)).thenReturn(Optional.of(chatStore));
+        when(service.instance("handbook")).thenReturn(Optional.of(knowledgeBase));
+
+        VectorStoreApiController controller =
+                new VectorStoreApiController(service, new VectorStoreAccess(new SessionAccess(sessions)));
+        mvc = MockMvcBuilders.standaloneSetup(controller).setCustomArgumentResolvers(callers.resolver()).build();
+    }
+
+    @Test
+    void theListHoldsTheKnowledgeBasesAndOnlyTheCallersOwnChatStores() throws Exception {
+        callers.actAs("alice");
+        mvc.perform(get("/api/vector-stores/stores"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+
+        callers.actAs("bob");
+        mvc.perform(get("/api/vector-stores/stores"))
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("handbook"));
+    }
+
+    @Test
+    void someoneElsesChatStoreIsNotFoundAndTheServiceIsNeverAsked() throws Exception {
+        callers.actAs("bob");
+
+        mvc.perform(get("/api/vector-stores/stores/{name}", alicesStore)).andExpect(status().isNotFound());
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/search", alicesStore), "{\"query\":\"salary\"}"))
+                .andExpect(status().isNotFound());
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/chunks", alicesStore), "{\"text\":\"planted\"}"))
+                .andExpect(status().isNotFound());
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/ingest", alicesStore), "{\"fileId\":\"file-1\"}"))
+                .andExpect(status().isNotFound());
+        mvc.perform(delete("/api/vector-stores/stores/{name}", alicesStore)).andExpect(status().isNotFound());
+
+        verify(service, never()).search(any(), any(), anyInt(), anyDouble());
+        verify(service, never()).upsertChunk(any(), any(), any(), any(), any(), any());
+        verify(service, never()).ingestStoredFile(any(), any(), any());
+        verify(service, never()).deleteStore(any());
+    }
+
+    @Test
+    void theChatsUserReachesTheirStoreAndEveryoneReachesAKnowledgeBase() throws Exception {
+        when(service.search(any(), any(), anyInt(), anyDouble())).thenReturn(List.of());
+
+        callers.actAs("alice");
+        mvc.perform(get("/api/vector-stores/stores/{name}", alicesStore)).andExpect(status().isOk());
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/search", alicesStore), "{\"query\":\"notes\"}"))
+                .andExpect(status().isOk());
+
+        callers.actAs("bob");
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/search", "handbook"), "{\"query\":\"notes\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aChatStoreNameIsTheChatsUsersEvenBeforeTheStoreIsRegistered() throws Exception {
+        when(service.search(any(), any(), anyInt(), anyDouble())).thenReturn(List.of());
+        String unregistered = VectorStoreAccess.CHAT_STORE_PREFIX
+                + sessionService.openChat(agent.id(), UserId.of("alice")).id().value();
+
+        callers.actAs("bob");
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/chunks", unregistered), "{\"text\":\"planted\"}"))
+                .andExpect(status().isNotFound());
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/search", "session-no-such-chat"), "{\"query\":\"x\"}"))
+                .andExpect(status().isNotFound());
+
+        callers.actAs("alice");
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/search", unregistered), "{\"query\":\"x\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void noStoreIsCreatedUnderAChatStoreName() throws Exception {
+        callers.actAs("alice");
+
+        mvc.perform(json(post("/api/vector-stores/stores"), "{\"name\":\"session-anything\"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(service, never()).createStore(any(), any());
+    }
+
+    @Test
+    void ingestionReadsTheFileAsTheCaller() throws Exception {
+        when(service.ingestStoredFile(any(), any(), any())).thenReturn("ingested");
+
+        callers.actAs("bob");
+        mvc.perform(json(post("/api/vector-stores/stores/{name}/ingest", "handbook"), "{\"fileId\":\"file-1\"}"))
+                .andExpect(status().isOk());
+
+        verify(service).ingestStoredFile("handbook", "file-1", UserId.of("bob"));
+    }
+
+    private static org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder json(
+            org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder request, String body) {
+        return request.contentType(MediaType.APPLICATION_JSON).content(body);
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/WorkspaceApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/WorkspaceApiControllerOwnershipTest.java
@@ -1,0 +1,91 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentSessionRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryWorkspaceStore;
+import ai.mindconnect.agent.runtime.domain.AgentSession;
+import ai.mindconnect.agent.runtime.tools.workspace.WorkspaceScope;
+import ai.mindconnect.agentrest.auth.SessionAccess;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Every workspace is the caller's: a path names the caller's own id or
+ * {@code me}, a session workspace opens for the session's owner, and anything
+ * else answers 404.
+ */
+class WorkspaceApiControllerOwnershipTest {
+
+    private static final AgentId AGENT = AgentId.of("default-chat");
+
+    private final TestCallers callers = new TestCallers();
+    private final InMemoryAgentSessionRepository sessions = new InMemoryAgentSessionRepository();
+    private final InMemoryWorkspaceStore store = new InMemoryWorkspaceStore();
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        var controller = new WorkspaceApiController(store, new SessionAccess(sessions));
+        mvc = MockMvcBuilders.standaloneSetup(controller).setCustomArgumentResolvers(callers.resolver()).build();
+        store.write(WorkspaceScope.user(UserId.of("alice")), "notes.md", "alice's notes");
+        store.write(WorkspaceScope.user(UserId.of("bob")), "notes.md", "bob's notes");
+        store.write(WorkspaceScope.agentUser(AGENT, UserId.of("alice")), "memory.md", "about alice");
+        store.write(WorkspaceScope.agentUser(AGENT, UserId.of("bob")), "memory.md", "about bob");
+    }
+
+    @Test
+    void theUserWorkspaceIsTheCallersOwn() throws Exception {
+        callers.actAs("alice");
+
+        mvc.perform(get("/api/workspaces/user/me/files"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("notes.md"));
+        mvc.perform(get("/api/workspaces/user/alice/files/notes.md"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("alice's notes"));
+        mvc.perform(get("/api/workspaces/user/bob/files")).andExpect(status().isNotFound());
+        mvc.perform(get("/api/workspaces/user/bob/files/notes.md")).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void theAgentWorkspaceIsTheCallersOwn() throws Exception {
+        callers.actAs("alice");
+
+        mvc.perform(get("/api/workspaces/agent/{agent}/user/me/files/memory.md", AGENT.value()))
+                .andExpect(status().isOk())
+                .andExpect(content().string("about alice"));
+        mvc.perform(get("/api/workspaces/agent/{agent}/user/bob/files", AGENT.value()))
+                .andExpect(status().isNotFound());
+        mvc.perform(get("/api/workspaces/agent/{agent}/user/bob/files/memory.md", AGENT.value()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void aSessionWorkspaceOpensForTheSessionsOwner() throws Exception {
+        AgentSession alices = session("alice");
+        AgentSession bobs = session("bob");
+        store.write(WorkspaceScope.session(AGENT, UserId.of("bob"), bobs.id()), "draft.md", "bob's draft");
+        callers.actAs("alice");
+
+        mvc.perform(get("/api/workspaces/session/{id}/files", alices.id().value()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+        mvc.perform(get("/api/workspaces/session/{id}/files", bobs.id().value()))
+                .andExpect(status().isNotFound());
+        mvc.perform(get("/api/workspaces/session/{id}/files/draft.md", bobs.id().value()))
+                .andExpect(status().isNotFound());
+    }
+
+    private AgentSession session(String owner) {
+        return sessions.save(AgentSession.start(AGENT, UserId.of(owner), ConversationId.random()));
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/TranscriptionJobServiceTest.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agentrest.service;
 
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
 import ai.mindconnect.filestore.StoredFile;
@@ -192,12 +193,22 @@ class TranscriptionJobServiceTest {
     }
 
     @Test
-    void theRequesterIsRememberedForTheOwnerCheck() throws Exception {
-        String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
-                null, null, null, "mc_user").taskId();
+    void theRequesterIsRememberedForTheOwnerCheckAndOwnsTheRecording() throws Exception {
+        TranscriptionJobService.Job job = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, UserId.of("alice"));
 
-        assertThat(TranscriptionJobService.requesterOf(queue.get(taskId).orElseThrow()))
-                .contains("mc_user");
+        assertThat(TranscriptionJobService.requesterOf(queue.get(job.taskId()).orElseThrow()))
+                .contains(UserId.of("alice"));
+        assertThat(files.find(FileId.of(job.fileId()))).get()
+                .extracting(StoredFile::creator).isEqualTo(UserId.of("alice"));
+    }
+
+    @Test
+    void aJobOnNobodysBehalfHasNoRequester() throws Exception {
+        String taskId = service.submit(AUDIO, "speech.webm", "audio/webm",
+                null, null, null, null).taskId();
+
+        assertThat(TranscriptionJobService.requesterOf(queue.get(taskId).orElseThrow())).isEmpty();
     }
 
     // ── Stubs ──────────────────────────────────────────────────────────────
@@ -208,12 +219,12 @@ class TranscriptionJobServiceTest {
         private final Map<FileId, StoredFile> meta = new LinkedHashMap<>();
 
         @Override
-        public StoredFile save(String name, String contentType, InputStream content)
+        public StoredFile save(String name, String contentType, InputStream content, UserId creator)
                 throws IOException {
             FileId id = FileId.of("file-" + UUID.randomUUID());
             byte[] bytes = content.readAllBytes();
             stored.put(id, bytes);
-            StoredFile file = new StoredFile(id, name, contentType, bytes.length, Instant.now());
+            StoredFile file = new StoredFile(id, name, contentType, bytes.length, Instant.now(), creator);
             meta.put(id, file);
             return file;
         }

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/VectorStoreServiceIngestTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/service/VectorStoreServiceIngestTest.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.agentrest.service;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.filestore.FileStore;
+import ai.mindconnect.filestore.StoredFile;
+import ai.mindconnect.filestore.filesystem.FilesystemFileStore;
+import ai.mindconnect.vectorstore.tools.VectorStores;
+import ai.mindconnect.workflow.persistence.port.WorkflowDataRepository;
+import ai.mindconnect.workflow.persistence.port.WorkflowInstanceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Ingesting a stored file reads it as the caller: a file the caller may not
+ * read is reported like a missing one, before any store is touched.
+ */
+class VectorStoreServiceIngestTest {
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void aFileTheReaderMayNotReadIsReportedLikeAMissingOne() throws Exception {
+        FileStore files = new FilesystemFileStore(dir.resolve("data"), new Namespace("test"));
+        StoredFile alices = files.save("notes.txt", "text/plain",
+                new ByteArrayInputStream("secret".getBytes(StandardCharsets.UTF_8)), UserId.of("alice"));
+        var beans = new StaticListableBeanFactory();
+        beans.addBean("files", files);
+        VectorStoreService service = new VectorStoreService(beans.getBeanProvider(VectorStores.class),
+                beans.getBeanProvider(FileStore.class), beans.getBeanProvider(WorkflowDataRepository.class),
+                beans.getBeanProvider(WorkflowInstanceRepository.class), dir.resolve("tools").toString());
+
+        assertThatThrownBy(() -> service.ingestStoredFile("handbook", alices.id().value(), UserId.of("bob")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No such file");
+        // Alice's own file passes the check and goes on to the stores — which this host has none of.
+        assertThatThrownBy(() -> service.ingestStoredFile("handbook", alices.id().value(), UserId.of("alice")))
+                .isInstanceOf(NotConfiguredException.class);
+    }
+}

--- a/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/main/java/ai/mindconnect/chatui/ui/controller/ChatFilesUiController.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.filestore.FileId;
 
 /**
@@ -111,11 +112,13 @@ public class ChatFilesUiController {
                           @AuthenticationPrincipal OidcUser user) throws IOException {
         SessionId sessionId = SessionId.of(sessionIdValue);
         requireOwned(sessionId, user);
+        // The caller owns the session (checked above), so the uploads are the session owner's files.
+        UserId owner = UserId.of(SessionOwnership.userIdOf(user));
         UiPatch patch = UiPatch.of();
         for (MultipartFile file : files) {
             StoredFile stored;
             try (InputStream content = file.getInputStream()) {
-                stored = fileStore.save(file.getOriginalFilename(), file.getContentType(), content);
+                stored = fileStore.save(file.getOriginalFilename(), file.getContentType(), content, owner);
             }
             SessionFileService.AttachResult result = sessionFiles.attach(sessionId, stored);
             patch.toast(result.success()

--- a/agents/server/mc-agent-security/pom.xml
+++ b/agents/server/mc-agent-security/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-agent-security</artifactId>
+    <name>mc-agent-security</name>
+    <packaging>jar</packaging>
+    <description>
+        Spring Security for the agent apps: bearer authentication of the REST API
+        with a JWT of the identity provider or a personal API token, the caller of
+        a request as a UserId for the REST layer, and the user record kept in step
+        with who signs in. Auto-configured; each app composes its filter chains
+        from these parts.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-api-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- oidcLogin() of spring-security-test builds an OAuth2AuthenticationToken -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiAuthentication.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiAuthentication.java
@@ -1,0 +1,141 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.user.service.ApiTokenService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderInitializationException;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.SupplierJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Bearer authentication for the REST API, in one piece an app adds to its
+ * API filter chain with {@link #apply}: a bearer token is either one of our
+ * personal API tokens ({@code mct_…}) or a JWT of the identity provider. Either
+ * way the request runs as a user, and the user record is kept current.
+ *
+ * <p>The token's shape decides which of the two checks it gets, and it gets
+ * only that one. A {@code ProviderManager} would hand a rejected API token on
+ * to the JWT check — which then contacts the identity provider for a string
+ * that was never a JWT, and turns an unreachable provider into a failed
+ * request instead of a rejected token.
+ */
+public class ApiAuthentication {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiAuthentication.class);
+
+    private final AuthenticationManager manager;
+    private final UserRecorder recorder;
+
+    public ApiAuthentication(ApiTokenService tokens, UserRecorder recorder, JwtDecoder jwtDecoder) {
+        this.recorder = Objects.requireNonNull(recorder, "recorder");
+        ApiTokenAuthenticationProvider apiTokens = new ApiTokenAuthenticationProvider(tokens, recorder);
+        JwtAuthenticationProvider jwt = new JwtAuthenticationProvider(Objects.requireNonNull(jwtDecoder, "jwtDecoder"));
+        jwt.setJwtAuthenticationConverter(new JwtUserConverter(recorder));
+        this.manager = authentication -> {
+            String token = ((BearerTokenAuthenticationToken) authentication).getToken();
+            return ApiTokenService.looksLikeApiToken(token)
+                    ? apiTokens.authenticate(authentication)
+                    : jwt.authenticate(authentication);
+        };
+    }
+
+    /**
+     * Makes a filter chain a bearer-only API: a request authenticates with a
+     * token or not at all. A browser session does not count there, so a
+     * foreign site has no cookie to ride on and the chain needs no CSRF token.
+     * A request the chain turns away gets 401 or 403 with a JSON body
+     * ({@link ApiErrorResponder}).
+     */
+    public HttpSecurity apply(HttpSecurity http) throws Exception {
+        ApiErrorResponder errors = new ApiErrorResponder();
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .oauth2ResourceServer(rs -> rs
+                        .authenticationManagerResolver(request -> manager)
+                        .authenticationEntryPoint(errors)
+                        .accessDeniedHandler(errors))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(errors)
+                        .accessDeniedHandler(errors));
+    }
+
+    public AuthenticationManager authenticationManager() {
+        return manager;
+    }
+
+    public UserRecorder recorder() {
+        return recorder;
+    }
+
+    /**
+     * A decoder for JWTs of {@code issuerUri}: signature against the issuer's
+     * published keys, issuer and lifetime checked, and — when
+     * {@code audiences} names any — an audience among them.
+     *
+     * <p>The issuer's metadata is fetched on the first token, not at startup,
+     * so the app starts while the identity provider is still coming up. While
+     * the provider cannot be reached a JWT is rejected (401, and a warning in
+     * the log) and the next token tries again; API tokens are not affected.
+     * Without an issuer every JWT is rejected.
+     */
+    public static JwtDecoder jwtDecoder(String issuerUri, List<String> audiences) {
+        if (issuerUri == null || issuerUri.isBlank()) {
+            return token -> {
+                throw new BadJwtException("No JWT issuer is configured (mindconnect.auth.jwt.issuer-uri)");
+            };
+        }
+        List<String> accepted = audiences == null ? List.of()
+                : audiences.stream().map(String::strip).filter(a -> !a.isEmpty()).toList();
+        JwtDecoder lazy = new SupplierJwtDecoder(() -> {
+            NimbusJwtDecoder decoder = JwtDecoders.fromIssuerLocation(issuerUri);
+            OAuth2TokenValidator<Jwt> validator = JwtValidators.createDefaultWithIssuer(issuerUri);
+            if (!accepted.isEmpty()) {
+                validator = new DelegatingOAuth2TokenValidator<>(validator, audience(accepted));
+            }
+            decoder.setJwtValidator(validator);
+            return decoder;
+        });
+        return token -> {
+            try {
+                return lazy.decode(token);
+            } catch (JwtDecoderInitializationException e) {
+                log.warn("Rejecting a bearer JWT: the issuer {} cannot be reached ({})", issuerUri, rootCause(e));
+                throw new BadJwtException("The token issuer cannot be reached", e);
+            }
+        };
+    }
+
+    private static OAuth2TokenValidator<Jwt> audience(List<String> accepted) {
+        return jwt -> jwt.getAudience() != null && jwt.getAudience().stream().anyMatch(accepted::contains)
+                ? OAuth2TokenValidatorResult.success()
+                : OAuth2TokenValidatorResult.failure(new OAuth2Error("invalid_token",
+                        "The token is not meant for this API (audience)", null));
+    }
+
+    private static String rootCause(Throwable e) {
+        Throwable root = e;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return root.toString();
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiErrorResponder.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiErrorResponder.java
@@ -1,0 +1,70 @@
+package ai.mindconnect.agent.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
+import org.springframework.security.oauth2.server.resource.web.access.BearerTokenAccessDeniedHandler;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What the API answers a request it does not let through: the status and the
+ * {@code WWW-Authenticate} header a bearer client expects, plus a short JSON
+ * body a person reading a bare {@code curl} can act on —
+ * {@code {"status":401,"error":"Unauthorized","message":"…"}}.
+ *
+ * <p>Without a token the message says what kind of token to send; with a
+ * rejected one it repeats why it was rejected, the same text the
+ * {@code WWW-Authenticate} header carries.
+ */
+public class ApiErrorResponder implements AuthenticationEntryPoint, AccessDeniedHandler {
+
+    static final String TOKEN_REQUIRED =
+            "A bearer token is required: a personal API token (mct_...) or an access token of the identity provider";
+    static final String ACCESS_DENIED = "Access denied";
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final BearerTokenAuthenticationEntryPoint unauthorized = new BearerTokenAuthenticationEntryPoint();
+    private final BearerTokenAccessDeniedHandler forbidden = new BearerTokenAccessDeniedHandler();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException exception) throws IOException {
+        // Sets the status (401, or 400 for a malformed Authorization header) and the header.
+        unauthorized.commence(request, response, exception);
+        write(response, exception instanceof OAuth2AuthenticationException oauth
+                && oauth.getError().getDescription() != null
+                ? oauth.getError().getDescription()
+                : TOKEN_REQUIRED);
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException exception) throws IOException {
+        forbidden.handle(request, response, exception);
+        write(response, ACCESS_DENIED);
+    }
+
+    private static void write(HttpServletResponse response, String message) throws IOException {
+        HttpStatus status = HttpStatus.resolve(response.getStatus());
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", response.getStatus());
+        body.put("error", status == null ? "" : status.getReasonPhrase());
+        body.put("message", message);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(JSON.writeValueAsString(body));
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiTokenAuthentication.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiTokenAuthentication.java
@@ -1,0 +1,45 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiTokenId;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import java.util.Objects;
+
+/**
+ * A request authenticated by a personal API token: it runs as the token's
+ * owner. The secret is not kept — only which token it was.
+ */
+public class ApiTokenAuthentication extends AbstractAuthenticationToken {
+
+    private final UserId userId;
+    private final ApiTokenId tokenId;
+
+    public ApiTokenAuthentication(UserId userId, ApiTokenId tokenId) {
+        super(AuthorityUtils.createAuthorityList("ROLE_USER"));
+        this.userId = Objects.requireNonNull(userId, "userId");
+        this.tokenId = Objects.requireNonNull(tokenId, "tokenId");
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public UserId getPrincipal() {
+        return userId;
+    }
+
+    @Override
+    public String getName() {
+        return userId.value();
+    }
+
+    /** The token that authenticated the request. */
+    public ApiTokenId tokenId() {
+        return tokenId;
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiTokenAuthenticationProvider.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/ApiTokenAuthenticationProvider.java
@@ -1,0 +1,46 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.user.domain.ApiToken;
+import ai.mindconnect.user.service.ApiTokenService;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+
+import java.util.Objects;
+
+/**
+ * Authenticates a bearer token that is one of our API tokens. Anything else —
+ * a JWT — it leaves to the next provider by returning null; a token with our
+ * prefix that does not check out is rejected here and never offered to the
+ * JWT provider.
+ */
+public class ApiTokenAuthenticationProvider implements AuthenticationProvider {
+
+    private final ApiTokenService tokens;
+    private final UserRecorder recorder;
+
+    public ApiTokenAuthenticationProvider(ApiTokenService tokens, UserRecorder recorder) {
+        this.tokens = Objects.requireNonNull(tokens, "tokens");
+        this.recorder = Objects.requireNonNull(recorder, "recorder");
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) {
+        String secret = ((BearerTokenAuthenticationToken) authentication).getToken();
+        if (!ApiTokenService.looksLikeApiToken(secret)) {
+            return null;
+        }
+        ApiToken token = tokens.authenticate(secret)
+                .orElseThrow(() -> new InvalidBearerTokenException("Invalid, expired or revoked API token"));
+        recorder.record(token.userId(), null, null, null, null);
+        ApiTokenAuthentication result = new ApiTokenAuthentication(token.userId(), token.id());
+        result.setDetails(authentication.getDetails());
+        return result;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return BearerTokenAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/DevUserFilter.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/DevUserFilter.java
@@ -1,0 +1,56 @@
+package ai.mindconnect.agent.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * Authentication off: every request runs as one fixed user, presented exactly
+ * like a browser login ({@link OidcUser}, {@code preferred_username} = the
+ * user), so that nothing downstream needs a second code path for the dev
+ * mode. Not a bean: an app adds it to its open filter chain only.
+ */
+public class DevUserFilter extends OncePerRequestFilter {
+
+    private final OidcUser devUser;
+
+    public DevUserFilter(String userName) {
+        OidcIdToken idToken = OidcIdToken.withTokenValue("dev")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plus(3650, ChronoUnit.DAYS))
+                .subject(userName)
+                .claim(StandardClaimNames.PREFERRED_USERNAME, userName)
+                .claim(StandardClaimNames.NAME, userName)
+                .build();
+        this.devUser = new DefaultOidcUser(List.of(new SimpleGrantedAuthority("ROLE_USER")), idToken);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        Authentication current = SecurityContextHolder.getContext().getAuthentication();
+        if (current == null || !(current.getPrincipal() instanceof OidcUser)) {
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(UsernamePasswordAuthenticationToken.authenticated(
+                    devUser, null, devUser.getAuthorities()));
+            SecurityContextHolder.setContext(context);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/JwtUserConverter.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/JwtUserConverter.java
@@ -1,0 +1,41 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.Objects;
+
+/**
+ * Turns a validated JWT into the request's authentication. The caller is the
+ * {@value #USER_ID_CLAIM} claim — the same value a browser login yields, so a
+ * user's sessions are the same whichever way they authenticate. A token
+ * without that claim is rejected rather than mapped to another identity.
+ */
+public class JwtUserConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    /** The claim that becomes the {@link UserId}. */
+    public static final String USER_ID_CLAIM = "preferred_username";
+
+    private final UserRecorder recorder;
+
+    public JwtUserConverter(UserRecorder recorder) {
+        this.recorder = Objects.requireNonNull(recorder, "recorder");
+    }
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        String name = jwt.getClaimAsString(USER_ID_CLAIM);
+        if (name == null || name.isBlank()) {
+            throw new InvalidBearerTokenException("The token carries no " + USER_ID_CLAIM + " claim");
+        }
+        recorder.record(UserId.of(name), jwt.getSubject(),
+                jwt.getIssuer() == null ? null : jwt.getIssuer().toString(),
+                jwt.getClaimAsString("name"), jwt.getClaimAsString("email"));
+        return new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList("ROLE_USER"), name);
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/MindconnectSecurityAutoConfiguration.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/MindconnectSecurityAutoConfiguration.java
@@ -1,0 +1,106 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agentrest.auth.CurrentUserResolver;
+import ai.mindconnect.user.port.out.ApiTokenRepository;
+import ai.mindconnect.user.port.out.UserRepository;
+import ai.mindconnect.user.service.ApiTokenService;
+import ai.mindconnect.user.service.UserService;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+import java.util.List;
+
+/**
+ * The parts the apps compose their security from: the user and token
+ * services over the persistence starter's repositories, the caller resolver
+ * for the REST layer, and {@link ApiAuthentication}. Filter chains are not
+ * defined here — which paths take a browser login, a bearer token or nothing
+ * is each app's decision.
+ *
+ * <pre>
+ * mindconnect:
+ *   auth:
+ *     jwt:
+ *       issuer-uri: https://auth.example.com/realms/mindconnect   # KC_ISSUER_URI
+ *       audiences: mc-api                                          # optional
+ * </pre>
+ */
+@AutoConfiguration(afterName = {
+        "ai.mindconnect.agent.starter.file.FilePersistenceAutoConfiguration",
+        "ai.mindconnect.agent.starter.postgres.PostgresPersistenceConfig"})
+@ConditionalOnClass(HttpSecurity.class)
+@ConditionalOnBean({UserRepository.class, ApiTokenRepository.class})
+public class MindconnectSecurityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    UserService userService(UserRepository users) {
+        return new UserService(users);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    ApiTokenService apiTokenService(ApiTokenRepository tokens) {
+        return new ApiTokenService(tokens);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    UserRecorder userRecorder(UserService users) {
+        return new UserRecorder(users);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(CurrentUserResolver.class)
+    CurrentUserResolver currentUserResolver() {
+        return new SecurityCurrentUserResolver();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(JwtDecoder.class)
+    JwtDecoder mindconnectJwtDecoder(@Value("${mindconnect.auth.jwt.issuer-uri:}") String issuerUri,
+                                     @Value("${mindconnect.auth.jwt.audiences:}") List<String> audiences) {
+        return ApiAuthentication.jwtDecoder(issuerUri, audiences);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    ApiAuthentication apiAuthentication(ApiTokenService tokens, UserRecorder recorder, JwtDecoder jwtDecoder) {
+        return new ApiAuthentication(tokens, recorder, jwtDecoder);
+    }
+
+    /**
+     * With authentication on, the OpenAPI description declares the bearer
+     * scheme, so Swagger UI offers <b>Authorize</b> and "Try it out" sends the
+     * token — the API does not take the browser session Swagger UI runs in.
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(name = "org.springdoc.core.customizers.OpenApiCustomizer")
+    @ConditionalOnProperty(name = "mindconnect.auth.enabled", havingValue = "true")
+    static class BearerOpenApi {
+
+        static final String SCHEME = "bearer";
+
+        @Bean
+        OpenApiCustomizer mindconnectBearerOpenApi() {
+            return openApi -> openApi
+                    .schemaRequirement(SCHEME, new SecurityScheme()
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .description("A personal API token (mct_…, created on the profile page) "
+                                    + "or an access token of the identity provider"))
+                    .addSecurityItem(new SecurityRequirement().addList(SCHEME));
+        }
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/SecurityCurrentUserResolver.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/SecurityCurrentUserResolver.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUserResolver;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.Optional;
+
+/**
+ * The caller of the current request, from whatever authenticated it: a
+ * personal API token, a bearer JWT, or a browser login (including the fixed
+ * dev user, which is a login too). Everything else — anonymous, or an
+ * authentication this does not know — has no caller, and the REST layer
+ * answers 401.
+ */
+public class SecurityCurrentUserResolver implements CurrentUserResolver {
+
+    @Override
+    public Optional<UserId> currentUser() {
+        return userIdOf(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    /** The user an authentication stands for; empty when it stands for nobody we know. */
+    public static Optional<UserId> userIdOf(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            return Optional.empty();
+        }
+        if (authentication instanceof ApiTokenAuthentication token) {
+            return Optional.of(token.getPrincipal());
+        }
+        if (authentication instanceof JwtAuthenticationToken jwt) {
+            return nonBlank(jwt.getName());
+        }
+        if (authentication.getPrincipal() instanceof OidcUser oidc) {
+            return nonBlank(oidc.getPreferredUsername());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<UserId> nonBlank(String value) {
+        return value == null || value.isBlank() ? Optional.empty() : Optional.of(UserId.of(value));
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/UserRecorder.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/UserRecorder.java
@@ -1,0 +1,55 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tells the {@link UserService} who signed in, but not on every request: it
+ * remembers whom it recorded recently and calls the service at most once per
+ * {@link UserService#LOGIN_RESOLUTION} per user, so an API client's burst of
+ * calls does not become a burst of reads of the user store.
+ *
+ * <p>A failing user store never fails the request: the caller is already
+ * authenticated, the record is bookkeeping.
+ */
+public class UserRecorder {
+
+    private static final Logger log = LoggerFactory.getLogger(UserRecorder.class);
+
+    private final UserService users;
+    private final Clock clock;
+    private final Map<UserId, Instant> recent = new ConcurrentHashMap<>();
+
+    public UserRecorder(UserService users) {
+        this(users, Clock.systemUTC());
+    }
+
+    public UserRecorder(UserService users, Clock clock) {
+        this.users = Objects.requireNonNull(users, "users");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /** Records a sign-in; details the caller does not know are null. */
+    public void record(UserId id, String subject, String issuer, String displayName, String email) {
+        Instant now = clock.instant();
+        Instant last = recent.get(id);
+        if (last != null && Duration.between(last, now).compareTo(UserService.LOGIN_RESOLUTION) < 0) {
+            return;
+        }
+        try {
+            users.recordLogin(id, subject, issuer, displayName, email);
+            recent.put(id, now);
+        } catch (RuntimeException e) {
+            log.warn("Could not record the sign-in of {}: {}", id, e.toString());
+        }
+    }
+}

--- a/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/UserRecordingFilter.java
+++ b/agents/server/mc-agent-security/src/main/java/ai/mindconnect/agent/security/UserRecordingFilter.java
@@ -1,0 +1,43 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Records the user behind a browser login (or the dev user) — the one kind of
+ * authentication that does not pass through a place of ours where it could be
+ * recorded, the way a JWT or an API token does. Not a bean: an app adds it to
+ * its filter chains, so it never runs outside them.
+ */
+public class UserRecordingFilter extends OncePerRequestFilter {
+
+    private final UserRecorder recorder;
+
+    public UserRecordingFilter(UserRecorder recorder) {
+        this.recorder = Objects.requireNonNull(recorder, "recorder");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof OidcUser oidc
+                && oidc.getPreferredUsername() != null && !oidc.getPreferredUsername().isBlank()) {
+            recorder.record(UserId.of(oidc.getPreferredUsername()), oidc.getSubject(),
+                    oidc.getIssuer() == null ? null : oidc.getIssuer().toString(),
+                    oidc.getFullName(), oidc.getEmail());
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/agents/server/mc-agent-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agents/server/mc-agent-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ai.mindconnect.agent.security.MindconnectSecurityAutoConfiguration

--- a/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/ApiFilterChainTest.java
+++ b/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/ApiFilterChainTest.java
@@ -1,0 +1,219 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agentrest.auth.CurrentUser;
+import ai.mindconnect.agentrest.auth.CurrentUserResolver;
+import ai.mindconnect.agentrest.auth.CurrentUserWebConfig;
+import ai.mindconnect.agentrest.auth.CurrentUsers;
+import ai.mindconnect.user.adapter.memory.InMemoryApiTokenRepository;
+import ai.mindconnect.user.adapter.memory.InMemoryUserRepository;
+import ai.mindconnect.user.service.ApiTokenService;
+import ai.mindconnect.user.service.UserService;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * An API filter chain built the way the apps build theirs: a request is
+ * answered as the user its API token or its JWT names, and not at all without
+ * one — a browser session does not count, and no CSRF token is asked for.
+ */
+@WebMvcTest(properties = "mindconnect.auth.enabled=true")
+@ContextConfiguration(classes = ApiFilterChainTest.TestApp.class)
+class ApiFilterChainTest {
+
+    private static final RSAKey SIGNING_KEY = rsaKey();
+    private static final RSAKey FOREIGN_KEY = rsaKey();
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ApiTokenService tokens;
+
+    @Test
+    void withoutAuthenticationTheApiAnswers401AndSaysWhatToSend() throws Exception {
+        mvc.perform(get("/api/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string("WWW-Authenticate", "Bearer"))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value(ApiErrorResponder.TOKEN_REQUIRED));
+    }
+
+    @Test
+    void anApiTokenRunsTheRequestAsItsOwner() throws Exception {
+        String secret = tokens.issue(UserId.of("alice"), "cli", null).secret();
+
+        mvc.perform(get("/api/me").header("Authorization", "Bearer " + secret))
+                .andExpect(status().isOk()).andExpect(content().string("alice"));
+        mvc.perform(post("/api/me").header("Authorization", "Bearer " + secret))
+                .andExpect(status().isOk()).andExpect(content().string("alice"));
+    }
+
+    @Test
+    void aRevokedOrForgedApiTokenIsRejected() throws Exception {
+        var issued = tokens.issue(UserId.of("alice"), "cli", null);
+        tokens.revoke(UserId.of("alice"), issued.token().id());
+
+        mvc.perform(get("/api/me").header("Authorization", "Bearer " + issued.secret()))
+                .andExpect(status().isUnauthorized());
+        mvc.perform(get("/api/me").header("Authorization", "Bearer mct_forged"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("Invalid, expired or revoked API token"));
+    }
+
+    @Test
+    void aJwtRunsTheRequestAsTheUserItNames() throws Exception {
+        mvc.perform(get("/api/me").header("Authorization", "Bearer " + jwt(SIGNING_KEY, "bob")))
+                .andExpect(status().isOk()).andExpect(content().string("bob"));
+        mvc.perform(post("/api/me").header("Authorization", "Bearer " + jwt(SIGNING_KEY, "bob")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void aJwtSignedByAnotherKeyOrNamingNobodyIsRejected() throws Exception {
+        mvc.perform(get("/api/me").header("Authorization", "Bearer " + jwt(FOREIGN_KEY, "bob")))
+                .andExpect(status().isUnauthorized());
+        mvc.perform(get("/api/me").header("Authorization", "Bearer " + jwt(SIGNING_KEY, null)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void aWriteWithoutTokenAndSessionAnswers401NotACsrfError() throws Exception {
+        mvc.perform(post("/api/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(ApiErrorResponder.TOKEN_REQUIRED));
+    }
+
+    @Test
+    void aBrowserSessionDoesNotCountForTheApi() throws Exception {
+        // A logged-in browser as the secured UI chain leaves it: the context in the HttpSession.
+        OidcUser carol = new DefaultOidcUser(List.of(), OidcIdToken.withTokenValue("id-token")
+                .subject("sub-carol").claim("preferred_username", "carol")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(300)).build());
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+                new SecurityContextImpl(new OAuth2AuthenticationToken(carol, carol.getAuthorities(), "keycloak")));
+
+        mvc.perform(get("/api/me").session(session))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(ApiErrorResponder.TOKEN_REQUIRED));
+        mvc.perform(post("/api/me").session(session))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── fixture ─────────────────────────────────────────────────────────────
+
+    private static String jwt(RSAKey key, String preferredUsername) {
+        var claims = JwtClaimsSet.builder().subject("sub-x").issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300));
+        if (preferredUsername != null) {
+            claims.claim("preferred_username", preferredUsername);
+        }
+        var encoder = new NimbusJwtEncoder(new ImmutableJWKSet<>(new JWKSet(key)));
+        return encoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(SignatureAlgorithm.RS256).keyId(key.getKeyID()).build(), claims.build())).getTokenValue();
+    }
+
+    private static RSAKey rsaKey() {
+        try {
+            return new RSAKeyGenerator(2048).keyID(java.util.UUID.randomUUID().toString()).generate();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @RestController
+    static class Echo {
+        @GetMapping("/api/me")
+        String me(@CurrentUser UserId user) {
+            return user.value();
+        }
+
+        @PostMapping("/api/me")
+        String write(@CurrentUser UserId user) {
+            return user.value();
+        }
+    }
+
+    @Configuration
+    @EnableWebSecurity
+    @Import({Echo.class, CurrentUsers.class, CurrentUserWebConfig.class})
+    static class TestApp {
+
+        @Bean
+        ApiTokenService apiTokenService() {
+            return new ApiTokenService(new InMemoryApiTokenRepository());
+        }
+
+        @Bean
+        UserRecorder userRecorder() {
+            return new UserRecorder(new UserService(new InMemoryUserRepository()));
+        }
+
+        @Bean
+        CurrentUserResolver currentUserResolver() {
+            return new SecurityCurrentUserResolver();
+        }
+
+        @Bean
+        JwtDecoder jwtDecoder() throws Exception {
+            return NimbusJwtDecoder.withPublicKey(SIGNING_KEY.toRSAPublicKey()).build();
+        }
+
+        @Bean
+        ApiAuthentication apiAuthentication(ApiTokenService tokens, UserRecorder recorder, JwtDecoder decoder) {
+            return new ApiAuthentication(tokens, recorder, decoder);
+        }
+
+        @Bean
+        SecurityFilterChain api(HttpSecurity http, ApiAuthentication api) throws Exception {
+            api.apply(http.securityMatcher("/api/**")
+                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated()));
+            return http.build();
+        }
+    }
+}

--- a/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/BearerAuthenticationTest.java
+++ b/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/BearerAuthenticationTest.java
@@ -1,0 +1,154 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.adapter.memory.InMemoryApiTokenRepository;
+import ai.mindconnect.user.adapter.memory.InMemoryUserRepository;
+import ai.mindconnect.user.domain.User;
+import ai.mindconnect.user.port.out.UserRepository;
+import ai.mindconnect.user.service.ApiTokenService;
+import ai.mindconnect.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The two kinds of bearer token: ours is checked against the token store and
+ * never handed on; anything else goes to the JWT provider, where only a token
+ * naming a user becomes one. Both record who signed in.
+ */
+class BearerAuthenticationTest {
+
+    private final InMemoryUserRepository users = new InMemoryUserRepository();
+    private final ApiTokenService tokens = new ApiTokenService(new InMemoryApiTokenRepository());
+    private final UserRecorder recorder = new UserRecorder(new UserService(users));
+    private final ApiTokenAuthenticationProvider provider = new ApiTokenAuthenticationProvider(tokens, recorder);
+
+    @Test
+    void anIssuedTokenAuthenticatesItsOwnerAndRecordsTheSignIn() {
+        ApiTokenService.Issued issued = tokens.issue(UserId.of("alice"), "cli", null);
+
+        Authentication result = provider.authenticate(new BearerTokenAuthenticationToken(issued.secret()));
+
+        assertThat(result).isInstanceOfSatisfying(ApiTokenAuthentication.class, auth -> {
+            assertThat(auth.isAuthenticated()).isTrue();
+            assertThat(auth.getPrincipal()).isEqualTo(UserId.of("alice"));
+            assertThat(auth.tokenId()).isEqualTo(issued.token().id());
+            assertThat(auth.getCredentials()).isNull();
+        });
+        assertThat(users.findById(UserId.of("alice"))).isPresent();
+    }
+
+    @Test
+    void aRevokedOrUnknownTokenOfOurShapeIsRejectedHere() {
+        ApiTokenService.Issued issued = tokens.issue(UserId.of("alice"), "cli", null);
+        tokens.revoke(UserId.of("alice"), issued.token().id());
+
+        assertThatThrownBy(() -> provider.authenticate(new BearerTokenAuthenticationToken(issued.secret())))
+                .isInstanceOf(InvalidBearerTokenException.class);
+        assertThatThrownBy(() -> provider.authenticate(new BearerTokenAuthenticationToken("mct_forged")))
+                .isInstanceOf(InvalidBearerTokenException.class);
+    }
+
+    @Test
+    void aTokenOfAnotherShapeIsLeftToTheNextProvider() {
+        assertThat(provider.authenticate(new BearerTokenAuthenticationToken("eyJhbGciOiJSUzI1NiJ9.e30.sig"))).isNull();
+        assertThat(provider.supports(BearerTokenAuthenticationToken.class)).isTrue();
+    }
+
+    @Test
+    void aJwtBecomesTheUserItNamesAndIsRecordedWithItsDetails() {
+        Jwt jwt = Jwt.withTokenValue("t").header("alg", "RS256")
+                .subject("sub-1").issuer("https://auth.example.com/realms/mc")
+                .claim("preferred_username", "bob").claim("name", "Bob Builder").claim("email", "bob@example.com")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60))
+                .build();
+
+        var authentication = new JwtUserConverter(recorder).convert(jwt);
+
+        assertThat(authentication.getName()).isEqualTo("bob");
+        assertThat(users.findById(UserId.of("bob"))).get()
+                .extracting(User::subject, User::issuer, User::displayName, User::email)
+                .containsExactly("sub-1", "https://auth.example.com/realms/mc", "Bob Builder", "bob@example.com");
+    }
+
+    @Test
+    void aJwtWithoutTheUserClaimIsRejectedRatherThanMappedToAnotherIdentity() {
+        Jwt jwt = Jwt.withTokenValue("t").header("alg", "RS256").subject("sub-1")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60)).build();
+
+        assertThatThrownBy(() -> new JwtUserConverter(recorder).convert(jwt))
+                .isInstanceOf(InvalidBearerTokenException.class);
+        assertThat(users.findAll()).isEmpty();
+    }
+
+    @Test
+    void theRecorderCallsTheServiceOncePerResolutionAndSurvivesAFailingStore() {
+        var counting = new CountingUsers(new InMemoryUserRepository(), false);
+        var clock = Clock.fixed(Instant.parse("2026-09-11T12:00:00Z"), ZoneOffset.UTC);
+        var throttled = new UserRecorder(new UserService(counting, clock), clock);
+
+        throttled.record(UserId.of("alice"), null, null, "Alice", null);
+        throttled.record(UserId.of("alice"), null, null, "Alice Smith", null);
+        assertThat(counting.saves).isEqualTo(1);
+
+        var broken = new UserRecorder(new UserService(new CountingUsers(new InMemoryUserRepository(), true)));
+        broken.record(UserId.of("alice"), null, null, null, null);
+    }
+
+    @Test
+    void aRejectedApiTokenIsNeverHandedToTheJwtCheck() {
+        int[] decodes = {0};
+        JwtDecoder failing = token -> {
+            decodes[0]++;
+            throw new IllegalStateException("the JWT decoder must not see this token");
+        };
+        var api = new ApiAuthentication(tokens, recorder, failing);
+
+        assertThatThrownBy(() -> api.authenticationManager()
+                .authenticate(new BearerTokenAuthenticationToken("mct_forged")))
+                .isInstanceOf(InvalidBearerTokenException.class);
+        assertThat(decodes[0]).isZero();
+    }
+
+    @Test
+    void anUnreachableIssuerRejectsTheJwtInsteadOfFailingTheRequest() {
+        JwtDecoder decoder = ApiAuthentication.jwtDecoder("http://127.0.0.1:1/realms/nowhere", List.of());
+        var api = new ApiAuthentication(tokens, recorder, decoder);
+
+        assertThatThrownBy(() -> api.authenticationManager()
+                .authenticate(new BearerTokenAuthenticationToken("eyJhbGciOiJSUzI1NiJ9.e30.sig")))
+                .isInstanceOf(InvalidBearerTokenException.class);
+    }
+
+    /** Counts saves, or fails them. */
+    private static class CountingUsers implements UserRepository {
+        private final UserRepository delegate;
+        private final boolean failOnSave;
+        int saves;
+
+        CountingUsers(UserRepository delegate, boolean failOnSave) {
+            this.delegate = delegate;
+            this.failOnSave = failOnSave;
+        }
+
+        @Override public Optional<User> findById(UserId id) { return delegate.findById(id); }
+        @Override public List<User> findAll() { return delegate.findAll(); }
+        @Override public void save(User user) {
+            if (failOnSave) throw new IllegalStateException("disk full");
+            saves++;
+            delegate.save(user);
+        }
+    }
+}

--- a/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/DevUserFilterTest.java
+++ b/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/DevUserFilterTest.java
@@ -1,0 +1,32 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** With authentication off, every request is the dev user — as a login, so the rest of the app sees nothing special. */
+class DevUserFilterTest {
+
+    @AfterEach
+    void clear() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void aRequestRunsAsTheDevUser() throws Exception {
+        AtomicReference<Optional<UserId>> seen = new AtomicReference<>();
+
+        new DevUserFilter("dev").doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(),
+                (request, response) -> seen.set(new SecurityCurrentUserResolver().currentUser()));
+
+        assertThat(seen.get()).contains(UserId.of("dev"));
+    }
+}

--- a/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/SecurityCurrentUserResolverTest.java
+++ b/agents/server/mc-agent-security/src/test/java/ai/mindconnect/agent/security/SecurityCurrentUserResolverTest.java
@@ -1,0 +1,61 @@
+package ai.mindconnect.agent.security;
+
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.user.domain.ApiTokenId;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Every way a request can be authenticated maps to the same kind of caller — and nothing else maps to one. */
+class SecurityCurrentUserResolverTest {
+
+    @Test
+    void anApiTokenStandsForItsOwner() {
+        assertThat(SecurityCurrentUserResolver.userIdOf(new ApiTokenAuthentication(UserId.of("alice"), ApiTokenId.random())))
+                .contains(UserId.of("alice"));
+    }
+
+    @Test
+    void aJwtStandsForTheUserItNames() {
+        Jwt jwt = Jwt.withTokenValue("t").header("alg", "RS256").subject("sub-1")
+                .claim("preferred_username", "bob").issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60))
+                .build();
+        var authentication = new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList("ROLE_USER"), "bob");
+
+        assertThat(SecurityCurrentUserResolver.userIdOf(authentication)).contains(UserId.of("bob"));
+    }
+
+    @Test
+    void aBrowserLoginStandsForItsPreferredUsername() {
+        OidcIdToken idToken = OidcIdToken.withTokenValue("id").subject("sub-2")
+                .claim(StandardClaimNames.PREFERRED_USERNAME, "carol")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60)).build();
+        var user = new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), idToken);
+
+        assertThat(SecurityCurrentUserResolver.userIdOf(
+                UsernamePasswordAuthenticationToken.authenticated(user, null, user.getAuthorities())))
+                .contains(UserId.of("carol"));
+    }
+
+    @Test
+    void anonymousUnauthenticatedAndUnknownAuthenticationsStandForNobody() {
+        assertThat(SecurityCurrentUserResolver.userIdOf(null)).isEmpty();
+        assertThat(SecurityCurrentUserResolver.userIdOf(new AnonymousAuthenticationToken(
+                "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))).isEmpty();
+        assertThat(SecurityCurrentUserResolver.userIdOf(
+                UsernamePasswordAuthenticationToken.unauthenticated("mallory", "guess"))).isEmpty();
+        assertThat(SecurityCurrentUserResolver.userIdOf(
+                new TestingAuthenticationToken("mallory", null, "ROLE_USER"))).isEmpty();
+    }
+}

--- a/agents/springstarter/mc-agent-starter-file/pom.xml
+++ b/agents/springstarter/mc-agent-starter-file/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>mc-file-store</artifactId>
         </dependency>
         <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>

--- a/agents/springstarter/mc-agent-starter-file/src/main/java/ai/mindconnect/agent/starter/file/FilePersistenceAutoConfiguration.java
+++ b/agents/springstarter/mc-agent-starter-file/src/main/java/ai/mindconnect/agent/starter/file/FilePersistenceAutoConfiguration.java
@@ -7,6 +7,10 @@ import ai.mindconnect.filestore.FileStoreBackend;
 import ai.mindconnect.llm.adapter.file.EncryptingLlmConfigRepository;
 import ai.mindconnect.llm.adapter.file.FileLlmConfigRepository;
 import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import ai.mindconnect.user.adapter.file.FileApiTokenRepository;
+import ai.mindconnect.user.adapter.file.FileUserRepository;
+import ai.mindconnect.user.port.out.ApiTokenRepository;
+import ai.mindconnect.user.port.out.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -64,6 +68,20 @@ public class FilePersistenceAutoConfiguration {
             return files;
         }
         return new EncryptingLlmConfigRepository(files, helper);
+    }
+
+    /** The installation's users, under {@code <mindconnect.data.base-dir>/<namespace>/system/users}. */
+    @Bean
+    @ConditionalOnMissingBean(UserRepository.class)
+    UserRepository userRepository(@Value("${mindconnect.data.base-dir:data}") String baseDir, Namespace namespace) {
+        return new FileUserRepository(Path.of(baseDir), namespace);
+    }
+
+    /** Personal API tokens, stored as hashes under {@code <mindconnect.data.base-dir>/<namespace>/system/api-tokens}. */
+    @Bean
+    @ConditionalOnMissingBean(ApiTokenRepository.class)
+    ApiTokenRepository apiTokenRepository(@Value("${mindconnect.data.base-dir:data}") String baseDir, Namespace namespace) {
+        return new FileApiTokenRepository(Path.of(baseDir), namespace);
     }
 
     /** Uploads: the {@code filesystem} backend under {@code <mindconnect.data.base-dir>/<namespace>/files} unless configured otherwise. */

--- a/agents/springstarter/mc-agent-starter-postgres/pom.xml
+++ b/agents/springstarter/mc-agent-starter-postgres/pom.xml
@@ -48,6 +48,10 @@
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-file-store-pg</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-user-pg</artifactId>
+        </dependency>
         <!-- the SPI and the filesystem backend, for mindconnect.file-store.backend=filesystem under Postgres -->
         <dependency>
             <groupId>ai.mindconnect</groupId>

--- a/agents/springstarter/mc-agent-starter-postgres/src/main/java/ai/mindconnect/agent/starter/postgres/PostgresPersistenceConfig.java
+++ b/agents/springstarter/mc-agent-starter-postgres/src/main/java/ai/mindconnect/agent/starter/postgres/PostgresPersistenceConfig.java
@@ -178,4 +178,16 @@ public class PostgresPersistenceConfig {
         return new EncryptingLlmConfigRepository(
                 new PgLlmConfigRepository(mindconnectSql, namespace).initSchema(), encryptionHelper);
     }
+
+    // ── users ───────────────────────────────────────────────────────────────
+
+    @Bean
+    ai.mindconnect.user.port.out.UserRepository userRepository(Sql mindconnectSql, Namespace namespace) {
+        return new ai.mindconnect.user.adapter.pg.PgUserRepository(mindconnectSql, namespace).initSchema();
+    }
+
+    @Bean
+    ai.mindconnect.user.port.out.ApiTokenRepository apiTokenRepository(Sql mindconnectSql, Namespace namespace) {
+        return new ai.mindconnect.user.adapter.pg.PgApiTokenRepository(mindconnectSql, namespace).initSchema();
+    }
 }

--- a/agents/vectorstore/mc-file-store-core/src/main/java/ai/mindconnect/filestore/FileStore.java
+++ b/agents/vectorstore/mc-file-store-core/src/main/java/ai/mindconnect/filestore/FileStore.java
@@ -1,6 +1,8 @@
 package ai.mindconnect.filestore;
 
 
+import ai.mindconnect.agent.UserId;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -12,8 +14,18 @@ import java.util.Optional;
  */
 public interface FileStore {
 
-    /** Stores {@code content} under a fresh id and returns its metadata. */
-    StoredFile save(String name, String contentType, InputStream content) throws IOException;
+    /** Stores {@code content} under a fresh id, on nobody's behalf, and returns its metadata. */
+    default StoredFile save(String name, String contentType, InputStream content) throws IOException {
+        return save(name, contentType, content, null);
+    }
+
+    /**
+     * Stores {@code content} under a fresh id and returns its metadata.
+     *
+     * @param creator the user the file is stored for, recorded as its
+     *                {@link StoredFile#creator()}; {@code null} for nobody
+     */
+    StoredFile save(String name, String contentType, InputStream content, UserId creator) throws IOException;
 
     Optional<StoredFile> find(FileId id);
 

--- a/agents/vectorstore/mc-file-store-core/src/main/java/ai/mindconnect/filestore/StoredFile.java
+++ b/agents/vectorstore/mc-file-store-core/src/main/java/ai/mindconnect/filestore/StoredFile.java
@@ -1,5 +1,7 @@
 package ai.mindconnect.filestore;
 
+import ai.mindconnect.agent.UserId;
+
 import java.time.Instant;
 
 /**
@@ -7,18 +9,44 @@ import java.time.Instant;
  * equivalent of an OpenAI Files-API file object. Content is read through the
  * {@link FileStore}, never by path: chats and vector stores reference the id,
  * and only the backend knows where the bytes live (disk, object storage, db).
+ *
+ * @param creator the user the file was stored for; {@code null} for a file
+ *                stored on nobody's behalf — by an embedding library, or
+ *                before creators were recorded
  */
 public record StoredFile(
         FileId id,
         String name,
         String contentType,
         long size,
-        Instant createdAt
+        Instant createdAt,
+        UserId creator
 ) {
 
     public StoredFile {
         if (id == null) {
             throw new IllegalArgumentException("A stored file needs an id");
         }
+    }
+
+    /** A file without a creator. */
+    public StoredFile(FileId id, String name, String contentType, long size, Instant createdAt) {
+        this(id, name, contentType, size, createdAt, null);
+    }
+
+    /** Whether {@code user} is the recorded creator. A file without one belongs to nobody. */
+    public boolean createdBy(UserId user) {
+        return creator != null && creator.equals(user);
+    }
+
+    /**
+     * Whether {@code user} may read the file by its id: its creator may, and
+     * so may anyone for a file without a creator. Those were stored before
+     * creators were recorded and are still referenced by id from chats and
+     * transcripts; their random ids are what kept them private so far, and
+     * locking them away would break those references for their owners.
+     */
+    public boolean readableBy(UserId user) {
+        return creator == null || creator.equals(user);
     }
 }

--- a/agents/vectorstore/mc-file-store/src/main/java/ai/mindconnect/filestore/filesystem/FilesystemFileStore.java
+++ b/agents/vectorstore/mc-file-store/src/main/java/ai/mindconnect/filestore/filesystem/FilesystemFileStore.java
@@ -3,6 +3,7 @@ package ai.mindconnect.filestore.filesystem;
 import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.EntityId;
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.filestore.FileId;
 import ai.mindconnect.filestore.FileStore;
 import ai.mindconnect.filestore.StoredFile;
@@ -44,8 +45,9 @@ public final class FilesystemFileStore implements FileStore {
         this.root = baseDir.resolve(namespace.value()).resolve("files");
     }
 
+    /** The creator lands in {@code meta.json}; metadata written before creators existed loads without one. */
     @Override
-    public StoredFile save(String name, String contentType, InputStream content) throws IOException {
+    public StoredFile save(String name, String contentType, InputStream content, UserId creator) throws IOException {
         FileId id = FileId.of("file-" + EntityId.randomValue().replace("-", "").substring(0, 20));
         String safeName = Path.of(name == null || name.isBlank() ? "upload.bin" : name)
                 .getFileName().toString().replaceAll("[^A-Za-z0-9._ -]", "_");
@@ -53,7 +55,7 @@ public final class FilesystemFileStore implements FileStore {
         Files.createDirectories(dir);
         Path target = dir.resolve(safeName);
         long size = Files.copy(content, target, StandardCopyOption.REPLACE_EXISTING);
-        StoredFile file = new StoredFile(id, safeName, contentType, size, Instant.now());
+        StoredFile file = new StoredFile(id, safeName, contentType, size, Instant.now(), creator);
         // The metadata is what makes the upload exist for readers; it lands whole or not at all.
         AtomicFiles.write(dir.resolve("meta.json"), out -> MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, file));
         return file;

--- a/agents/vectorstore/mc-file-store/src/test/java/ai/mindconnect/filestore/FilesystemFileStoreTest.java
+++ b/agents/vectorstore/mc-file-store/src/test/java/ai/mindconnect/filestore/FilesystemFileStoreTest.java
@@ -1,11 +1,13 @@
 package ai.mindconnect.filestore;
 
 
+import ai.mindconnect.agent.UserId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -61,5 +63,42 @@ class FilesystemFileStoreTest {
         assertThat(other.find(saved.id())).isEmpty();
         assertThat(other.list()).isEmpty();
         assertThat(store.list()).containsExactly(saved);
+    }
+
+    @Test
+    void theCreatorIsRecordedAndReadBack() throws Exception {
+        StoredFile alices = store().save("a.txt", "text/plain",
+                new ByteArrayInputStream("a".getBytes(StandardCharsets.UTF_8)), UserId.of("alice"));
+        StoredFile nobodys = store().save("b.txt", "text/plain",
+                new ByteArrayInputStream("b".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(alices.creator()).isEqualTo(UserId.of("alice"));
+        // A fresh store instance reads the metadata from disk.
+        assertThat(store().find(alices.id())).contains(alices);
+        assertThat(store().find(nobodys.id())).get().extracting(StoredFile::creator).isNull();
+        assertThat(store().list()).containsExactlyInAnyOrder(alices, nobodys);
+    }
+
+    @Test
+    void metadataWrittenBeforeCreatorsLoadsWithoutOne() throws Exception {
+        Path fileDir = dir.resolve("test").resolve("files").resolve("file-0123456789abcdef0123");
+        Files.createDirectories(fileDir);
+        Files.writeString(fileDir.resolve("old.txt"), "old");
+        Files.writeString(fileDir.resolve("meta.json"), """
+                {
+                  "id" : "file-0123456789abcdef0123",
+                  "name" : "old.txt",
+                  "contentType" : "text/plain",
+                  "size" : 3,
+                  "createdAt" : "2026-01-01T10:00:00Z"
+                }
+                """);
+
+        StoredFile old = store().find(FileId.of("file-0123456789abcdef0123")).orElseThrow();
+
+        assertThat(old.creator()).isNull();
+        assertThat(old.name()).isEqualTo("old.txt");
+        assertThat(store().list()).containsExactly(old);
+        assertThat(store().content(old.id()).readAllBytes()).asString(StandardCharsets.UTF_8).isEqualTo("old");
     }
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -74,6 +74,17 @@ curl -so /dev/null -w '%{http_code}\n' \
   "https://<AUTH_DOMAIN>/realms/mindconnect/protocol/openid-connect/logout?client_id=mc-admin-ui&post_logout_redirect_uri=https%3A%2F%2F<ADMIN_DOMAIN>%2F"
 ```
 
+### Calling the API
+
+With the `keycloak` profile, `/api/**` and `/v1/**` need a bearer token. Users
+create personal API tokens on their profile page — the avatar in the header;
+an access token of the realm works as well and is checked against the same
+`KC_ISSUER_URI` the login uses, so there is nothing more to configure:
+
+```bash
+curl -H "Authorization: Bearer mct_…" https://<ADMIN_DOMAIN>/api/agents
+```
+
 ## Deploying a new version
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,9 @@
         <module>agents/adapter/postgres/mc-message-repository-pg</module>
         <module>agents/adapter/postgres/mc-agent-runtime-pg</module>
         <module>agents/adapter/postgres/mc-file-store-pg</module>
+        <module>agents/core/mc-user-core</module>
+        <module>agents/core/mc-user</module>
+        <module>agents/adapter/postgres/mc-user-pg</module>
         <module>agents/springstarter/mc-agent-starter-file</module>
         <module>agents/springstarter/mc-agent-starter-postgres</module>
         <module>agents/core/mc-credentials</module>
@@ -121,6 +124,7 @@
         <module>agents/mcp/mc-agent-tools-mcp</module>
         <module>agents/mcp/mc-mcp-gateway-admin-ui-rest</module>
         <module>agents/server/mc-agent-api-rest</module>
+        <module>agents/server/mc-agent-security</module>
         <module>agents/server/mc-agent-api-app</module>
         <module>agents/server/mc-agent-chat-ui-rest</module>
         <module>agents/server/mc-agent-admin-ui-rest</module>

--- a/website/docs/agents/authentication.md
+++ b/website/docs/agents/authentication.md
@@ -87,9 +87,15 @@ the user's workspace files, uploaded files, transcriptions, and the responses
 of the Responses API. Somebody else's id is answered exactly like an id that
 does not exist — `404` — so an id seen in a URL or a log opens nothing.
 
-The configuration of the installation — agents, LLM configs, vector stores,
-workflows, MCP servers — is open to every authenticated user. Roles are not
-part of this yet.
+The configuration of the installation — agents, LLM configs, knowledge-base
+vector stores, workflows, MCP servers — is open to every authenticated user.
+Roles are not part of this yet.
+
+A chat's upload store (`session-…`) is not configuration: it holds what one
+user attached to one chat. The vector-store API and the Admin UI's vector-store
+pages neither list it for anyone else nor let them search, fill or delete it,
+and no store can be created under such a name. Ingesting a stored file into
+any store takes only a file the caller may read.
 
 ## The CLI
 

--- a/website/docs/agents/authentication.md
+++ b/website/docs/agents/authentication.md
@@ -1,0 +1,101 @@
+---
+title: Authentication
+sidebar_position: 9
+---
+
+# Authentication
+
+Who may call an installation, and as whom. Both apps — the Admin UI
+(`mc-agent-admin-ui-app`, which also serves the REST API and the OpenAI
+Responses API) and the agent server (`mc-agent-api-app`) — know the same two
+modes.
+
+| Mode | Switched on by | Every request runs as |
+|---|---|---|
+| **Off** (default) | — | the dev user, `MC_DEV_USER` (default `mc_user`) |
+| **On** | Admin UI: the `keycloak` Spring profile · agent server: `MC_AUTH_ENABLED=true` | the authenticated user; without authentication, nothing is answered |
+
+The user id is the identity provider's `preferred_username` — for a browser
+login, a JWT and an API token alike, so a user's sessions are the same whichever
+way they come in.
+
+## Browser login
+
+The Admin UI signs users in with Keycloak (OIDC, authorization code). The
+tokens stay on the server; the browser holds an `HttpOnly` session cookie, and
+writing requests carry the `X-XSRF-TOKEN` header the UI sends on its own. See
+[Deploying](https://github.com/mindconnect-ai/mindconnect/tree/main/deploy) for
+setting up the realm.
+
+## Programs: a bearer token
+
+`/api/**` and `/v1/**` take a bearer token and nothing else. The Admin UI's
+browser session does not count there, so they ask for no CSRF token either:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" https://app.example.com/api/agents
+```
+
+Without a token, or with one that is not accepted, the answer is `401` with
+`WWW-Authenticate: Bearer` and a JSON body saying why:
+
+```json
+{"status":401,"error":"Unauthorized","message":"Invalid, expired or revoked API token"}
+```
+
+Swagger UI in the Admin UI's API section calls the API the same way: enter a
+token under **Authorize**, and *Try it out* sends it.
+
+Two kinds of token are accepted.
+
+### Personal API tokens
+
+Created by the user themself: click the avatar in the header → **API tokens** →
+**New token**, give it a name and a lifetime (30 days, 90 days, a year, or no
+expiry). The secret (`mct_…`) is shown **once**, in the dialog that follows;
+the installation keeps only its SHA-256 hash and the first characters, so a
+lost token cannot be displayed again — create a new one. A token acts with its
+owner's rights and nobody else's; **Revoke** ends it at once.
+
+Tokens are stored with the rest of the installation's data
+(`<data>/<namespace>/system/api-tokens/` or the `mc_api_token` table), so an
+agent server sharing the Admin UI's data directory or database — and namespace —
+accepts the tokens created there.
+
+### JWTs of the identity provider
+
+An access token of the configured realm works too, as long as it carries a
+`preferred_username` claim. The signature is checked against the realm's
+published keys, as are the issuer and the lifetime; the realm's metadata is
+fetched with the first token, so the app starts while Keycloak is still coming
+up.
+
+| Setting | Variable | Default |
+|---|---|---|
+| `mindconnect.auth.jwt.issuer-uri` | `KC_ISSUER_URI` | Admin UI: the login realm · agent server: _(none — JWTs rejected, API tokens still work)_ |
+| `mindconnect.auth.jwt.audiences` | `MC_JWT_AUDIENCES` | _(empty — any audience)_ |
+
+Keycloak puts `account` into `aud` by default. To accept only tokens meant for
+this installation, add an audience mapper to the client that issues them and
+list that audience in `MC_JWT_AUDIENCES`.
+
+## What a caller can reach
+
+Everything that belongs to a user answers only to that user: sessions and all
+that hangs off them (chat, stream, history, memory, approvals, attached files),
+the user's workspace files, uploaded files, transcriptions, and the responses
+of the Responses API. Somebody else's id is answered exactly like an id that
+does not exist — `404` — so an id seen in a URL or a log opens nothing.
+
+The configuration of the installation — agents, LLM configs, vector stores,
+workflows, MCP servers — is open to every authenticated user. Roles are not
+part of this yet.
+
+## The CLI
+
+The CLI's remote mode authenticates with an API token:
+
+```bash
+MC_REMOTE_TOKEN=mct_… mvn -f agents/client/mc-agent-cli/pom.xml spring-boot:run \
+  -Dspring-boot.run.arguments=--mindconnect.remote.url=https://app.example.com
+```

--- a/website/docs/agents/cli.md
+++ b/website/docs/agents/cli.md
@@ -48,6 +48,12 @@ mindconnect:
     url: http://localhost:8080
 ```
 
+A server with authentication switched on also needs a token: set
+`mindconnect.remote.token` (or the environment variable `MC_REMOTE_TOKEN`) and
+the CLI sends it as `Authorization: Bearer <token>` with every request. The
+server works out the user from that token; `mindconnect.user.id` only names
+the owner of local-mode data.
+
 ## Using the CLI
 
 Once you're in a session, just type a message and press Enter to send it to the

--- a/website/docs/agents/environment-variables.md
+++ b/website/docs/agents/environment-variables.md
@@ -42,6 +42,7 @@ as an env var in `SCREAMING_SNAKE` form (e.g. `MINDCONNECT_DATA_BASE_DIR`).
 | `mindconnect.tools.base-dir` | user home | Working/base directory for `bash` and the file tools — security-relevant. |
 | `mindconnect.user.id` | app-specific | The user id that owns sessions and data (the CLI ships a hard-coded default). |
 | `mindconnect.remote.url` | _(unset)_ | Points the CLI at a remote agent server instead of local mode. |
+| `mindconnect.remote.token` | _(unset)_ | Bearer token the CLI sends to a remote agent server that requires authentication; also read from `MC_REMOTE_TOKEN`. |
 | `mindconnect.code-exec.*` | — | Sandbox limits for `code_execute`: `runtime`, `network`, `languages`, `memory`, `cpus`, `timeout-seconds`, `idle-seconds`. |
 | `mindconnect.vector-store.*` | — | Vector-store backend: `backend`, `url`, `user`, `password`, `embedding-config` (default `embeddings`). The `memory` backend keeps its files in `<data.base-dir>/<namespace>/vector-stores`. |
 | `mindconnect.file-store.*` | — | File-store backend: `backend`. The `filesystem` backend keeps uploads in `<data.base-dir>/<namespace>/files`. |
@@ -79,11 +80,14 @@ key — they talk to LM Studio at `http://localhost:1234`.
 
 ## Authentication (Admin UI / Keycloak)
 
+See [Authentication](./authentication.md) for what the modes mean.
+
 | Variable | Default | Notes |
 |----------|---------|-------|
-| `MC_AUTH_ENABLED` | `false` | `false` (default) runs the Admin UI without Keycloak. Keycloak login is enabled via the **`keycloak` Spring profile** (which sets this itself) — setting the variable alone is not enough. |
+| `MC_AUTH_ENABLED` | `false` | `false` (default) runs the Admin UI without Keycloak. Keycloak login is enabled via the **`keycloak` Spring profile** (which sets this itself) — setting the variable alone is not enough. The agent server (`mc-agent-api-app`) has no login and is switched on by this variable alone: every request then needs a bearer token. |
 | `MC_DEV_USER` | `mc_user` | Auto-login username used when auth is disabled |
-| `KC_ISSUER_URI` | `http://localhost:8180/realms/mindconnect` | Keycloak realm issuer (only with the `keycloak` profile) |
+| `KC_ISSUER_URI` | `http://localhost:8180/realms/mindconnect` | Keycloak realm issuer — the browser login (only with the `keycloak` profile) and the issuer bearer JWTs on `/api/**` and `/v1/**` are checked against. Agent server: no default; without it only API tokens are accepted. |
+| `MC_JWT_AUDIENCES` | _(empty)_ | Comma-separated; when set, a bearer JWT must carry one of these audiences |
 | `KC_CLIENT_ID` | `mc-admin-ui` | OIDC client id |
 | `KC_CLIENT_SECRET` | _(empty)_ | OIDC client secret, if your client is confidential |
 

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -17,6 +17,20 @@ Interactive documentation ships with the server: **http://localhost:8080/swagger
 generated from the same annotations the endpoints carry. The pages below cover
 the parts that need more explanation than a signature.
 
+## Authentication
+
+With authentication off (the default) every request runs as the dev user. With
+it on, every request needs a bearer token — a personal API token created on the
+profile page of the Admin UI, or an access token of the Keycloak realm:
+
+```bash
+curl -H "Authorization: Bearer mct_…" http://localhost:8080/api/agents
+```
+
+The caller is always the authenticated user; no endpoint takes a user id from
+the request. In Swagger UI, **Authorize** takes the token. See
+[Authentication](./authentication.md).
+
 ## Agents and sessions
 
 | | |
@@ -28,14 +42,22 @@ the parts that need more explanation than a signature.
 | `PUT /api/agents/{id}/tools` | replace the tool list |
 | `POST /api/agents/{id}/copy` | duplicate as `{name}-copy` |
 | `DELETE /api/agents/{id}` | delete |
-| `POST /api/sessions` | start a session — body `{agentId, userId}` |
-| `GET /api/sessions?agentId=&userId=` | a user's sessions for one agent |
+| `POST /api/sessions` | start a session for the caller — body `{agentId}` |
+| `GET /api/sessions?agentId=` | the caller's sessions for one agent |
 | `GET /api/sessions/{id}/history` | the persisted messages |
 | `DELETE /api/sessions/{id}` | delete the session |
 
 A server runs in one namespace, set with `mindconnect.namespace` (default
 `local`, `MC_NAMESPACE`); no endpoint names one. Ids travel as their plain
 value, in paths and in JSON.
+
+Every user-scoped resource — a session and everything under
+`/api/sessions/{id}`, an uploaded file, a workspace, the user stream, a
+transcription job — belongs to the authenticated caller, and a request for
+someone else's answers 404, exactly like one for an id that does not exist.
+No request names its user: a `userId` an older client still sends is ignored.
+Agents, LLM configs, vector stores and workflows are shared configuration,
+open to every authenticated caller.
 
 ## OpenAI Responses API
 
@@ -69,6 +91,11 @@ changes nothing for anyone else. A name that is neither is refused rather
 than quietly answered by something else. The client's **conversation** is a
 session, so `previous_response_id` continues the session that response was
 made in.
+
+Responses, conversations and files belong to the authenticated caller, as on
+`/api`: someone else's response or file answers `404` with
+`{"error": {"type": "not_found", …}}`, and a `previous_response_id` or
+`conversation` that is not the caller's is treated like an unknown one.
 
 Not supported: client-side function tools — this runtime executes tools
 inside the turn instead of handing them back to the caller — skills, and
@@ -172,10 +199,11 @@ someone that an agent is waiting for them — needs the opposite: little about
 every session, without attaching to any of them. That is the user stream:
 
 ```bash
-curl -N "http://localhost:8080/api/users/$USER/stream?afterSeq=0"
+curl -N "http://localhost:8080/api/users/me/stream?afterSeq=0"
 ```
 
-The first frame is the `attached` frame with the buffer bounds
+The path names the caller: `me`, or the caller's own user id. Any other user
+answers 404. The first frame is the `attached` frame with the buffer bounds
 (`firstBufferedSeq`, `latestSeq`); then the buffered events after `afterSeq`
 replay and the stream continues live. Every frame is one JSON object with a
 `seq` and a `type`, and the `sessionId` it is about:
@@ -312,9 +340,9 @@ for you — a transcript is worth little without the audio behind it, and only
 the caller knows when that stops being true. The job's `fileId` and `fileUrl`
 come back with the submit answer and with every poll.
 
-A job that a request submitted under a login is readable only by that user;
-on an installation without login, by anyone who reaches the endpoint, like
-the rest of this API.
+A job is readable only by the user who submitted it, and the recording is that
+user's file. A job from before requesters were recorded stays readable by
+anyone who has its id.
 
 ## Beyond chat
 
@@ -326,3 +354,11 @@ CRUD shapes and are best read in the Swagger UI. One shape worth knowing:
 ingested file produced, 0 for an image, which goes to the model with the
 next message instead. `DELETE …/files?file=` takes the file's name or its
 ingested id.
+
+A file in the store is its uploader's (`creator` in the file object).
+`GET /api/files` lists the caller's own files; by id, a file answers its
+uploader only, and only the uploader deletes it. Files uploaded before
+uploaders were recorded have no `creator`: they stay readable by id — chats
+and transcripts still point at them — but are not listed and cannot be
+deleted through the API. Attaching a file by id, to a chat message or a
+session, works only for a file the caller may read.

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -56,8 +56,9 @@ Every user-scoped resource — a session and everything under
 transcription job — belongs to the authenticated caller, and a request for
 someone else's answers 404, exactly like one for an id that does not exist.
 No request names its user: a `userId` an older client still sends is ignored.
-Agents, LLM configs, vector stores and workflows are shared configuration,
-open to every authenticated caller.
+Agents, LLM configs, knowledge-base vector stores and workflows are shared
+configuration, open to every authenticated caller; a chat's upload store
+(`session-…`) answers only to the chat's user.
 
 ## OpenAI Responses API
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -25,6 +25,7 @@ const sidebars = {
         },
         'agents/cli',
         'agents/rest-api',
+        'agents/authentication',
         'agents/llm-gateway',
         {
           type: 'category',


### PR DESCRIPTION
## What

The REST API (`/api/**`) and the OpenAI Responses API (`/v1/**`) now take **bearer tokens only** once authentication is on:

- an **access token of the Keycloak realm** — signature, issuer and lifetime checked against `KC_ISSUER_URI`, optionally an audience from `MC_JWT_AUDIENCES`; the realm metadata is fetched lazily, so the app starts while Keycloak is still coming up;
- a **personal API token** (`mct_…`) that a user creates on the new **profile page** behind the header avatar — shown once (with a copy button), stored as a SHA-256 hash, with expiry, *last used* and revoke.

The browser session does not count on the API, so the API needs no CSRF token. A rejected request gets `401` with `WWW-Authenticate: Bearer` and a JSON body saying why (`{"status":401,"error":"Unauthorized","message":"…"}`).

Everything a user owns answers only that user: sessions and what hangs off them, workspace files, uploaded files, transcriptions, responses — and a chat's upload store (`session-…`) in the vector stores. The REST layer takes the caller from the authentication, never from the request (`userId` in a body is ignored), and another user's ids answer `404`. Knowledge-base vector stores, agents, LLM configs and workflows stay shared configuration.

## Why

Before, the API only answered to a browser session with a CSRF token — no program could call it on a secured installation — and the agent server (`mc-agent-api-app`) had no authentication at all.

## How

- **New modules**
  - `mc-user-core` — `User`, `ApiToken`, ports, `UserService`, `ApiTokenService`
  - `mc-user` — file and in-memory adapters (`<data>/<ns>/system/users|api-tokens/`)
  - `mc-user-pg` — `mc_user`, `mc_api_token`
  - `mc-agent-security` — `ApiAuthentication` (routes a token by its shape to the API-token or the JWT check, so a rejected API token never reaches the identity provider), `ApiErrorResponder`, caller resolver, dev-user filter, auto-configuration, OpenAPI bearer scheme (Swagger UI **Authorize**)
- **Admin UI app** — a separate bearer-only filter chain for `/api/**` and `/v1/**`; the UI chain (session + CSRF) is unchanged. The vector-store file download moves to `/admin/vector-stores/files/{id}/content`.
- **Agent server** — `MC_AUTH_ENABLED=true` secures it the same way; off, every request runs as `MC_DEV_USER`.
- **Ownership** — `@CurrentUser` in the REST controllers; `StoredFile` records its creator (file store, `mc_file.creator` added by `ADD COLUMN IF NOT EXISTS`); files stored before stay readable by id.
- **Vector stores** — `VectorStoreAccess`: a store registered with scope `SESSION`, or named `session-<id>`, answers only to the owner of that session. `/api/vector-stores` lists only reachable stores and answers `404` for a foreign chat store on get, search, chunks, ingest and delete; no store can be created under a `session-` name (`400`). `ingestStoredFile` reads the file as the caller. The admin UI's vector-store pages apply the same rule; their files tab lists what the caller may read, and only the uploader deletes a file.
- **CLI** — remote mode sends `MC_REMOTE_TOKEN`.
- **Docs** — new `website/docs/agents/authentication.md`, REST API, environment variables, CLI, deploy README; manual test `agents/doc/manual-tests/api/api-tokens.md`.

## Testing

- Unit / slice tests: user modules, `mc-agent-security` (filter chain with API tokens, JWTs, a browser session that must not count, unreachable issuer, JSON errors), ownership tests for the REST controllers and the runtime backend, vector stores (`VectorStoreApiControllerOwnershipTest`, `VectorStoreServiceIngestTest`), profile page, file download.
- Verified live against a local Keycloak (admin UI with the `keycloak` profile, agent server with auth on):
  - no token / forged token / bad JWT → `401` with JSON; a real API token → `200`, writes without CSRF, a session created with `userId: bob` in the body belongs to the caller; no `Set-Cookie` on API responses; browser navigation still redirects to the login page;
  - a real chat upload store is listed, readable and searchable for its user; another user's chat store answers `404` on get, search, chunks and delete; an unknown `session-…` name `404`; creating a `session-…` store `400`.
- Not yet run:
  - the manual test `api-tokens.md` end to end with two Keycloak users (`last-verified: never`);
  - ingesting another user's file, live (no such file in the local data — covered by `VectorStoreServiceIngestTest`);
  - the admin UI's vector-store pages and Swagger **Authorize** in a signed-in browser.

## Upgrade notes

- Programs that called `/api/**` or `/v1/**` with a browser session cookie now need a token.
- The admin UI's vector-store pages no longer show another user's chat upload stores or files, and a file without a creator can no longer be deleted there either.
- Deploying needs no configuration change: the admin UI checks JWTs against the realm it already logs in with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
