### PR TITLE
Reach a chat's upload store only on its user's behalf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ fresh empty one, so nothing has to be moved by hand at release time.
   a different description for this installation, without touching any agent
   definition. What an agent definition says about a tool still wins for that
   agent. Stored in `<data>/<namespace>/system/tool-settings.json`.
+- **workflow:** run attributes. `WorkflowContext` carries values the host
+  hands one run (`getAttribute` / `setAttribute`), passed in with
+  `WorkflowExecutorService.executeWorkflow(workflow, params, attributes)` or
+  `WorkflowRunService.runWithAttributes(...)`. Every step of the run sees them,
+  parallel for-each blocks and called workflows included; a resumed run starts
+  without them.
+- **agents:** `ToolCallScope.rootSessionId`, the chat at the top of a sub-agent
+  chain, and `ToolInvoker.call(tool, arguments, scope)`, which the tool-call
+  workflow step now calls with the scope found on its run.
 
 ### Removed
 
@@ -60,6 +69,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
   and `vector_delete_file` tools refuse the upload store of any other chat
   session, so the model cannot be talked into reading another user's
   attachments by naming their store.
+- **agents:** a chat's upload store now belongs to the chat's user, and only
+  calls made for that user reach it. The check above applied inside a chat
+  only: a workflow started from the workflow admin or
+  `/api/workflows/{id}/run` resolved its tool steps for nobody in particular
+  and could read or fill any chat's uploads, and so could a chat model that
+  ran such a workflow as a tool; `vector_ingest_file` did not check at all. A
+  workflow run as an agent tool now runs its tool steps for the calling user
+  and session, the upload pipeline ingests on behalf of the chat's user, and a
+  run for nobody reaches no chat's store. A sub-agent's `vector_search`
+  without a store searches the uploads of the chat that started it. Upload
+  stores from before this change record their owner the next time their chat
+  uploads a file; until then only that chat reaches them.
 
 - **agents:** coming back to the chat no longer lands in a different
   conversation. The chat opened whichever conversation had been started

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,10 @@ fresh empty one, so nothing has to be moved by hand at release time.
   ran such a workflow as a tool; `vector_ingest_file` did not check at all. A
   workflow run as an agent tool now runs its tool steps for the calling user
   and session, the upload pipeline ingests on behalf of the chat's user, and a
-  run for nobody reaches no chat's store. A sub-agent's `vector_search`
+  run outside any chat reaches no chat's store, whatever user it runs as. A sub-agent's `vector_search`
   without a store searches the uploads of the chat that started it. Upload
   stores from before this change record their owner the next time their chat
-  uploads a file; until then only that chat reaches them.
+  writes to them; until then only that chat reaches them.
 
 - **agents:** coming back to the chat no longer lands in a different
   conversation. The chat opened whichever conversation had been started

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
@@ -170,15 +170,19 @@ final class AttachSupport {
                 stores.registry().saveTemplate(created);
                 return created;
             });
+            var chat = sessions.findById(sessionId).orElseThrow(() ->
+                    new IllegalArgumentException("unknown session " + sessionId.value()));
+            // The store is the chat's user's: the vector tools reach it only on that user's behalf.
             var store = stores.open(storeName, template.name(),
                     ai.mindconnect.vectorstore.tools.VectorStoreInstance.Scope.SESSION,
-                    sessionId.value());
+                    sessionId.value(), chat.userId() == null ? null : chat.userId().value());
             var instance = stores.settingsFor(storeName);
 
             String message;
             if (instance.ingestionWorkflow() != null && !instance.ingestionWorkflow().isBlank()
                     && workflowModulesPresent()) {
-                message = WorkflowIngestion.run(environment, stores, instance, stored, fileStore, workflows, namespace.value());
+                message = WorkflowIngestion.run(environment, stores, instance, stored, fileStore, workflows, namespace.value(),
+                        new ai.mindconnect.agent.tool.ToolCallScope(chat.userId(), sessionId, null));
             } else {
                 String text = new String(fileStore.content(stored.id()).readAllBytes(),
                         java.nio.charset.StandardCharsets.UTF_8);
@@ -214,7 +218,8 @@ final class AttachSupport {
                           ai.mindconnect.filestore.StoredFile stored,
                           ai.mindconnect.filestore.FileStore fileStore,
                           ai.mindconnect.workflow.persistence.port.WorkflowDataRepository hostWorkflows,
-                          String partition) throws Exception {
+                          String partition,
+                          ai.mindconnect.agent.tool.ToolCallScope scope) throws Exception {
             java.nio.file.Path base = java.nio.file.Path.of(
                     environment.getOrDefault("defaultBaseDir", System.getProperty("user.home")));
             java.nio.file.Path dir = base.resolve("vector-store-uploads").resolve(instance.name());
@@ -230,9 +235,11 @@ final class AttachSupport {
             var workflow = workflows.findById(instance.ingestionWorkflow()).orElseThrow(() ->
                     new IllegalStateException("Ingestion workflow '" + instance.ingestionWorkflow()
                             + "' not found in the workflow store"));
+            // The tool steps run on behalf of the chat's user and session — the calls its store accepts.
             var report = new ai.mindconnect.workflow.admin.run.WorkflowRunService(null)
-                    .run(workflow, Map.of("file", base.relativize(target).toString(),
-                            "store", instance.name()));
+                    .runWithAttributes(workflow, Map.of("file", base.relativize(target).toString(),
+                            "store", instance.name()),
+                            Map.of(ai.mindconnect.agent.tool.ToolCallScope.class.getName(), scope));
             if (!report.success()) {
                 throw new IllegalStateException("ingestion workflow failed: " + report.error());
             }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/AgentTurnWorker.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/AgentTurnWorker.java
@@ -250,7 +250,9 @@ public final class AgentTurnWorker implements TaskWorker {
         ConversationMessageLog messageLog = new ConversationMessageLog(
                 conversationManager, history, session.userId().value(), def.id(), turnId, run, tokenCounter);
 
-        SessionTools tools = new SessionTools(toolRegistry, dynamicToolActivations, def, session);
+        // A sub-agent's tools see the chat that started the chain: the user's uploads are there.
+        SessionTools tools = new SessionTools(toolRegistry, dynamicToolActivations, def, session,
+                session.parentSessionId() == null ? session.id() : sessionService.rootSession(session.id()).id());
         QueuedAgentRoundToolExecutor executor = new QueuedAgentRoundToolExecutor(
                 ctx, conversationManager, sessionService, def, session, turnId, run, conversationId, depth);
 

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/SessionTools.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/SessionTools.java
@@ -29,13 +29,25 @@ public final class SessionTools implements ToolDefinitionProvider {
     private final DynamicToolActivations dynamicToolActivations;
     private final AgentDefinition def;
     private final AgentSession session;
+    private final SessionId rootSessionId;
 
+    /** The toolset of a session that is its own root — a chat, not a sub-agent. */
     public SessionTools(ToolRegistry toolRegistry, DynamicToolActivations dynamicToolActivations,
                         AgentDefinition def, AgentSession session) {
+        this(toolRegistry, dynamicToolActivations, def, session, session.id());
+    }
+
+    /**
+     * @param rootSessionId the chat at the top of the session's sub-agent chain,
+     *                      handed to the tools as {@link ToolCallScope#rootSessionId()}
+     */
+    public SessionTools(ToolRegistry toolRegistry, DynamicToolActivations dynamicToolActivations,
+                        AgentDefinition def, AgentSession session, SessionId rootSessionId) {
         this.toolRegistry = toolRegistry;
         this.dynamicToolActivations = dynamicToolActivations;
         this.def = def;
         this.session = session;
+        this.rootSessionId = rootSessionId != null ? rootSessionId : session.id();
     }
 
     /**
@@ -73,9 +85,9 @@ public final class SessionTools implements ToolDefinitionProvider {
     }
 
     /** Whether {@code toolName} is one of the inline delegation tools this agent enables. */
-    /** Who is calling, for the factories and advisors: this session, its user, this agent. */
+    /** Who is calling, for the factories and advisors: this session, its user, this agent, its chat. */
     private ToolCallScope scope() {
-        return new ToolCallScope(session.userId(), session.id(), def.id());
+        return new ToolCallScope(session.userId(), session.id(), def.id(), rootSessionId);
     }
 
     public boolean isInline(String toolName) {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/ToolCallWorker.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/task/ToolCallWorker.java
@@ -333,7 +333,9 @@ public final class ToolCallWorker implements TaskWorker {
     private String runRegistryTool(AgentSession session, AgentDefinition def,
                                    TokenCounter tokenCounter, Consumer<StreamEvent> stream,
                                    String callId, String toolName, Map<String, Object> arguments) {
-        SessionTools tools = new SessionTools(toolRegistry, dynamicToolActivations, def, session);
+        // A sub-agent's tools see the chat that started the chain: the user's uploads are there.
+        SessionTools tools = new SessionTools(toolRegistry, dynamicToolActivations, def, session,
+                session.parentSessionId() == null ? session.id() : sessionService.rootSession(session.id()).id());
         ToolExecutor.Context toolContext = new ToolExecutor.Context(
                 stream, session.conversationId(), def.id(), tokenCounter,
                 session.userId(), session.id());

--- a/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/ToolCallScope.java
+++ b/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/ToolCallScope.java
@@ -12,15 +12,24 @@ import ai.mindconnect.agent.UserId;
  * <p>Session and agent are optional — a tool resolved for the catalog or a
  * test bench has neither.
  *
- * @param userId    who is chatting; may be null for the installation's own runs
- * @param sessionId the session; null when a tool is resolved outside one
- * @param agentId   the agent whose binding is resolved; null under the same conditions
+ * @param userId        who is chatting; may be null for the installation's own runs
+ * @param sessionId     the session; null when a tool is resolved outside one
+ * @param agentId       the agent whose binding is resolved; null under the same conditions
+ * @param rootSessionId the chat at the top of the session's sub-agent chain — the one the
+ *                      user sees and attaches files to; the session itself when it is no
+ *                      sub-agent's, null without a session
  */
 public record ToolCallScope(
         UserId userId,
         SessionId sessionId,
-        AgentId agentId
+        AgentId agentId,
+        SessionId rootSessionId
 ) {
+
+    /** A scope whose session is its own root: a top-level chat, or no session at all. */
+    public ToolCallScope(UserId userId, SessionId sessionId, AgentId agentId) {
+        this(userId, sessionId, agentId, sessionId);
+    }
 
     /** A scope with no session and no agent — resolving a tool to look at it, not to run it. */
     public static ToolCallScope detached(UserId userId) {

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/McAgentWorkflowStepsAutoConfiguration.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/McAgentWorkflowStepsAutoConfiguration.java
@@ -121,9 +121,17 @@ public class McAgentWorkflowStepsAutoConfiguration {
         ToolInvoker invoker = new ToolInvoker() {
             @Override
             public String call(String toolName, java.util.Map<String, Object> arguments) {
+                return call(toolName, arguments, null);
+            }
+
+            @Override
+            public String call(String toolName, java.util.Map<String, Object> arguments,
+                               ToolCallScope scope) {
+                // A run started for nobody in particular — the workflow admin, the
+                // REST API — acts as the workflow user, who owns no chat.
                 Tool tool = toolRegistry
                         .resolve(AgentTool.of(toolName),
-                                ToolCallScope.detached(UserId.of(WORKFLOW_USER)))
+                                scope != null ? scope : ToolCallScope.detached(UserId.of(WORKFLOW_USER)))
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "No tool named '" + toolName + "' is resolvable"
                                 + " (known: " + toolRegistry.knownToolNames() + ")"));

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/WorkflowTool.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/WorkflowTool.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.agent.tools.workflow;
 
 import ai.mindconnect.agent.tool.Tool;
+import ai.mindconnect.agent.tool.ToolCallScope;
 import ai.mindconnect.schema.Schema;
 import ai.mindconnect.schema.SchemaValidator;
 import ai.mindconnect.workflow.domain.HaltData;
@@ -25,6 +26,10 @@ import java.util.Optional;
  * embedded engine — the definition is re-read from the repository per call, so admin-UI
  * edits apply to the very next invocation.
  *
+ * <p>The run acts for the caller: the {@link ToolCallScope} this tool was created with goes
+ * onto the run, so its tool-call steps resolve their tools for the same user, session and
+ * agent a direct call would have.
+ *
  * <p>Outcomes map to LLM-readable text: the workflow result on success, a descriptive error
  * on failure, and for a halt (human-in-the-loop suspension) a message naming the inputs the
  * halt is waiting for — resuming from an agent is not supported yet.
@@ -37,12 +42,15 @@ final class WorkflowTool implements Tool {
     private final String workflowId;
     private final Schema params;
     private final String description;
+    private final ToolCallScope scope;
 
-    WorkflowTool(WorkflowDataRepository repository, String workflowId, WorkflowData snapshot) {
+    WorkflowTool(WorkflowDataRepository repository, String workflowId, WorkflowData snapshot,
+                 ToolCallScope scope) {
         this.repository = repository;
         this.workflowId = workflowId;
         this.params = snapshot.getParams() != null ? snapshot.getParams() : Schema.object();
         this.description = buildDescription(workflowId, snapshot);
+        this.scope = scope;
     }
 
     @Override
@@ -78,7 +86,8 @@ final class WorkflowTool implements Tool {
 
         try {
             WorkflowResult result = new WorkflowExecutorService(SpiWorkflowContextFactory.create())
-                    .executeWorkflow(wf, args);
+                    .executeWorkflow(wf, args,
+                            scope == null ? Map.of() : Map.of(ToolCallScope.class.getName(), scope));
             if (result.isError()) {
                 Throwable error = result.getError();
                 String message = error != null && error.getMessage() != null

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/WorkflowToolProvider.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/WorkflowToolProvider.java
@@ -105,8 +105,9 @@ public final class WorkflowToolProvider implements MultiToolProvider {
             return Optional.empty();
         }
         String workflowId = toolName.substring(TOOL_NAME_PREFIX.length());
-        // scope may carry null userId/sessionId (the tool catalog resolves with nulls) — unused here.
+        // The run acts for this scope: its tool steps resolve their tools with it.
+        // The tool catalog probes with null userId/sessionId, which a run tolerates.
         return repository.findById(workflowId)
-                .map(wf -> new WorkflowTool(repository, workflowId, wf));
+                .map(wf -> new WorkflowTool(repository, workflowId, wf, scope));
     }
 }

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/step/ToolCallStep.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/step/ToolCallStep.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.tools.workflow.step;
 
+import ai.mindconnect.agent.tool.ToolCallScope;
 import ai.mindconnect.workflow.execution.BaseStepInstance;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +27,11 @@ public class ToolCallStep extends BaseStepInstance<ToolCallData> {
         Map<String, Object> arguments = parseArguments(cfg);
 
         logDebug("calling tool '%s'", cfg.getTool());
-        String result = ToolInvokers.require().call(cfg.getTool().trim(), arguments);
+        // On whose behalf: the host puts the caller's scope on the run (an agent
+        // tool, a chat upload); a run started for nobody in particular has none.
+        ToolCallScope scope = getWorkflowContext() == null ? null
+                : getWorkflowContext().getAttribute(ToolCallScope.class);
+        String result = ToolInvokers.require().call(cfg.getTool().trim(), arguments, scope);
         // Tools report failure as text by convention ("Error: …"). A failed
         // tool must FAIL the step — a workflow that reports success while its
         // tool errored is a silent lie (ingestion once "succeeded" with zero

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/step/ToolInvoker.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/step/ToolInvoker.java
@@ -1,5 +1,7 @@
 package ai.mindconnect.agent.tools.workflow.step;
 
+import ai.mindconnect.agent.tool.ToolCallScope;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -17,6 +19,18 @@ public interface ToolInvoker {
      * @throws RuntimeException when the tool doesn't exist or cannot be resolved
      */
     String call(String toolName, Map<String, Object> arguments);
+
+    /**
+     * Resolves and executes the tool on behalf of {@code scope} — the user,
+     * session and agent the workflow runs for, as the host put it on the run
+     * ({@link ai.mindconnect.workflow.execution.WorkflowContext#getAttribute(Class)}).
+     * {@code null} when the run was started for nobody in particular. A host
+     * whose tools depend on the caller overrides this; the default ignores the
+     * scope.
+     */
+    default String call(String toolName, Map<String, Object> arguments, ToolCallScope scope) {
+        return call(toolName, arguments);
+    }
 
     /** The registry's current tool names — used by editors for a picker. */
     default Set<String> knownToolNames() {

--- a/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/WorkflowToolProviderTest.java
+++ b/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/WorkflowToolProviderTest.java
@@ -1,6 +1,11 @@
 package ai.mindconnect.agent.tools.workflow;
 
 import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.tools.workflow.step.ToolCallData;
+import ai.mindconnect.agent.tools.workflow.step.ToolInvoker;
+import ai.mindconnect.agent.tools.workflow.step.ToolInvokers;
 import ai.mindconnect.agent.tool.AgentTool;
 import ai.mindconnect.agent.tool.Tool;
 import ai.mindconnect.agent.tool.ToolCallScope;
@@ -16,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -81,6 +88,48 @@ class WorkflowToolProviderTest {
                 AgentTool.of(name), new ToolCallScope(null, null, null));
         assertThat(tool).isPresent();
         return tool.get();
+    }
+
+    /**
+     * A workflow run as an agent tool acts for its caller: the scope the tool
+     * was created with reaches the workflow's tool steps — not a detached one.
+     */
+    @Test
+    void toolStepsRunOnBehalfOfTheCaller() {
+        ToolCallData probe = new ToolCallData();
+        probe.setName("probe");
+        probe.setTool("probe_tool");
+        probe.setArguments("{}");
+        probe.setAssignResultToVar("out");
+        WorkflowData wf = new WorkflowData();
+        wf.setName("probing");
+        wf.setResultFrom("out");
+        wf.addSteps(probe);
+        repository.save("probing", wf);
+
+        List<ToolCallScope> scopes = new ArrayList<>();
+        ToolInvokers.set(new ToolInvoker() {
+            @Override
+            public String call(String tool, Map<String, Object> args) {
+                return call(tool, args, null);
+            }
+
+            @Override
+            public String call(String tool, Map<String, Object> args, ToolCallScope scope) {
+                scopes.add(scope);
+                return "probed";
+            }
+        });
+        try {
+            ToolCallScope alice = new ToolCallScope(UserId.of("alice"), SessionId.random(), null);
+            Tool tool = provider.create("workflow_probing", AgentTool.of("workflow_probing"), alice)
+                    .orElseThrow();
+
+            assertThat(tool.execute(Map.of())).isEqualTo("probed");
+            assertThat(scopes).containsExactly(alice);
+        } finally {
+            ToolInvokers.clear();
+        }
     }
 
     @Test

--- a/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/step/ToolCallStepTest.java
+++ b/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/step/ToolCallStepTest.java
@@ -1,5 +1,8 @@
 package ai.mindconnect.agent.tools.workflow.step;
 
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.tool.ToolCallScope;
 import ai.mindconnect.workflow.domain.WorkflowData;
 import ai.mindconnect.workflow.execution.WorkflowExecutorService;
 import ai.mindconnect.workflow.execution.WorkflowResult;
@@ -143,6 +146,35 @@ class ToolCallStepTest {
 
         assertThat(result.isSuccess()).as(String.valueOf(result.getError())).isTrue();
         assertThat(result.getResult()).isEqualTo("Error: inspect me downstream");
+    }
+
+    /**
+     * On whose behalf a tool runs is the host's to say: the scope it puts on
+     * the run reaches the invoker, and a run without one hands over none.
+     */
+    @Test
+    void theScopeOnTheRunReachesTheInvoker() {
+        List<ToolCallScope> scopes = new ArrayList<>();
+        ToolInvokers.set(new ToolInvoker() {
+            @Override
+            public String call(String tool, Map<String, Object> args) {
+                return call(tool, args, null);
+            }
+
+            @Override
+            public String call(String tool, Map<String, Object> args, ToolCallScope scope) {
+                scopes.add(scope);
+                return "ok";
+            }
+        });
+        ToolCallScope alice = new ToolCallScope(UserId.of("alice"), SessionId.random(), null);
+        WorkflowExecutorService service = new WorkflowExecutorService(SpiWorkflowContextFactory.create());
+
+        assertThat(service.executeWorkflow(workflow("{}"), Map.of("topic", "unused"),
+                Map.of(ToolCallScope.class.getName(), alice)).isSuccess()).isTrue();
+        assertThat(service.executeWorkflow(workflow("{}"), Map.of("topic", "unused")).isSuccess()).isTrue();
+
+        assertThat(scopes).containsExactly(alice, null);
     }
 
     @Test

--- a/agents/doc/manual-tests/chat/session-isolation.md
+++ b/agents/doc/manual-tests/chat/session-isolation.md
@@ -66,6 +66,8 @@ c() { printf '%-16s %s\n' "$1" "$(curl -s -o /dev/null -m 5 -w '%{http_code}' "$
 
 ## Not covered here
 
-The `vector_search` / `vector_upsert` / `vector_delete_file` guard against a
-foreign `store: session-<id>` is a tool-level rule and is pinned by
-`VectorToolsTest.sessionUploadStoresAreNotReachableFromOtherSessions`.
+The rule that a chat's upload store (`session-<id>`) is reachable by the
+`vector_*` tools only for the chat's user is a tool-level rule and is pinned by
+`VectorToolsTest.aChatsUploadStoreIsReachableOnlyForItsUser`; that a workflow
+run as an agent tool passes the caller's scope to its tool steps by
+`WorkflowToolProviderTest.toolStepsRunOnBehalfOfTheCaller`.

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
@@ -27,6 +27,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Map;
 import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.tool.ToolCallScope;
 
 /**
  * Attaches a stored file to a chat session — the one code path shared by the
@@ -164,6 +165,10 @@ public class SessionFileService {
             return new AttachResult(stored, null, false,
                     stored.name() + ": vector stores are not configured in this application.");
         }
+        AgentSession chat = sessions.findById(sessionId).orElse(null);
+        if (chat == null) {
+            return new AttachResult(stored, null, false, stored.name() + ": unknown session " + sessionId);
+        }
         String storeName = "session-" + sessionId.value();
         VectorStoreTemplate template = stores.template(CHAT_UPLOADS_TEMPLATE).orElseGet(() -> {
             VectorStoreTemplate created = new VectorStoreTemplate(CHAT_UPLOADS_TEMPLATE,
@@ -172,7 +177,9 @@ public class SessionFileService {
             stores.registry().saveTemplate(created);
             return created;
         });
-        stores.open(storeName, template.name(), VectorStoreInstance.Scope.SESSION, sessionId.value());
+        // The store is the chat's user's: the vector tools reach it only on that user's behalf.
+        stores.open(storeName, template.name(), VectorStoreInstance.Scope.SESSION, sessionId.value(),
+                chat.userId() == null ? null : chat.userId().value());
         VectorStoreInstance instance = stores.settingsFor(storeName);
 
         try {
@@ -200,9 +207,13 @@ public class SessionFileService {
                 var workflow = workflows.findById(instance.ingestionWorkflow()).orElseThrow(() ->
                         new IllegalStateException("Ingestion workflow '" + instance.ingestionWorkflow()
                                 + "' not found"));
+                // The workflow's tool steps run on behalf of this chat's user and
+                // session — the calls its upload store accepts.
                 var report = new WorkflowRunService(workflowInstances)
-                        .run(workflow, Map.of("file", spoolBase.relativize(target).toString(),
-                                "store", storeName));
+                        .runWithAttributes(workflow, Map.of("file", spoolBase.relativize(target).toString(),
+                                "store", storeName),
+                                Map.of(ToolCallScope.class.getName(),
+                                        new ToolCallScope(chat.userId(), sessionId, null)));
                 if (!report.success()) {
                     return new AttachResult(stored, storeName, false,
                             stored.name() + ": ingestion failed — " + report.error());

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorIngestFileTool.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorIngestFileTool.java
@@ -18,17 +18,21 @@ import java.util.Map;
  * Reads the file relative to the tools base directory, extracts text (via the
  * document reader when {@code mc-agent-tools-document} is on the classpath —
  * docx/pdf/markdown — else plain UTF-8), chunks OpenAI-style (800/400) and
- * embeds into the store, replacing previous chunks of the same path.
+ * embeds into the store, replacing previous chunks of the same path. A chat's
+ * upload store follows the same rule as for the other knowledge tools
+ * ({@link VectorTools#refusedStore}).
  */
 public final class VectorIngestFileTool implements Tool {
 
     private final VectorStores stores;
     private final String baseDir;
+    private final ToolCallScope callScope;
 
-    VectorIngestFileTool(VectorStores stores, String baseDir) {
+    VectorIngestFileTool(VectorStores stores, String baseDir, ToolCallScope callScope) {
         this.stores = stores;
         this.baseDir = baseDir == null || baseDir.isBlank()
                 ? System.getProperty("user.home") : baseDir;
+        this.callScope = callScope;
     }
 
     @Override
@@ -63,6 +67,10 @@ public final class VectorIngestFileTool implements Tool {
         String storeName = arguments.get("store") instanceof String s && !s.isBlank() ? s : null;
         if (relative == null || storeName == null) {
             return "Error: 'path' and 'store' are required.";
+        }
+        String denied = VectorTools.refusedStore(stores, storeName, callScope);
+        if (denied != null) {
+            return denied;
         }
         Path base = Path.of(baseDir).toAbsolutePath().normalize();
         Path file = base.resolve(relative).normalize();
@@ -123,7 +131,7 @@ public final class VectorIngestFileTool implements Tool {
         }
 
         @Override public Tool create(AgentTool agentTool, ToolCallScope scope) {
-            return new VectorIngestFileTool(stores, baseDir);
+            return new VectorIngestFileTool(stores, baseDir, scope);
         }
     }
 }

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorIngestFileTool.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorIngestFileTool.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.vectorstore.tools;
 
+import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.tool.AgentTool;
 import ai.mindconnect.agent.tool.Tool;
 import ai.mindconnect.agent.tool.ToolCallScope;
@@ -83,7 +84,12 @@ public final class VectorIngestFileTool implements Tool {
         try {
             String text = extractText(base, file);
             String template = arguments.get("template") instanceof String t && !t.isBlank() ? t : null;
-            var store = stores.open(storeName, template, VectorStoreInstance.Scope.GLOBAL, null);
+            // The chat's own upload store is registered as the chat's, owned by its user.
+            SessionId ownChat = VectorTools.ownChatStore(storeName, callScope);
+            var store = ownChat == null
+                    ? stores.open(storeName, template, VectorStoreInstance.Scope.GLOBAL, null)
+                    : stores.open(storeName, template, VectorStoreInstance.Scope.SESSION, ownChat.value(),
+                            callScope.userId() == null ? null : callScope.userId().value());
             return DirectIngestion.ingest(stores, store, storeName, relative, text);
         } catch (Exception e) {
             return "Error: vector_ingest_file failed for '" + relative + "': " + e.getMessage();

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStoreInstance.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStoreInstance.java
@@ -13,6 +13,10 @@ import java.util.Map;
  * <p>{@code scope} ties the store to a lifecycle and visibility: a chat
  * session's upload store ({@code SESSION} + session id), an agent's knowledge
  * base ({@code AGENT} + agent name), or a {@code GLOBAL} store.
+ *
+ * <p>{@code owner} is the user a store's content belongs to — for a chat's
+ * upload store, the user of that chat. Null for shared stores, and for stores
+ * registered before owners were recorded.
  */
 public record VectorStoreInstance(
         String name,
@@ -24,6 +28,7 @@ public record VectorStoreInstance(
         Map<String, String> metadata,
         Scope scope,
         String scopeRef,
+        String owner,
         Instant createdAt
 ) {
     public enum Scope { GLOBAL, AGENT, SESSION }
@@ -37,8 +42,20 @@ public record VectorStoreInstance(
     /** Creation: copy the template's settings onto the new instance. */
     public static VectorStoreInstance fromTemplate(String name, VectorStoreTemplate template,
                                                    Scope scope, String scopeRef) {
+        return fromTemplate(name, template, scope, scopeRef, null);
+    }
+
+    /** Creation of a store that belongs to {@code owner} (a user id). */
+    public static VectorStoreInstance fromTemplate(String name, VectorStoreTemplate template,
+                                                   Scope scope, String scopeRef, String owner) {
         return new VectorStoreInstance(name, template.name(), template.backend(),
                 template.backendConfig(), template.embeddingConfig(), template.ingestionWorkflow(),
-                template.metadata(), scope, scopeRef, Instant.now());
+                template.metadata(), scope, scopeRef, owner, Instant.now());
+    }
+
+    /** This instance, recorded as belonging to {@code owner}. */
+    public VectorStoreInstance withOwner(String owner) {
+        return new VectorStoreInstance(name, templateName, backend, backendConfig, embeddingConfig,
+                ingestionWorkflow, metadata, scope, scopeRef, owner, createdAt);
     }
 }

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStoreInstance.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStoreInstance.java
@@ -53,9 +53,12 @@ public record VectorStoreInstance(
                 template.metadata(), scope, scopeRef, owner, Instant.now());
     }
 
-    /** This instance, recorded as belonging to {@code owner}. */
-    public VectorStoreInstance withOwner(String owner) {
+    /**
+     * This instance as the upload store of chat {@code scopeRef}, belonging to
+     * {@code owner}; its backend settings stay as they were.
+     */
+    public VectorStoreInstance asChatStore(String scopeRef, String owner) {
         return new VectorStoreInstance(name, templateName, backend, backendConfig, embeddingConfig,
-                ingestionWorkflow, metadata, scope, scopeRef, owner, createdAt);
+                ingestionWorkflow, metadata, Scope.SESSION, scopeRef, owner, createdAt);
     }
 }

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStores.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStores.java
@@ -138,9 +138,9 @@ public final class VectorStores {
 
     /**
      * Like {@link #open(String, String, VectorStoreInstance.Scope, String)}, for
-     * a store that belongs to {@code owner} (a user id). A session store
-     * registered before owners were recorded gets its owner filled in when it
-     * is opened again for its own session.
+     * a store that belongs to {@code owner} (a user id). Opened as a chat's
+     * store ({@code SESSION} scope), an existing instance without an owner is
+     * claimed for that chat — see {@link #claimsChatStore}.
      */
     public VectorStore open(String storeName, String templateName,
                             VectorStoreInstance.Scope scope, String scopeRef, String owner) {
@@ -150,13 +150,29 @@ public final class VectorStores {
                     new IllegalArgumentException("Unknown vector store template '" + templateName + "'"));
             instance = registry.registerInstance(
                     VectorStoreInstance.fromTemplate(storeName, template, scope, scopeRef, owner));
-        } else if (owner != null && instance.owner() == null
-                && instance.scope() == VectorStoreInstance.Scope.SESSION
-                && scopeRef != null && scopeRef.equals(instance.scopeRef())) {
-            instance = instance.withOwner(owner);
+        } else if (claimsChatStore(instance, storeName, scope, scopeRef, owner)) {
+            instance = instance.asChatStore(scopeRef, owner);
             registry.saveInstance(instance);
         }
         return openWith(instance);
+    }
+
+    /**
+     * Whether opening a store for its own chat records the chat and its user on
+     * an instance that lacks an owner: one registered before owners were
+     * recorded, or one registered under the chat's {@code session-} name with
+     * another scope (a tool wrote into it before any upload). An instance that
+     * has an owner, or that belongs to another session, is left alone.
+     */
+    private static boolean claimsChatStore(VectorStoreInstance instance, String storeName,
+                                           VectorStoreInstance.Scope scope, String scopeRef, String owner) {
+        if (owner == null || scopeRef == null || scope != VectorStoreInstance.Scope.SESSION
+                || instance.owner() != null) {
+            return false;
+        }
+        return instance.scope() == VectorStoreInstance.Scope.SESSION
+                ? scopeRef.equals(instance.scopeRef())
+                : storeName.equals(VectorTools.SESSION_STORE_PREFIX + scopeRef);
     }
 
     /** Opens by the instance's own settings (no registration side effects). */

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStores.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStores.java
@@ -133,12 +133,28 @@ public final class VectorStores {
      */
     public VectorStore open(String storeName, String templateName,
                             VectorStoreInstance.Scope scope, String scopeRef) {
+        return open(storeName, templateName, scope, scopeRef, null);
+    }
+
+    /**
+     * Like {@link #open(String, String, VectorStoreInstance.Scope, String)}, for
+     * a store that belongs to {@code owner} (a user id). A session store
+     * registered before owners were recorded gets its owner filled in when it
+     * is opened again for its own session.
+     */
+    public VectorStore open(String storeName, String templateName,
+                            VectorStoreInstance.Scope scope, String scopeRef, String owner) {
         VectorStoreInstance instance = registry.instance(storeName).orElse(null);
         if (instance == null) {
             VectorStoreTemplate template = template(templateName).orElseThrow(() ->
                     new IllegalArgumentException("Unknown vector store template '" + templateName + "'"));
             instance = registry.registerInstance(
-                    VectorStoreInstance.fromTemplate(storeName, template, scope, scopeRef));
+                    VectorStoreInstance.fromTemplate(storeName, template, scope, scopeRef, owner));
+        } else if (owner != null && instance.owner() == null
+                && instance.scope() == VectorStoreInstance.Scope.SESSION
+                && scopeRef != null && scopeRef.equals(instance.scopeRef())) {
+            instance = instance.withOwner(owner);
+            registry.saveInstance(instance);
         }
         return openWith(instance);
     }

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorTools.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorTools.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.vectorstore.tools;
 
 import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
 import ai.mindconnect.agent.tool.AgentTool;
 import ai.mindconnect.agent.tool.Tool;
 import ai.mindconnect.agent.tool.ToolCallScope;
@@ -28,6 +29,9 @@ import java.util.Map;
  * </ul>
  */
 public final class VectorTools {
+
+    /** The name prefix of a chat's upload store: {@code session-<sessionId>}. */
+    static final String SESSION_STORE_PREFIX = "session-";
 
     private VectorTools() {}
 
@@ -101,7 +105,7 @@ public final class VectorTools {
                     || !(arguments.get("chunks") instanceof List<?> rawChunks) || rawChunks.isEmpty()) {
                 return "Error: 'store', 'file_id' and a non-empty 'chunks' array are required.";
             }
-            String denied = foreignSessionStore(stores, storeName, callScope);
+            String denied = refusedStore(stores, storeName, callScope);
             if (denied != null) {
                 return denied;
             }
@@ -139,7 +143,11 @@ public final class VectorTools {
                             ? callScope.agentId().value() : null;
                     case GLOBAL -> null;
                 };
-                VectorStore store = stores.open(storeName, str(arguments, "template"), scope, scopeRef);
+                // A session-scoped store is the chat's user's, like an upload store.
+                String owner = scope == VectorStoreInstance.Scope.SESSION
+                        && callScope != null && callScope.userId() != null
+                        ? callScope.userId().value() : null;
+                VectorStore store = stores.open(storeName, str(arguments, "template"), scope, scopeRef, owner);
                 store.deleteFile(fileId);   // replace semantics
                 store.upsert(chunks);
                 return "Stored " + chunks.size() + " chunk(s) for file '" + fileId + "' in store '"
@@ -151,11 +159,6 @@ public final class VectorTools {
     }
 
     record SearchTool(VectorStores stores, ToolCallScope callScope) implements Tool {
-
-        /** The chat session's upload store — where attached files land. */
-        static String sessionStoreName(SessionId sessionId) {
-            return "session-" + sessionId.value();
-        }
 
         @Override public String name() { return "vector_search"; }
 
@@ -185,12 +188,15 @@ public final class VectorTools {
                 return "Error: 'query' is required.";
             }
             if (storeName == null) {
-                if (callScope == null || callScope.sessionId() == null) {
+                // The chat's store, not the session's own: a sub-agent's session
+                // has no uploads — the files were attached to the chat above it.
+                SessionId chat = chatSession(callScope);
+                if (chat == null) {
                     return "Error: no 'store' given and no chat session to default to.";
                 }
-                storeName = sessionStoreName(callScope.sessionId());
+                storeName = sessionStoreName(chat);
             }
-            String denied = foreignSessionStore(stores, storeName, callScope);
+            String denied = refusedStore(stores, storeName, callScope);
             if (denied != null) {
                 return denied;
             }
@@ -243,7 +249,7 @@ public final class VectorTools {
             if (storeName == null || fileId == null) {
                 return "Error: 'store' and 'file_id' are required.";
             }
-            String denied = foreignSessionStore(stores, storeName, callScope);
+            String denied = refusedStore(stores, storeName, callScope);
             if (denied != null) {
                 return denied;
             }
@@ -258,39 +264,75 @@ public final class VectorTools {
 
     // ── helpers ────────────────────────────────────────────────────────────
 
+    /** The upload store of a chat session — where attached files land. */
+    static String sessionStoreName(SessionId sessionId) {
+        return SESSION_STORE_PREFIX + sessionId.value();
+    }
+
+    /** The chat a call belongs to: the top of its sub-agent chain, where the user's uploads are. */
+    static SessionId chatSession(ToolCallScope scope) {
+        if (scope == null) {
+            return null;
+        }
+        return scope.rootSessionId() != null ? scope.rootSessionId() : scope.sessionId();
+    }
+
     /**
-     * A chat session's upload store holds what one user attached to one chat,
-     * and the model running in that chat is the user's proxy — so from inside
-     * a session a tool may only touch that session's own store. Everything
-     * else it names is a knowledge base (global or an agent's) and stays open.
-     * Two things mark a store as another session's: a registered
-     * {@code SESSION} scope naming a different session, and the
-     * {@code session-} name the upload pipeline uses — the name matters for
-     * stores that do not exist yet, or the model could create
-     * {@code session-<other>} itself and read what lands there later.
+     * A chat's upload store holds what one user attached to one chat, so it is
+     * that user's: a tool reaches it only when it runs for that user — in the
+     * chat itself, in another chat of theirs, in a sub-agent the chat started,
+     * or in a workflow run on their behalf. Everything else a tool names is a
+     * knowledge base (global or an agent's) and stays open.
      *
-     * <p>A call without a session is the installation's own run and is not
-     * restricted here: the ingestion workflow that fills an upload store
-     * resolves its tools detached from any session.
+     * <p>A store is a chat's when it is registered with the {@code SESSION}
+     * scope, or when its name has the {@code session-} form the upload
+     * pipeline uses. Its user is the owner recorded when the store was
+     * registered. Without an owner — a {@code session-} store nobody registered
+     * yet, or one from before owners were recorded — only its own chat reaches
+     * it; otherwise the model could create {@code session-<other>} itself and
+     * read what lands there later.
+     *
+     * <p>A call made for nobody in particular — a workflow started from the
+     * workflow admin or the REST API runs as the {@code workflow} user — owns
+     * no chat and reaches none. The upload pipeline runs its ingestion on
+     * behalf of the chat's user.
      *
      * @return the tool's error text, or {@code null} when access is fine
      */
-    static String foreignSessionStore(VectorStores stores, String storeName, ToolCallScope callScope) {
-        if (callScope == null || callScope.sessionId() == null) {
+    static String refusedStore(VectorStores stores, String storeName, ToolCallScope callScope) {
+        VectorStoreInstance registered = stores.registry().instance(storeName).orElse(null);
+        boolean chatStore = storeName.startsWith(SESSION_STORE_PREFIX)
+                || (registered != null && registered.scope() == VectorStoreInstance.Scope.SESSION);
+        if (!chatStore) {
             return null;
         }
-        SessionId own = callScope.sessionId();
-        if (storeName.equals(SearchTool.sessionStoreName(own))) {
-            return null;
+        if (registered != null && registered.owner() != null) {
+            UserId user = callScope == null ? null : callScope.userId();
+            return user != null && registered.owner().equals(user.value()) ? null : refusal(storeName);
         }
-        VectorStoreInstance settings = stores.settingsFor(storeName);
-        boolean anotherSessionsScope = settings.scope() == VectorStoreInstance.Scope.SESSION
-                && !own.value().equals(settings.scopeRef());
-        if (anotherSessionsScope || storeName.startsWith("session-")) {
-            return "Error: store '" + storeName + "' belongs to another chat session and is not "
-                    + "accessible from this one. Omit 'store' to search the files attached to this chat.";
+        return ownChat(storeName, registered, callScope) ? null : refusal(storeName);
+    }
+
+    /** Whether the call runs in the chat the store is named or registered for, or in a sub-agent of it. */
+    private static boolean ownChat(String storeName, VectorStoreInstance registered, ToolCallScope scope) {
+        if (scope == null) {
+            return false;
         }
-        return null;
+        for (SessionId session : new SessionId[]{scope.sessionId(), scope.rootSessionId()}) {
+            if (session == null) {
+                continue;
+            }
+            if (storeName.equals(sessionStoreName(session))
+                    || (registered != null && session.value().equals(registered.scopeRef()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String refusal(String storeName) {
+        return "Error: store '" + storeName + "' holds another chat's uploads and is not accessible "
+                + "here. Omit 'store' to search the files attached to this chat.";
     }
 
     private static Map<String, Object> schema(Map<String, Object> properties, List<String> required) {

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorTools.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorTools.java
@@ -143,6 +143,13 @@ public final class VectorTools {
                             ? callScope.agentId().value() : null;
                     case GLOBAL -> null;
                 };
+                // The chat's own upload store is registered as the chat's whatever
+                // scope was asked for — otherwise its owner is never recorded.
+                SessionId ownChat = ownChatStore(storeName, callScope);
+                if (ownChat != null) {
+                    scope = VectorStoreInstance.Scope.SESSION;
+                    scopeRef = ownChat.value();
+                }
                 // A session-scoped store is the chat's user's, like an upload store.
                 String owner = scope == VectorStoreInstance.Scope.SESSION
                         && callScope != null && callScope.userId() != null
@@ -292,10 +299,11 @@ public final class VectorTools {
      * it; otherwise the model could create {@code session-<other>} itself and
      * read what lands there later.
      *
-     * <p>A call made for nobody in particular — a workflow started from the
-     * workflow admin or the REST API runs as the {@code workflow} user — owns
-     * no chat and reaches none. The upload pipeline runs its ingestion on
-     * behalf of the chat's user.
+     * <p>Only a call made in a chat acts for a user. A call outside any chat —
+     * a workflow started from the workflow admin or the REST API — reaches no
+     * chat's store, whatever user id it carries: such runs resolve their tools
+     * as a fixed {@code workflow} user, and a real account may have that name.
+     * The upload pipeline runs its ingestion with the chat's scope.
      *
      * @return the tool's error text, or {@code null} when access is fine
      */
@@ -307,10 +315,23 @@ public final class VectorTools {
             return null;
         }
         if (registered != null && registered.owner() != null) {
-            UserId user = callScope == null ? null : callScope.userId();
+            UserId user = callScope == null || callScope.sessionId() == null ? null : callScope.userId();
             return user != null && registered.owner().equals(user.value()) ? null : refusal(storeName);
         }
         return ownChat(storeName, registered, callScope) ? null : refusal(storeName);
+    }
+
+    /** The chat whose own upload store {@code storeName} is — the call's session or its root — or null. */
+    static SessionId ownChatStore(String storeName, ToolCallScope scope) {
+        if (scope == null) {
+            return null;
+        }
+        for (SessionId session : new SessionId[]{scope.sessionId(), scope.rootSessionId()}) {
+            if (session != null && storeName.equals(sessionStoreName(session))) {
+                return session;
+            }
+        }
+        return null;
     }
 
     /** Whether the call runs in the chat the store is named or registered for, or in a sub-agent of it. */

--- a/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/VectorToolsTest.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/VectorToolsTest.java
@@ -180,6 +180,10 @@ class VectorToolsTest {
         assertThat(tool(new VectorTools.UpsertFactory(), ToolCallScope.detached(UserId.of("workflow")))
                 .execute(chunk(bobsStore, "x", "planted")))
                 .startsWith("Error:").contains("another chat's uploads");
+        // Not even when it carries the owner's user id: only a call in a chat acts for a user.
+        assertThat(tool(new VectorTools.SearchFactory(), ToolCallScope.detached(UserId.of("bob")))
+                .execute(Map.of("store", bobsStore, "query", "finance")))
+                .startsWith("Error:").contains("another chat's uploads");
 
         // Alice, from her own chat: search, upsert and delete are refused ...
         ToolCallScope alice = chat("alice", SessionId.random());
@@ -218,8 +222,8 @@ class VectorToolsTest {
 
     /**
      * An upload store registered before owners were recorded is reachable
-     * from its own chat only — until the upload pipeline opens it for that chat
-     * again and records the chat's user.
+     * from its own chat only — until its chat writes to it again, through the
+     * upload pipeline or a tool, and the chat's user is recorded as its owner.
      */
     @Test
     void anUploadStoreWithoutOwnerIsReachableFromItsOwnChatUntilItGetsOne() {
@@ -227,21 +231,61 @@ class VectorToolsTest {
         String oldStore = "session-" + oldChat.value();
         stores().open(oldStore, null, VectorStoreInstance.Scope.SESSION, oldChat.value());
 
-        assertThat(tool(new VectorTools.UpsertFactory(), chat("carol", oldChat))
-                .execute(chunk(oldStore, "notes", "container notes")))
-                .contains("Stored 1 chunk(s)");
         assertThat(tool(new VectorTools.SearchFactory(), chat("carol", oldChat))
                 .execute(Map.of("query", "container")))
-                .contains("container notes");
+                .contains("No results");
         assertThat(tool(new VectorTools.SearchFactory(), chat("carol", SessionId.random()))
                 .execute(Map.of("store", oldStore, "query", "container")))
                 .startsWith("Error:");
 
-        stores().open(oldStore, null, VectorStoreInstance.Scope.SESSION, oldChat.value(), "carol");
+        // Its own chat writes to it: the store is claimed for the chat's user.
+        assertThat(tool(new VectorTools.UpsertFactory(), chat("carol", oldChat))
+                .execute(chunk(oldStore, "notes", "container notes")))
+                .contains("Stored 1 chunk(s)");
+        assertThat(stores().registry().instance(oldStore).orElseThrow().owner()).isEqualTo("carol");
 
         assertThat(tool(new VectorTools.SearchFactory(), chat("carol", SessionId.random()))
                 .execute(Map.of("store", oldStore, "query", "container")))
                 .contains("container notes");
+    }
+
+    /**
+     * A chat's own store is the chat's however it came about: a tool writing
+     * into it before any upload registers it so, and the upload pipeline claims
+     * a store registered under the chat's name with another scope — but never
+     * one that already has an owner or belongs to another chat.
+     */
+    @Test
+    void aChatsOwnStoreIsRegisteredAsTheChatsWhoeverCreatesIt() {
+        SessionId davesChat = SessionId.random();
+        String davesStore = "session-" + davesChat.value();
+        assertThat(tool(new VectorTools.UpsertFactory(), chat("dave", davesChat))
+                .execute(chunk(davesStore, "early", "container notes")))
+                .contains("Stored 1 chunk(s)");
+        VectorStoreInstance registered = stores().registry().instance(davesStore).orElseThrow();
+        assertThat(registered.scope()).isEqualTo(VectorStoreInstance.Scope.SESSION);
+        assertThat(registered.scopeRef()).isEqualTo(davesChat.value());
+        assertThat(registered.owner()).isEqualTo("dave");
+        assertThat(tool(new VectorTools.SearchFactory(), chat("dave", SessionId.random()))
+                .execute(Map.of("store", davesStore, "query", "container")))
+                .contains("container notes");
+
+        // Registered under the chat's name as GLOBAL: the chat's pipeline claims it.
+        SessionId erinsChat = SessionId.random();
+        String erinsStore = "session-" + erinsChat.value();
+        stores().open(erinsStore, null, VectorStoreInstance.Scope.GLOBAL, null);
+        stores().open(erinsStore, null, VectorStoreInstance.Scope.SESSION, erinsChat.value(), "erin");
+        VectorStoreInstance claimed = stores().registry().instance(erinsStore).orElseThrow();
+        assertThat(claimed.scope()).isEqualTo(VectorStoreInstance.Scope.SESSION);
+        assertThat(claimed.scopeRef()).isEqualTo(erinsChat.value());
+        assertThat(claimed.owner()).isEqualTo("erin");
+        // An owned store is not claimed again, and nobody claims another chat's name.
+        stores().open(erinsStore, null, VectorStoreInstance.Scope.SESSION, erinsChat.value(), "mallory");
+        assertThat(stores().registry().instance(erinsStore).orElseThrow().owner()).isEqualTo("erin");
+        String franksStore = "session-" + SessionId.random().value();
+        stores().open(franksStore, null, VectorStoreInstance.Scope.GLOBAL, null);
+        stores().open(franksStore, null, VectorStoreInstance.Scope.SESSION, SessionId.random().value(), "mallory");
+        assertThat(stores().registry().instance(franksStore).orElseThrow().owner()).isNull();
     }
 
     @Test
@@ -254,5 +298,13 @@ class VectorToolsTest {
                 .startsWith("Error:").contains("another chat's uploads");
         assertThat(ingest.execute(Map.of("path", "doc.txt", "store", "kb")))
                 .contains("Stored");
+
+        // Its own chat's store, written before any upload, is registered as that chat's.
+        SessionId alicesChat = SessionId.random();
+        String alicesStore = "session-" + alicesChat.value();
+        assertThat(tool(new VectorIngestFileTool.Factory(), chat("alice", alicesChat))
+                .execute(Map.of("path", "doc.txt", "store", alicesStore)))
+                .contains("Stored");
+        assertThat(stores().registry().instance(alicesStore).orElseThrow().owner()).isEqualTo("alice");
     }
 }

--- a/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/VectorToolsTest.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/VectorToolsTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,7 @@ class VectorToolsTest {
             @Override public Optional<String> getString(String key) {
                 return switch (key) {
                     case "vectorStoreBackend" -> Optional.of("memory");
-                    case "dataBaseDir" -> Optional.of(dir.toString());
+                    case "dataBaseDir", "defaultBaseDir" -> Optional.of(dir.toString());
                     default -> Optional.empty();
                 };
             }
@@ -84,8 +85,23 @@ class VectorToolsTest {
         return factory.create(null, scope);
     }
 
-    private static ToolCallScope session(SessionId sessionId) {
-        return new ToolCallScope(UserId.of("alice"), sessionId, null);
+    private static ToolCallScope chat(String user, SessionId sessionId) {
+        return new ToolCallScope(UserId.of(user), sessionId, null);
+    }
+
+    private VectorStores stores() {
+        return VectorStores.fromEnvironment(env).orElseThrow();
+    }
+
+    /** A chat's upload store as the upload pipeline registers it: session-scoped, owned by the chat's user. */
+    private String uploadStore(String owner, SessionId chat) {
+        String name = "session-" + chat.value();
+        stores().open(name, null, VectorStoreInstance.Scope.SESSION, chat.value(), owner);
+        return name;
+    }
+
+    private static Map<String, Object> chunk(String store, String fileId, String text) {
+        return Map.of("store", store, "file_id", fileId, "chunks", List.of(Map.of("text", text)));
     }
 
     @Test
@@ -136,63 +152,107 @@ class VectorToolsTest {
     }
 
     /**
-     * The upload store of a chat is that chat's alone. Named from inside
-     * another session — search, upsert or delete — the store is refused; the
-     * own session reaches it by omitting {@code store} or naming it. A store
-     * named like a session that does not exist yet is refused too, so the
-     * model cannot squat on a foreign session's name. The upload pipeline runs
-     * its tools without a session and keeps filling any session's store.
+     * A chat's upload store belongs to the chat's user. Calls made for that
+     * user reach it — the ingestion workflow run on their behalf, another chat
+     * of theirs, a sub-agent their chat started. Calls for anyone else are
+     * refused, and so are calls for nobody in particular: a workflow started
+     * from the workflow admin or the REST API.
      */
     @Test
-    void sessionUploadStoresAreNotReachableFromOtherSessions() {
-        SessionId mine = SessionId.random();
-        SessionId theirs = SessionId.random();
-        String theirStore = "session-" + theirs.value();
+    void aChatsUploadStoreIsReachableOnlyForItsUser() {
+        SessionId bobsChat = SessionId.random();
+        String bobsStore = uploadStore("bob", bobsChat);
 
-        // Their session's store and a session-scoped store under a free name.
-        Tool theirUpsert = tool(new VectorTools.UpsertFactory(), session(theirs));
-        assertThat(theirUpsert.execute(Map.of("store", theirStore, "scope", "session",
-                "file_id", "secret.pdf", "chunks", List.of(Map.of("text", "the finance report")))))
+        // The ingestion workflow runs on behalf of bob's chat and fills the store.
+        assertThat(tool(new VectorTools.UpsertFactory(), chat("bob", bobsChat))
+                .execute(chunk(bobsStore, "secret.pdf", "the finance report")))
                 .contains("Stored 1 chunk(s)");
-        assertThat(theirUpsert.execute(Map.of("store", "their-notes", "scope", "session",
-                "file_id", "notes", "chunks", List.of(Map.of("text", "finance notes")))))
-                .contains("Stored 1 chunk(s)");
-
-        // The ingestion workflow resolves its tools detached — no session, no restriction.
-        assertThat(tool(new VectorTools.UpsertFactory()).execute(Map.of("store", theirStore,
-                "file_id", "second.pdf", "chunks", List.of(Map.of("text", "finance appendix")))))
+        // So does a session-scoped store under a free name.
+        assertThat(tool(new VectorTools.UpsertFactory(), chat("bob", bobsChat)).execute(Map.of(
+                "store", "bob-notes", "scope", "session", "file_id", "notes",
+                "chunks", List.of(Map.of("text", "finance notes")))))
                 .contains("Stored 1 chunk(s)");
 
-        Tool search = tool(new VectorTools.SearchFactory(), session(mine));
-        Tool upsert = tool(new VectorTools.UpsertFactory(), session(mine));
-        Tool delete = tool(new VectorTools.DeleteFileFactory(), session(mine));
+        // Runs for nobody in particular reach no chat's store.
+        assertThat(tool(new VectorTools.SearchFactory())
+                .execute(Map.of("store", bobsStore, "query", "finance")))
+                .startsWith("Error:").contains("another chat's uploads");
+        assertThat(tool(new VectorTools.UpsertFactory(), ToolCallScope.detached(UserId.of("workflow")))
+                .execute(chunk(bobsStore, "x", "planted")))
+                .startsWith("Error:").contains("another chat's uploads");
 
-        assertThat(search.execute(Map.of("store", theirStore, "query", "finance")))
-                .startsWith("Error:").contains("another chat session").doesNotContain("report");
-        assertThat(search.execute(Map.of("store", "their-notes", "query", "finance")))
-                .startsWith("Error:").contains("another chat session");
-        assertThat(upsert.execute(Map.of("store", theirStore, "file_id", "x",
-                "chunks", List.of(Map.of("text", "planted")))))
-                .startsWith("Error:").contains("another chat session");
-        assertThat(delete.execute(Map.of("store", theirStore, "file_id", "secret.pdf")))
-                .startsWith("Error:").contains("another chat session");
-        assertThat(upsert.execute(Map.of("store", "session-" + SessionId.random().value(), "file_id", "x",
-                "chunks", List.of(Map.of("text", "squatting")))))
+        // Alice, from her own chat: search, upsert and delete are refused ...
+        ToolCallScope alice = chat("alice", SessionId.random());
+        assertThat(tool(new VectorTools.SearchFactory(), alice)
+                .execute(Map.of("store", bobsStore, "query", "finance")))
+                .startsWith("Error:").doesNotContain("report");
+        assertThat(tool(new VectorTools.SearchFactory(), alice)
+                .execute(Map.of("store", "bob-notes", "query", "finance")))
+                .startsWith("Error:");
+        assertThat(tool(new VectorTools.UpsertFactory(), alice).execute(chunk(bobsStore, "x", "planted")))
+                .startsWith("Error:");
+        assertThat(tool(new VectorTools.DeleteFileFactory(), alice)
+                .execute(Map.of("store", bobsStore, "file_id", "secret.pdf")))
+                .startsWith("Error:");
+        // ... and so is a session name nobody registered: no squatting.
+        assertThat(tool(new VectorTools.UpsertFactory(), alice)
+                .execute(chunk("session-" + SessionId.random().value(), "x", "squatting")))
                 .startsWith("Error:");
 
-        // The own store stays reachable, by omission and by name.
-        assertThat(upsert.execute(Map.of("store", "session-" + mine.value(), "scope", "session",
-                "file_id", "mine.pdf", "chunks", List.of(Map.of("text", "podman container notes")))))
-                .contains("Stored 1 chunk(s)");
-        assertThat(search.execute(Map.of("query", "container"))).contains("podman");
-        assertThat(search.execute(Map.of("store", "session-" + mine.value(), "query", "container")))
-                .contains("podman");
+        // Bob reaches his store from another chat of his ...
+        assertThat(tool(new VectorTools.SearchFactory(), chat("bob", SessionId.random()))
+                .execute(Map.of("store", bobsStore, "query", "finance")))
+                .contains("the finance report");
+        // ... and a sub-agent his chat started searches it without naming it.
+        ToolCallScope subAgent = new ToolCallScope(UserId.of("bob"), SessionId.random(), null, bobsChat);
+        assertThat(tool(new VectorTools.SearchFactory(), subAgent).execute(Map.of("query", "finance")))
+                .contains("the finance report");
 
-        // Knowledge bases are not session stores and stay open to everyone.
-        assertThat(upsert.execute(Map.of("store", "kb", "file_id", "d",
-                "chunks", List.of(Map.of("text", "shared knowledge")))))
+        // Knowledge bases are not chat stores and stay open to everyone.
+        assertThat(tool(new VectorTools.UpsertFactory(), alice).execute(chunk("kb", "d", "shared knowledge")))
                 .contains("Stored 1 chunk(s)");
-        assertThat(tool(new VectorTools.SearchFactory(), session(theirs))
-                .execute(Map.of("store", "kb", "query", "knowledge"))).contains("shared");
+        assertThat(tool(new VectorTools.SearchFactory(), chat("bob", bobsChat))
+                .execute(Map.of("store", "kb", "query", "knowledge")))
+                .contains("shared");
+    }
+
+    /**
+     * An upload store registered before owners were recorded is reachable
+     * from its own chat only — until the upload pipeline opens it for that chat
+     * again and records the chat's user.
+     */
+    @Test
+    void anUploadStoreWithoutOwnerIsReachableFromItsOwnChatUntilItGetsOne() {
+        SessionId oldChat = SessionId.random();
+        String oldStore = "session-" + oldChat.value();
+        stores().open(oldStore, null, VectorStoreInstance.Scope.SESSION, oldChat.value());
+
+        assertThat(tool(new VectorTools.UpsertFactory(), chat("carol", oldChat))
+                .execute(chunk(oldStore, "notes", "container notes")))
+                .contains("Stored 1 chunk(s)");
+        assertThat(tool(new VectorTools.SearchFactory(), chat("carol", oldChat))
+                .execute(Map.of("query", "container")))
+                .contains("container notes");
+        assertThat(tool(new VectorTools.SearchFactory(), chat("carol", SessionId.random()))
+                .execute(Map.of("store", oldStore, "query", "container")))
+                .startsWith("Error:");
+
+        stores().open(oldStore, null, VectorStoreInstance.Scope.SESSION, oldChat.value(), "carol");
+
+        assertThat(tool(new VectorTools.SearchFactory(), chat("carol", SessionId.random()))
+                .execute(Map.of("store", oldStore, "query", "container")))
+                .contains("container notes");
+    }
+
+    @Test
+    void ingestFileFollowsTheSameRule() throws Exception {
+        Files.writeString(dir.resolve("doc.txt"), "finance numbers");
+        String bobsStore = uploadStore("bob", SessionId.random());
+        Tool ingest = tool(new VectorIngestFileTool.Factory(), chat("alice", SessionId.random()));
+
+        assertThat(ingest.execute(Map.of("path", "doc.txt", "store", bobsStore)))
+                .startsWith("Error:").contains("another chat's uploads");
+        assertThat(ingest.execute(Map.of("path", "doc.txt", "store", "kb")))
+                .contains("Stored");
     }
 }

--- a/website/docs/agents/vector-store.md
+++ b/website/docs/agents/vector-store.md
@@ -96,12 +96,15 @@ itself, in another chat of the same user, in a sub-agent the chat started
 workflow run on the user's behalf — the upload pipeline runs its ingestion
 workflow that way, and a workflow used as an agent tool runs its tool steps for
 the calling user and session. Everything else is refused, including a workflow
-started from the workflow admin or `/api/workflows/{id}/run`, which runs for
-nobody in particular. Knowledge bases (`GLOBAL` and `AGENT` stores) stay open.
+started from the workflow admin or `/api/workflows/{id}/run`: a run outside any
+chat reaches no chat's store, whatever user it runs as. Knowledge bases
+(`GLOBAL` and `AGENT` stores) stay open.
 
 A `session-…` name nobody registered yet, and an upload store from before
 owners were recorded, is reachable from its own chat only; the latter records
-its owner the next time the chat uploads a file.
+its owner the next time its chat writes to it, by an upload or a tool call. A
+tool writing into its own chat's store before any upload registers it as that
+chat's, owned by its user.
 
 ## The file store
 

--- a/website/docs/agents/vector-store.md
+++ b/website/docs/agents/vector-store.md
@@ -86,6 +86,23 @@ All four tools take a `store` name and speak **text only**:
 | `vector_delete_file` | Removes one file from a store. |
 | `vector_ingest_file` | Path in, searchable content out: reads the file (docx/PDF/markdown via the document reader when `mc-agent-tools-document` is present, else plain text), chunks OpenAI-style (800/400) and embeds — the one-call ingestion for workflows (`glob → ForEach → vector_ingest_file`). |
 
+### A chat's upload store belongs to its user
+
+Files attached to a chat land in that chat's store, `session-<sessionId>`,
+registered with the `SESSION` scope and the chat's user as its **owner**.
+The tools reach such a store only when they run for that user: in the chat
+itself, in another chat of the same user, in a sub-agent the chat started
+(whose `vector_search` without a `store` searches the chat's uploads), or in a
+workflow run on the user's behalf — the upload pipeline runs its ingestion
+workflow that way, and a workflow used as an agent tool runs its tool steps for
+the calling user and session. Everything else is refused, including a workflow
+started from the workflow admin or `/api/workflows/{id}/run`, which runs for
+nobody in particular. Knowledge bases (`GLOBAL` and `AGENT` stores) stay open.
+
+A `session-…` name nobody registered yet, and an upload store from before
+owners were recorded, is reachable from its own chat only; the latter records
+its owner the next time the chat uploads a file.
+
 ## The file store
 
 **`FileStore`** is deliberately small: `save(name, contentType, stream)`

--- a/website/docs/workflow/custom-steps.md
+++ b/website/docs/workflow/custom-steps.md
@@ -149,6 +149,28 @@ For Jackson to deserialize it, the class must be on the classpath and visible to
 the object mapper (`WorkflowObjectMapperFactory.create()` resolves `@class`
 names by reflection, so no extra registration is needed for round-tripping).
 
+## Values from the host: run attributes
+
+A step sometimes needs something the workflow's variables should not carry —
+on whose behalf the run happens, say. Hand such values to one run as
+**attributes**; every step of that run reads them from its context, parallel
+`for_each` blocks and called workflows included:
+
+```java
+var result = service.executeWorkflow(wf, Map.of("name", "Ada"),
+        Map.of(Tenant.class.getName(), new Tenant("acme")));
+```
+
+```java
+// inside a step; null when the host passed none
+Tenant tenant = getWorkflowContext().getAttribute(Tenant.class);
+```
+
+Unlike variables, attributes are invisible to expressions and are not part of
+a halted run's snapshot, so a resumed run starts without them. The agents area
+uses them to run a workflow's tool-call steps for the user and chat that
+started the run.
+
 ## Optional: PlantUML support
 
 If you also want your step authorable from PlantUML, implement a `DslStepBuilder`

--- a/workflow/mc-workflow-admin-rest/src/main/java/ai/mindconnect/workflow/admin/run/WorkflowRunService.java
+++ b/workflow/mc-workflow-admin-rest/src/main/java/ai/mindconnect/workflow/admin/run/WorkflowRunService.java
@@ -175,6 +175,23 @@ public class WorkflowRunService {
     public RunReport run(WorkflowData wf, Map<String, Object> params,
                          ai.mindconnect.workflow.execution.WorkflowEventListener extraListener,
                          boolean persist) {
+        return run(wf, params, extraListener, persist, Map.of());
+    }
+
+    /**
+     * Runs a workflow from the start with attributes for its steps — values the
+     * host hands the run, such as on whose behalf it happens (see
+     * {@link WorkflowContext#getAttributes()}). They are not part of a
+     * suspension: a run resumed later starts without them.
+     */
+    public RunReport runWithAttributes(WorkflowData wf, Map<String, Object> params,
+                                       Map<String, Object> attributes) {
+        return run(wf, params, null, false, attributes);
+    }
+
+    private RunReport run(WorkflowData wf, Map<String, Object> params,
+                          ai.mindconnect.workflow.execution.WorkflowEventListener extraListener,
+                          boolean persist, Map<String, Object> attributes) {
         Recorder recorder = new Recorder(wf);
         // SPI factory wires every WorkflowConfigurer on the classpath — so the
         // json:, javascript:, … resolvers are all active during the run.
@@ -187,7 +204,7 @@ public class WorkflowRunService {
 
         long startedAt = System.currentTimeMillis();
         try {
-            return report(wf, service.executeWorkflow(wf, params == null ? Map.of() : params),
+            return report(wf, service.executeWorkflow(wf, params == null ? Map.of() : params, attributes),
                     recorder, null, startedAt, persist);
         } catch (Exception e) {
             return failed(e);

--- a/workflow/mc-workflow/src/main/java/ai/mindconnect/workflow/execution/WorkflowContext.java
+++ b/workflow/mc-workflow/src/main/java/ai/mindconnect/workflow/execution/WorkflowContext.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Shared application context passed to every step during execution.
@@ -41,6 +43,16 @@ public class WorkflowContext {
     @Builder.Default
     private List<WorkflowEventListener> eventListeners = new ArrayList<>();
 
+    /**
+     * Values the host application hands one run for its own steps — on whose
+     * behalf the run happens, for instance — without the engine knowing their
+     * types. Every step of the run sees them: parallel for-each blocks and
+     * called workflows share this context. They are not part of a halted run's
+     * snapshot, so a resumed run starts without them.
+     */
+    @Builder.Default
+    private Map<String, Object> attributes = new ConcurrentHashMap<>();
+
     // -----------------------------------------------------------------------
     // Listener management
     // -----------------------------------------------------------------------
@@ -51,6 +63,40 @@ public class WorkflowContext {
 
     public boolean removeEventListener(WorkflowEventListener listener) {
         return eventListeners.remove(listener);
+    }
+
+    // -----------------------------------------------------------------------
+    // Attributes
+    // -----------------------------------------------------------------------
+
+    /** The attribute stored under {@code key}, or {@code null}. */
+    public Object getAttribute(String key) {
+        return attributeMap().get(key);
+    }
+
+    /** Stores {@code value} under {@code key}; a {@code null} value removes the attribute. */
+    public void setAttribute(String key, Object value) {
+        if (value == null) {
+            attributeMap().remove(key);
+        } else {
+            attributeMap().put(key, value);
+        }
+    }
+
+    /**
+     * The attribute stored under the type's name, when it holds a value of
+     * that type — the convention for attributes that are one typed object.
+     */
+    public <T> T getAttribute(Class<T> type) {
+        Object value = attributeMap().get(type.getName());
+        return type.isInstance(value) ? type.cast(value) : null;
+    }
+
+    private Map<String, Object> attributeMap() {
+        if (attributes == null) {
+            attributes = new ConcurrentHashMap<>();
+        }
+        return attributes;
     }
 
     // -----------------------------------------------------------------------

--- a/workflow/mc-workflow/src/main/java/ai/mindconnect/workflow/execution/WorkflowContextFactory.java
+++ b/workflow/mc-workflow/src/main/java/ai/mindconnect/workflow/execution/WorkflowContextFactory.java
@@ -46,7 +46,8 @@ public class WorkflowContextFactory {
                 scriptOutputWriter,
                 jsonMapper,
                 workflowDefinitionRegistry,
-                new ArrayList<>()
+                new ArrayList<>(),
+                new java.util.concurrent.ConcurrentHashMap<>()
         );
     }
 }

--- a/workflow/mc-workflow/src/main/java/ai/mindconnect/workflow/execution/WorkflowExecutorService.java
+++ b/workflow/mc-workflow/src/main/java/ai/mindconnect/workflow/execution/WorkflowExecutorService.java
@@ -46,7 +46,22 @@ public class WorkflowExecutorService {
      * @return a {@link WorkflowResult} describing the outcome
      */
     public WorkflowResult executeWorkflow(WorkflowData workflowData, Map<String, Object> params) {
+        return executeWorkflow(workflowData, params, Map.of());
+    }
+
+    /**
+     * Like {@link #executeWorkflow(WorkflowData, Map)}, with attributes every
+     * step of the run can read (see {@link WorkflowContext#getAttributes()}) —
+     * values the host hands the run, such as on whose behalf it happens.
+     *
+     * @param attributes attribute values by key; may be null or empty
+     */
+    public WorkflowResult executeWorkflow(WorkflowData workflowData, Map<String, Object> params,
+                                          Map<String, Object> attributes) {
         WorkflowContext context = createContext(workflowData.getName());
+        if (attributes != null) {
+            attributes.forEach(context::setAttribute);
+        }
         WorkflowInstance instance = new WorkflowInstance();
         instance.init(workflowData, null, context);
         // Add all environment vars to scope


### PR DESCRIPTION
## What

#65 made the `vector_*` tools refuse another session's upload store — but only for calls made inside a chat. Everything else resolved its tools detached, as the `workflow` user, and was not restricted:

- a workflow started from the workflow admin or `/api/workflows/{id}/run` could read or fill any chat's uploads (`file-ingestion` with `store=session-<other>`, or any workflow with a `vector_search` step);
- a chat model could do the same through a workflow exposed as an agent tool;
- `vector_ingest_file` did not check the store at all.

This PR makes a chat's upload store belong to the chat's **user** and lets only calls made for that user reach it.

## Changes

- **Owner on the store.** `VectorStoreInstance` records an `owner`. The upload pipeline (`SessionFileService`, `AttachSupport`) registers `session-<id>` with the chat's user; a store registered before owners existed gets its owner the next time its chat uploads a file.
- **One rule in `VectorTools.refusedStore`**, used by `vector_search`, `vector_upsert`, `vector_delete_file` and now `vector_ingest_file`: a chat store (SESSION scope or `session-` name) with an owner is reachable only by a call made **in a session** whose `scope.userId()` is that owner; without an owner (unregistered name, pre-existing store) only from its own chat. A run outside any chat reaches no chat's store, whatever user id it carries — such runs resolve their tools as the fixed `workflow` user, which a real account could also be called. Knowledge bases stay open.
- **A chat's own store is the chat's however it came about.** `vector_upsert` and `vector_ingest_file` register a store named after their own chat as `SESSION`, that chat, its user — whatever scope was asked for. Opening a store for its chat claims an unowned instance under the chat's name even if a tool registered it with another scope earlier; an owned instance or another chat's name is never claimed.
- **Who a workflow run is for travels with the run.** `WorkflowContext` gets run attributes (`executeWorkflow(wf, params, attributes)`, `WorkflowRunService.runWithAttributes`). `WorkflowTool` puts the calling `ToolCallScope` on the run; `ToolCallStep` passes it to the new `ToolInvoker.call(tool, args, scope)`; the Spring invoker resolves with it and falls back to the detached `workflow` user only when there is none. The upload pipeline runs its ingestion workflow with the chat's scope. Parallel for-each blocks and called workflows share the context; a resumed run starts without attributes.
- **Sub-agents.** `ToolCallScope.rootSessionId` (the 3-arg constructor stays). `SessionTools` fills it; a sub-agent's `vector_search` without a store searches the uploads of the chat that started it, and a sub-agent — same user — reaches that store by name.
- Changelog (agents *Fixed*, workflow + agents *Added*), docs (`vector-store.md`, `workflow/custom-steps.md`), manual test reference.

## Notes for review

- **Behaviour change for admins:** ingesting into a `session-…` store from the vector-store admin page or `POST /api/vector-stores/stores/{name}/ingest` goes through the ingestion workflow without a user and is now refused. Knowledge-base stores are unaffected.
- **Two points from a review pass are fixed in the second commit:** a store a tool registered under its chat's name before any upload never got an owner (the backfill only applied to `SESSION` instances), and an account named `workflow` would have been reachable from admin-started runs.
- Not in scope: the REST API taking the user from the request body (see #71); the vector-store core/ports refactor from the TODO has no code yet.

## Verification

- `mvn install` of the changed modules — `mc-workflow`, `mc-workflow-admin-rest`, `mc-agent-tool-spi`, `mc-agent-runtime-core`, `mc-agent-tools-workflow`, `mc-vector-store-tools`, `mc-agent-api-rest`, `mc-agent-runtime-builder`: all green, including
  - `VectorToolsTest.aChatsUploadStoreIsReachableOnlyForItsUser` (owner, other user, detached `workflow` user and detached owner id, squatting, same user's other chat, sub-agent default store), `anUploadStoreWithoutOwnerIsReachableFromItsOwnChatUntilItGetsOne`, `aChatsOwnStoreIsRegisteredAsTheChatsWhoeverCreatesIt`, `ingestFileFollowsTheSameRule`;
  - `ToolCallStepTest.theScopeOnTheRunReachesTheInvoker`, `WorkflowToolProviderTest.toolStepsRunOnBehalfOfTheCaller`.
- Live against the admin UI of this branch (auth off, dev user `bob`, sessions for `alice` and `bob` created over the REST API):
  - bob attaches a file to his chat → "up.txt attached — the agent can now search it"; the registry entry of `session-<bob>` reads `scope: SESSION`, `scopeRef: <bob's session>`, `owner: bob` — the ingestion workflow ran with the chat's scope and passed the check;
  - `POST /api/workflows/file-ingestion/run` with `store=session-<bob>` → `ERROR`, "store 'session-…' holds another chat's uploads"; bob's store still holds its one chunk;
  - the same run into `session-<alice>` (nothing uploaded) → refused, and no instance gets registered under that name;
  - the same run into a knowledge base → `SUCCESS`, one chunk stored;
  - no errors in the server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
