### PR TITLE
Serialize file store writes and change stored entities in one step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
   the next messages — summaries that covered the deleted range used to claim
   the new messages as well. With the file persistence a history page now reads
   only its own messages and appending lists nothing.
+- **agents:** two compactions of the same conversation no longer drop each
+  other's summary. The file persistence kept all summaries in one
+  `summaries.json` that every save read, extended and rewrote; each summary is
+  now its own file under `conversations/<id>/summaries/`. Summaries in the old
+  `summaries.json` are not read any more.
 
 - **agents:** tool calls no longer fail at random when sub-agents run in
   parallel. With the file persistence most stores truncated a file and wrote it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
   `summaries.json` that every save read, extended and rewrote; each summary is
   now its own file under `conversations/<id>/summaries/`. Summaries in the old
   `summaries.json` are not read any more.
+- **agents:** two uploads into the same chat at the same moment register its
+  vector store once; each could find the store missing and write its own
+  record. The memory vector-store backend no longer blocks a carrier thread
+  while a virtual thread waits for a store that is loading, saving or being
+  searched.
 
 - **agents:** tool calls no longer fail at random when sub-agents run in
   parallel. With the file persistence most stores truncated a file and wrote it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,24 @@ fresh empty one, so nothing has to be moved by hand at release time.
   once instead of risking a deadlock, a lock that stays taken times out naming
   its holder, and a second process on the same partition (namespace) of a data
   directory is refused — processes serving different namespaces share the
-  directory as before. The file stores do not use it yet.
+  directory as before. The file session store is the first to use it.
+- **common:** `DocumentTable.insert` (writes a new row, `false` when the key
+  exists) and `DocumentTable.update(key, change)`, which reads the row
+  `FOR UPDATE` and writes the change in the same transaction.
+
+### Changed
+
+- **agents:** `AgentSessionRepository` has `create` and `update(id, change)`
+  instead of `save`. A session is changed in one step on the state the store
+  holds, never by writing back a copy read earlier; implementations of the port
+  need the two methods.
+- **agents:** the file persistence keeps a session in one directory,
+  `data/<namespace>/sessions/<sessionId>/` — `session.json`, working memory and
+  the session's workspace files. Sessions stored under the earlier
+  `users/<userId>/sessions/` are not read any more; a warning in the log says
+  where they are. One process serves a namespace: a second process opening the
+  same namespace of the same data directory — the Admin UI while the CLI runs
+  in local mode, say — stops at startup with a message saying so.
 
 ### Removed
 
@@ -111,6 +128,14 @@ fresh empty one, so nothing has to be moved by hand at release time.
   `user_message`, `agent_response` and `last_messages` template variables are
   unchanged. A reviewer handing the answer back unchanged counts as a pass, not
   as a rewrite.
+
+- **agents:** changes to a session no longer overwrite each other. Tool
+  activations from parallel `tool_search` calls, an "allow for this session"
+  answered while tools ran, an attached file, a new title — each read the
+  session, changed its copy and wrote it back, so whichever came last silently
+  dropped what the others had written. The generated title also no longer
+  replaces a name the user gave the chat while it was being generated.
+
 - **agents:** tool calls no longer fail at random when sub-agents run in
   parallel. With the file persistence most stores truncated a file and wrote it
   anew, so a tool task reading the conversation while a sibling task saved a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ fresh empty one, so nothing has to be moved by hand at release time.
   chain, and `ToolInvoker.call(tool, arguments, scope)`, which the tool-call
   workflow step now calls with the scope found on its run.
 
+- **common:** `mc-file-repo`, the file counterpart of `mc-jdbc` for stores that
+  keep one JSON document per file. `Documents` reads without locking and lets
+  one writer at a time change a file — across the whole JVM, so two store
+  instances on the same directory take turns too — with `create`,
+  `createIfAbsent` and `update(key, change)` for changes that must not
+  overwrite each other. Writing while already holding a write lock fails at
+  once instead of risking a deadlock, a lock that stays taken times out naming
+  its holder, and a second process on the same partition (namespace) of a data
+  directory is refused — processes serving different namespaces share the
+  directory as before. The file stores do not use it yet.
+
 ### Removed
 
 - **agents:** the `mc-agent-tools-gmail` module. Gmail is now an MCP server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
   its holder, and a second process on the same partition (namespace) of a data
   directory is refused — processes serving different namespaces share the
   directory as before. The file session store is the first to use it.
+- **common:** `RecordLog` in `mc-file-repo` — an ordered log of JSON records
+  per parent (the messages of a conversation), one file per record, with an
+  in-memory index of the file names: `append` hands out the next key under
+  the directory's lock, pages read only their records, and a deleted tail's
+  keys are never handed out again.
+- **agents:** `MessageRepository.update(conversation, id, change)` changes a
+  stored message in one step.
 - **common:** `DocumentTable.insert` (writes a new row, `false` when the key
   exists) and `DocumentTable.update(key, change)`, which reads the row
   `FOR UPDATE` and writes the change in the same transaction.
@@ -135,6 +142,12 @@ fresh empty one, so nothing has to be moved by hand at release time.
   session, changed its copy and wrote it back, so whichever came last silently
   dropped what the others had written. The generated title also no longer
   replaces a name the user gave the chat while it was being generated.
+- **agents:** a message's token count, duration and compressed form no longer
+  overwrite each other when they are set at the same time, and deleting the
+  newest messages of a conversation no longer hands their sequence numbers to
+  the next messages — summaries that covered the deleted range used to claim
+  the new messages as well. With the file persistence a history page now reads
+  only its own messages and appending lists nothing.
 
 - **agents:** tool calls no longer fail at random when sub-agents run in
   parallel. With the file persistence most stores truncated a file and wrote it

--- a/agents/adapter/postgres/mc-agent-runtime-pg/src/main/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentSessionRepository.java
+++ b/agents/adapter/postgres/mc-agent-runtime-pg/src/main/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentSessionRepository.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 /**
  * {@link AgentSessionRepository} on Postgres: one row of {@code mc_agent_session}
@@ -66,8 +67,17 @@ public final class PgAgentSessionRepository implements AgentSessionRepository {
     }
 
     @Override
-    public AgentSession save(AgentSession session) {
-        return sessions.save(session);
+    public AgentSession create(AgentSession session) {
+        if (!sessions.insert(session)) {
+            throw new IllegalStateException("Session " + session.id().value() + " exists already");
+        }
+        return session;
+    }
+
+    /** Reads the row {@code FOR UPDATE} and writes the change in the same transaction. */
+    @Override
+    public Optional<AgentSession> update(SessionId id, UnaryOperator<AgentSession> change) {
+        return sessions.update(namespace.value(), id.value(), change);
     }
 
     @Override

--- a/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentSessionRepositoryTest.java
+++ b/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentSessionRepositoryTest.java
@@ -12,9 +12,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PgAgentSessionRepositoryTest {
 
@@ -38,7 +44,7 @@ class PgAgentSessionRepositoryTest {
         AgentSession s = session("david", "2026-09-03T10:00:00Z", null)
                 .withActivatedTools(List.of("web_search"))
                 .withApprovedTool("bash");
-        repo.save(s);
+        repo.create(s);
         assertThat(repo.findById(s.id())).contains(s);
     }
 
@@ -49,7 +55,7 @@ class PgAgentSessionRepositoryTest {
         AgentSession undated = session("david", null, null);
         AgentSession child = session("david", "2026-09-04T00:00:00Z", newest.id());
         AgentSession someoneElse = session("eve", "2026-09-05T00:00:00Z", null);
-        for (AgentSession s : List.of(oldest, child, undated, newest, someoneElse)) repo.save(s);
+        for (AgentSession s : List.of(oldest, child, undated, newest, someoneElse)) repo.create(s);
 
         assertThat(repo.findByUser(UserId.of("david"))).containsExactly(newest, oldest, undated);
         assertThat(repo.findByAgent(AGENT, UserId.of("david"))).containsExactly(child, newest, oldest, undated);
@@ -61,9 +67,9 @@ class PgAgentSessionRepositoryTest {
     void headersMatchTheFullSessionsFieldForField() {
         AgentSession a = session("david", "2026-09-03T00:00:00Z", null).withApprovedTool("bash");
         AgentSession b = session("david", "2026-09-01T00:00:00Z", null);
-        repo.save(a);
-        repo.save(b);
-        repo.save(session("david", "2026-09-02T00:00:00Z", a.id()));
+        repo.create(a);
+        repo.create(b);
+        repo.create(session("david", "2026-09-02T00:00:00Z", a.id()));
 
         var headers = repo.findHeadersByUser(UserId.of("david"));
         assertThat(headers).hasSize(2);
@@ -81,9 +87,42 @@ class PgAgentSessionRepositoryTest {
     @Test
     void deleteRemovesTheSessionOnly() {
         AgentSession s = session("david", "2026-09-03T10:00:00Z", null);
-        repo.save(s);
+        repo.create(s);
         repo.deleteById(s.id());
         assertThat(repo.findById(s.id())).isEmpty();
         repo.deleteById(s.id());
+    }
+
+    @Test
+    void createRefusesAnExistingSession() {
+        AgentSession s = repo.create(session("david", "2026-09-03T10:00:00Z", null));
+
+        assertThatThrownBy(() -> repo.create(s.withTitle("again"))).isInstanceOf(IllegalStateException.class);
+        assertThat(repo.findById(s.id())).contains(s);
+    }
+
+    @Test
+    void concurrentUpdatesOfOneSessionAllLand() throws Exception {
+        AgentSession s = repo.create(session("david", "2026-09-03T10:00:00Z", null));
+
+        try (ExecutorService pool = Executors.newFixedThreadPool(8)) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 40; i++) {
+                String tool = "tool_" + i;
+                futures.add(pool.submit(() -> repo.update(s.id(), x -> x.withActivatedTools(List.of(tool)))));
+                futures.add(pool.submit(() -> repo.update(s.id(), x -> x.withApprovedTool(tool))));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        AgentSession stored = repo.findById(s.id()).orElseThrow();
+        String[] all = IntStream.range(0, 40).mapToObj(i -> "tool_" + i).toArray(String[]::new);
+        assertThat(stored.activatedTools()).containsExactlyInAnyOrder(all);
+        assertThat(stored.approvedTools()).containsExactlyInAnyOrder(all);
+    }
+
+    @Test
+    void updatingAMissingSessionChangesNothing() {
+        assertThat(repo.update(SessionId.random(), x -> x.withTitle("never"))).isEmpty();
     }
 }

--- a/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgNamespaceIsolationTest.java
+++ b/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgNamespaceIsolationTest.java
@@ -67,8 +67,8 @@ class PgNamespaceIsolationTest {
         AgentSession parent = AgentSession.start(AgentId.random(), DAVID, ConversationId.random());
         AgentSession child = new AgentSession(SessionId.random(), parent.agentDefinitionId(), DAVID,
                 ConversationId.random(), "t", SessionStatus.ACTIVE, Instant.now(), null, parent.id(), null, null);
-        a.save(parent);
-        a.save(child);
+        a.create(parent);
+        a.create(child);
 
         assertThat(b.findById(parent.id())).isEmpty();
         assertThat(b.findByUser(DAVID)).isEmpty();

--- a/agents/adapter/postgres/mc-message-repository-pg/src/main/java/ai/mindconnect/message/adapter/pg/PgMessageRepository.java
+++ b/agents/adapter/postgres/mc-message-repository-pg/src/main/java/ai/mindconnect/message/adapter/pg/PgMessageRepository.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.IntFunction;
+import java.util.function.UnaryOperator;
 
 /**
  * {@link MessageRepository} on Postgres. One row of {@code mc_message} per
@@ -81,6 +82,12 @@ public final class PgMessageRepository implements MessageRepository {
     @Override
     public Message save(Message message) {
         return messages.save(message);
+    }
+
+    /** Reads the row {@code FOR UPDATE} and writes the change in the same transaction. */
+    @Override
+    public Optional<Message> update(ConversationId conversation, MessageId id, UnaryOperator<Message> change) {
+        return messages.update(namespace.value(), id.value(), change);
     }
 
     @Override

--- a/agents/adapter/postgres/mc-message-repository-pg/src/test/java/ai/mindconnect/message/adapter/pg/PgMessageUpdateTest.java
+++ b/agents/adapter/postgres/mc-message-repository-pg/src/test/java/ai/mindconnect/message/adapter/pg/PgMessageUpdateTest.java
@@ -1,0 +1,72 @@
+package ai.mindconnect.message.adapter.pg;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.jdbc.Sql;
+import ai.mindconnect.message.domain.ConversationId;
+import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageId;
+import ai.mindconnect.message.domain.MessageType;
+import ai.mindconnect.message.domain.ParticipantType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A token count and a duration set on one message at the same time both land — on Postgres as in the file store. */
+class PgMessageUpdateTest {
+
+    private final ConversationId conversation = ConversationId.random();
+
+    private PgMessageRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        Sql sql = Sql.of(TestDb.requirePostgres());
+        sql.execute("DROP TABLE IF EXISTS mc_message");
+        sql.execute("DROP TABLE IF EXISTS mc_message_seq");
+        repo = new PgMessageRepository(sql, new Namespace("test")).initSchema();
+    }
+
+    @Test
+    void concurrentChangesOfOneMessageBothLand() throws Exception {
+        Message message = repo.append(conversation, seq -> Message.of(conversation, "agent", ParticipantType.AGENT,
+                MessageType.TOOL_RESULT, "result", seq));
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+        Thread tokens = Thread.ofPlatform().start(() -> run(failures, () -> {
+            for (int i = 0; i < 50; i++) {
+                int count = i;
+                repo.update(conversation, message.id(), m -> m.withTokenCount(count));
+            }
+        }));
+        Thread durations = Thread.ofPlatform().start(() -> run(failures, () -> {
+            for (long i = 0; i < 50; i++) {
+                long ms = i;
+                repo.update(conversation, message.id(), m -> m.withDurationMs(ms));
+            }
+        }));
+        tokens.join();
+        durations.join();
+
+        assertThat(failures).isEmpty();
+        Message stored = repo.findById(conversation, message.id()).orElseThrow();
+        assertThat(stored.tokenCount()).isEqualTo(49);
+        assertThat(stored.durationMs()).isEqualTo(49L);
+    }
+
+    @Test
+    void updatingAMissingMessageChangesNothing() {
+        assertThat(repo.update(conversation, MessageId.random(), m -> m.withTokenCount(1))).isEmpty();
+    }
+
+    private static void run(Queue<Throwable> failures, Runnable body) {
+        try {
+            body.run();
+        } catch (Throwable t) {
+            failures.add(t);
+        }
+    }
+}

--- a/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
+++ b/agents/builder/mc-agent-runtime-builder/src/main/java/ai/mindconnect/agent/builder/AttachSupport.java
@@ -154,8 +154,7 @@ final class AttachSupport {
             // Not text to index: the image goes to the model with the next
             // message as an image part, or as that part's placeholder. Shown
             // once; afterwards the model asks for it through view_attachment.
-            sessions.findById(sessionId).ifPresent(session ->
-                    sessions.save(session.withAttachedFiles(List.of(attached))));
+            sessions.update(sessionId, session -> session.withAttachedFiles(List.of(attached)));
             activations.activate(sessionId,
                     List.of(ViewAttachmentTool.NAME));
             return stored.name() + " attached — it goes to the model with the next message.";
@@ -193,8 +192,7 @@ final class AttachSupport {
             activations.activate(sessionId, attached.isPdf()
                     ? List.of("vector_search", ViewAttachmentTool.NAME)
                     : List.of("vector_search"));
-            sessions.findById(sessionId).ifPresent(session ->
-                    sessions.save(session.withAttachedFiles(List.of(attached))));
+            sessions.update(sessionId, session -> session.withAttachedFiles(List.of(attached)));
             return message;
         } catch (Exception e) {
             throw new IllegalStateException("attachFile failed: " + e.getMessage(), e);

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/domain/AgentSession.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/domain/AgentSession.java
@@ -209,6 +209,18 @@ public record AgentSession(
                 .findFirst();
     }
 
+    /**
+     * This session running {@code agent} instead. The agent id moves with it:
+     * {@code agentDefinitionId} is the id the session is listed under and the
+     * key its workspace is filed by, and both should name the agent the chat
+     * actually runs.
+     */
+    public AgentSession withSessionAgent(ai.mindconnect.agent.runtime.domain.session.SessionAgent agent) {
+        return new AgentSession(id, agent.id(), userId, conversationId,
+                title, status, startedAt, completedAt, parentSessionId, parentTurnId,
+                parentToolCallId, activatedTools, attachedFiles, approvedTools, java.util.List.of(agent));
+    }
+
     /** This session with its agents replaced. */
     public AgentSession withSessionAgents(
             java.util.List<ai.mindconnect.agent.runtime.domain.session.SessionAgent> agents) {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/port/out/AgentSessionRepository.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/port/out/AgentSessionRepository.java
@@ -8,6 +8,7 @@ import ai.mindconnect.agent.UserId;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 /**
  * Storage of chat sessions, per tenant. One session is addressed by its
@@ -15,10 +16,35 @@ import java.util.Optional;
  * already names the tenant; the sessions of a user by tenant and user id,
  * because a user spans tenants and the same person has a separate history in
  * each.
+ *
+ * <p>A session is written from many threads at once — tool tasks activate
+ * tools, the approval answer adds a standing approval, an upload attaches a
+ * file, the title generator names the chat. So there is no {@code save} of a
+ * whole session: {@link #create} stores a new one, and {@link #update} changes
+ * a stored one in a single step, on the state it finds.
  */
 public interface AgentSessionRepository {
 
-    AgentSession save(AgentSession session);
+    /**
+     * Stores a session that is not stored yet.
+     *
+     * @throws IllegalStateException when a session with this id exists already
+     */
+    AgentSession create(AgentSession session);
+
+    /**
+     * Applies {@code change} to the stored session and stores the result, as one
+     * step: two updates of the same session never overwrite each other — the
+     * second is applied to what the first one wrote. A copy read earlier is never
+     * written back, because whatever was written to the session since would be lost.
+     *
+     * <p>{@code change} runs while the store holds the session and may run more
+     * than once: build the changed session from the one given, nothing else — no
+     * model call, no tool, no other store. Returning the given instance writes nothing.
+     *
+     * @return the session as stored afterwards, or empty when there is none
+     */
+    Optional<AgentSession> update(SessionId id, UnaryOperator<AgentSession> change);
 
     Optional<AgentSession> findById(SessionId id);
 

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/AgentChatService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/AgentChatService.java
@@ -429,8 +429,10 @@ public class AgentChatService {
             log.warn("Title generation failed — using user message as fallback: {}", e.getMessage());
             title = userMessage;
         }
-        sessionService.updateTitle(session.id(), title);
-        userChannels.publish(session.userId(), new UserEvent.SessionTitled(session.id(), title));
+        // Only an untitled session takes the generated title: a name the user
+        // gave the chat while the title was being generated stays.
+        AgentSession titled = sessionService.titleIfUntitled(session.id(), title);
+        userChannels.publish(session.userId(), new UserEvent.SessionTitled(session.id(), titled.title()));
     }
 
     // ── Memory ─────────────────────────────────────────────────────────────

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/AgentSessionService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/AgentSessionService.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 /**
  * CRUD operations on {@link AgentSession} — opening new chats, looking up,
@@ -107,7 +108,7 @@ public class AgentSessionService {
 
         AgentSession session = AgentSession.startSubAgent(agentDefinitionId, userId,
                 conversationId, parentSessionId, parentTurnId, parentToolCallId);
-        AgentSession saved = sessionRepository.save(session);
+        AgentSession saved = sessionRepository.create(session);
         // A sub-agent's session is the parent turn's business, not news for
         // the user's session list.
         if (parentSessionId == null) {
@@ -140,7 +141,7 @@ public class AgentSessionService {
         AgentSession session = AgentSession
                 .start(agent.id(), userId, conversationId)
                 .withSessionAgents(List.of(agent));
-        AgentSession saved = sessionRepository.save(session);
+        AgentSession saved = sessionRepository.create(session);
         userChannels.publish(userId, new UserEvent
                 .SessionStarted(saved.id(), agent.id()));
         return saved;
@@ -160,13 +161,7 @@ public class AgentSessionService {
      */
     public AgentSession replaceSessionAgent(SessionId sessionId,
                                             SessionAgent agent) {
-        AgentSession session = findSession(sessionId);
-        AgentSession moved = new AgentSession(session.id(), agent.id(),
-                session.userId(), session.conversationId(), session.title(), session.status(),
-                session.startedAt(), session.completedAt(), session.parentSessionId(),
-                session.parentTurnId(), session.parentToolCallId(), session.activatedTools(),
-                session.attachedFiles(), session.approvedTools(), List.of(agent));
-        return sessionRepository.save(moved);
+        return change(sessionId, session -> session.withSessionAgent(agent));
     }
 
     public List<AgentSession> listSessions(AgentId agentDefinitionId, UserId userId) {
@@ -216,13 +211,20 @@ public class AgentSessionService {
         return count;
     }
 
-    /**
-     * Sets the title of the given session. Used by the title-generation flow
-     * after the first user/agent exchange completes.
-     */
+    /** Sets the title of the given session — the user renaming the chat. */
     public AgentSession updateTitle(SessionId sessionId, String title) {
-        AgentSession session = findSession(sessionId);
-        return sessionRepository.save(session.withTitle(title));
+        return change(sessionId, session -> session.withTitle(title));
+    }
+
+    /**
+     * Sets {@code title} unless the session has one by now — the title generator
+     * after the first exchange, which must not overwrite a name the user gave the
+     * chat while the title was being generated.
+     *
+     * @return the session as stored, with whichever title it has
+     */
+    public AgentSession titleIfUntitled(SessionId sessionId, String title) {
+        return change(sessionId, session -> session.title() == null ? session.withTitle(title) : session);
     }
 
     /**
@@ -231,8 +233,18 @@ public class AgentSessionService {
      * see {@link AgentSession#approvedTools()}.
      */
     public AgentSession approveToolForSession(SessionId sessionId, String toolName) {
-        AgentSession session = findSession(sessionId);
-        return sessionRepository.save(session.withApprovedTool(toolName));
+        return change(sessionId, session -> session.approvedTools().contains(toolName)
+                ? session
+                : session.withApprovedTool(toolName));
+    }
+
+    /**
+     * Applies {@code change} to the stored session in one step, so a change made
+     * meanwhile by another thread — a tool activation, an attached file — is kept.
+     */
+    private AgentSession change(SessionId sessionId, UnaryOperator<AgentSession> change) {
+        return sessionRepository.update(sessionId, change)
+                .orElseThrow(() -> DomainException.notFound("AgentSession", sessionId.toString()));
     }
 
     /** The sub-sessions spawned from {@code parentSessionId} by run_agent calls. */

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/tools/toolsearch/DynamicToolActivations.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/tools/toolsearch/DynamicToolActivations.java
@@ -33,8 +33,9 @@ public final class DynamicToolActivations {
         if (sessionId == null || toolNames.isEmpty()) {
             return;
         }
-        sessions.findById(sessionId).ifPresent(session ->
-                sessions.save(session.withActivatedTools(toolNames)));
+        sessions.update(sessionId, session -> session.activatedTools().containsAll(toolNames)
+                ? session
+                : session.withActivatedTools(toolNames));
     }
 
     /** The names activated for this session; empty set when none (or unknown session). */

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/SessionHistoryTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/SessionHistoryTest.java
@@ -58,7 +58,11 @@ class SessionHistoryTest {
 
     private AgentSessionService serviceFor(AgentSession session, ConversationManager conversations) {
         AgentSessionRepository sessions = new AgentSessionRepository() {
-            @Override public AgentSession save(AgentSession s) { return s; }
+            @Override public AgentSession create(AgentSession s) { return s; }
+            @Override public Optional<AgentSession> update(SessionId id,
+                    java.util.function.UnaryOperator<AgentSession> change) {
+                return findById(id).map(change);
+            }
             @Override public Optional<AgentSession> findById(SessionId id) {
                 return session.id().equals(id) ? Optional.of(session) : Optional.empty();
             }

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/SessionTitleTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/SessionTitleTest.java
@@ -1,0 +1,81 @@
+package ai.mindconnect.agent.runtime.service;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.UserId;
+import ai.mindconnect.agent.runtime.domain.AgentSession;
+import ai.mindconnect.agent.runtime.port.out.AgentSessionRepository;
+import ai.mindconnect.common.DomainException;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.UnaryOperator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The title generator runs after the first exchange, and the user may rename
+ * the chat in the meantime. The generated title names an untitled chat only.
+ */
+class SessionTitleTest {
+
+    private final Map<SessionId, AgentSession> stored = new ConcurrentHashMap<>();
+    private final AgentSessionService service =
+            new AgentSessionService(null, new MapSessions(stored), null, null, null, null, null, null);
+
+    @Test
+    void theGeneratedTitleNamesAnUntitledChat() {
+        AgentSession session = store(newSession());
+
+        AgentSession titled = service.titleIfUntitled(session.id(), "Generated");
+
+        assertThat(titled.title()).isEqualTo("Generated");
+        assertThat(stored.get(session.id()).title()).isEqualTo("Generated");
+    }
+
+    @Test
+    void theGeneratedTitleDoesNotOverwriteANameTheUserGave() {
+        AgentSession session = store(newSession());
+        service.updateTitle(session.id(), "Weekly report");
+
+        AgentSession titled = service.titleIfUntitled(session.id(), "Generated");
+
+        assertThat(titled.title()).isEqualTo("Weekly report");
+        assertThat(stored.get(session.id()).title()).isEqualTo("Weekly report");
+    }
+
+    @Test
+    void renamingAMissingSessionIsNotFound() {
+        assertThatThrownBy(() -> service.updateTitle(SessionId.random(), "x"))
+                .isInstanceOf(DomainException.class);
+    }
+
+    private AgentSession store(AgentSession session) {
+        stored.put(session.id(), session);
+        return session;
+    }
+
+    private static AgentSession newSession() {
+        return AgentSession.start(AgentId.random(), UserId.of("alice"), ConversationId.random());
+    }
+
+    private record MapSessions(Map<SessionId, AgentSession> byId) implements AgentSessionRepository {
+        @Override public AgentSession create(AgentSession s) {
+            if (byId.putIfAbsent(s.id(), s) != null) throw new IllegalStateException("exists");
+            return s;
+        }
+        @Override public Optional<AgentSession> update(SessionId id, UnaryOperator<AgentSession> change) {
+            return Optional.ofNullable(byId.computeIfPresent(id, (key, current) -> change.apply(current)));
+        }
+        @Override public Optional<AgentSession> findById(SessionId id) { return Optional.ofNullable(byId.get(id)); }
+        @Override public List<AgentSession> findByAgent(AgentId agent, UserId user) { return List.of(); }
+        @Override public List<AgentSession> findByUser(UserId user) { return List.of(); }
+        @Override public List<AgentSession> findByParentSession(SessionId parent) { return List.of(); }
+        @Override public void deleteById(SessionId id) { byId.remove(id); }
+    }
+}

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/tools/attachment/ViewAttachmentToolTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/tools/attachment/ViewAttachmentToolTest.java
@@ -153,7 +153,13 @@ class ViewAttachmentToolTest {
     private static final class Sessions implements AgentSessionRepository {
         AgentSession session;
 
-        @Override public AgentSession save(AgentSession s) { session = s; return s; }
+        @Override public AgentSession create(AgentSession s) { session = s; return s; }
+        @Override public Optional<AgentSession> update(SessionId id,
+                                                       java.util.function.UnaryOperator<AgentSession> change) {
+            Optional<AgentSession> changed = findById(id).map(change);
+            changed.ifPresent(s -> session = s);
+            return changed;
+        }
         @Override public Optional<AgentSession> findById(SessionId id) {
             return Optional.ofNullable(session).filter(s -> s.id().equals(id));
         }

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/tools/toolsearch/ToolSearchToolTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/tools/toolsearch/ToolSearchToolTest.java
@@ -64,10 +64,14 @@ class ToolSearchToolTest {
     private static AgentSessionRepository sessionRepo(
             Map<SessionId, AgentSession> byId) {
         return new AgentSessionRepository() {
-            @Override public AgentSession save(
+            @Override public AgentSession create(
                     AgentSession session) {
                 byId.put(session.id(), session);
                 return session;
+            }
+            @Override public Optional<AgentSession> update(SessionId id,
+                    java.util.function.UnaryOperator<AgentSession> change) {
+                return Optional.ofNullable(byId.computeIfPresent(id, (key, current) -> change.apply(current)));
             }
             @Override public Optional<AgentSession> findById(SessionId id) {
                 return Optional.ofNullable(byId.get(id));

--- a/agents/core/mc-agent-runtime/pom.xml
+++ b/agents/core/mc-agent-runtime/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-file-repo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
             <artifactId>mc-llm-gateway-core</artifactId>
         </dependency>
         <dependency>

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentSessionRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentSessionRepository.java
@@ -1,78 +1,91 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
-import ai.mindconnect.common.util.AtomicFiles;
-import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.UserId;
-
 import ai.mindconnect.agent.runtime.domain.AgentSession;
 import ai.mindconnect.agent.runtime.port.out.AgentSessionRepository;
+import ai.mindconnect.filerepo.DocumentExistsException;
+import ai.mindconnect.filerepo.Documents;
+import ai.mindconnect.filerepo.FileRepo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 /**
- * Stores sessions under:
- *   {base}/users/{userId}/sessions/{sessionId}/session.json
+ * Stores sessions under {@code {base}/{namespace}/sessions/{sessionId}/session.json}.
+ *
+ * <p>The directory belongs to the session: its working memory and its workspace
+ * live beside {@code session.json}, and deleting the session deletes the
+ * directory. The path follows from the session id alone, which is what lets
+ * {@link #update} lock exactly this session's file — reads take no lock, and
+ * updates of one session take turns (see {@code mc-file-repo}).
+ *
+ * <p>Sessions stored under the earlier layout, {@code users/{userId}/sessions/},
+ * are not read; the repository logs once when it finds them.
  */
 public class FileAgentSessionRepository implements AgentSessionRepository {
 
     private static final Logger log = Logger.getLogger(FileAgentSessionRepository.class.getName());
+    private static final String SESSIONS = "sessions";
     private static final String FILE_NAME = "session.json";
-
-    private final Path baseDir;
-    private final ObjectMapper objectMapper;
-
-    public FileAgentSessionRepository(Path agentStorageDir, ObjectMapper objectMapper, Namespace namespace) {
-        this.baseDir = agentStorageDir.resolve(namespace.value()).toAbsolutePath();
-        this.objectMapper = objectMapper;
-        log.info("AgentSessionRepository base: " + this.baseDir);
-    }
 
     /**
      * Newest first, and tolerant of a session without a start time: one
      * unreadable timestamp should misplace a single row, not throw and take
      * the user's whole session list with it.
      */
-    private static final java.util.Comparator<AgentSession> NEWEST_FIRST =
-            java.util.Comparator.comparing(AgentSession::startedAt,
-                    java.util.Comparator.nullsLast(java.util.Comparator.reverseOrder()));
+    private static final Comparator<AgentSession> NEWEST_FIRST =
+            Comparator.comparing(AgentSession::startedAt, Comparator.nullsLast(Comparator.reverseOrder()));
+
+    private static final Comparator<AgentSession> OLDEST_FIRST =
+            Comparator.comparing(AgentSession::startedAt, Comparator.nullsLast(Comparator.naturalOrder()));
+
+    private final FileRepo repo;
+    private final Documents<SessionId, AgentSession> sessions;
+
+    public FileAgentSessionRepository(Path agentStorageDir, ObjectMapper objectMapper, Namespace namespace) {
+        this.repo = FileRepo.open(agentStorageDir, namespace.value());
+        this.sessions = Documents.of(AgentSession.class)
+                .path((SessionId id) -> SESSIONS + "/" + id.value() + "/" + FILE_NAME)
+                .build(repo, objectMapper);
+        log.info("AgentSessionRepository base: " + repo.root());
+        warnAboutEarlierLayout();
+    }
 
     @Override
-    public AgentSession save(AgentSession session) {
-        Path file = fileFor(session);
+    public AgentSession create(AgentSession session) {
         try {
-            // A session is read while other threads save it (tool tasks, title
-            // generation); a reader must never see the half-written file.
-            AtomicFiles.write(file, out -> objectMapper.writeValue(out, session));
-            return session;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            return sessions.create(session.id(), session);
+        } catch (DocumentExistsException e) {
+            throw new IllegalStateException("Session " + session.id().value() + " exists already", e);
         }
     }
 
     @Override
+    public Optional<AgentSession> update(SessionId id, UnaryOperator<AgentSession> change) {
+        return sessions.update(id, change);
+    }
+
+    @Override
     public Optional<AgentSession> findById(SessionId id) {
-        return allSessionDirs()
-                .filter(d -> d.getFileName().toString().equals(id.value()))
-                .map(d -> d.resolve(FILE_NAME))
-                .filter(Files::exists)
-                .map(f -> read(f))
-                .filter(s -> s.id().equals(id))
-                .findFirst();
+        return sessions.find(id);
     }
 
     @Override
     public List<AgentSession> findByAgent(AgentId agent, UserId user) {
-        return userSessions(user)
+        return all()
                 .filter(s -> s.agentDefinitionId().equals(agent) && s.userId().equals(user))
                 .sorted(NEWEST_FIRST)
                 .toList();
@@ -80,107 +93,63 @@ public class FileAgentSessionRepository implements AgentSessionRepository {
 
     @Override
     public List<AgentSession> findByUser(UserId user) {
-        return userSessions(user)
-                .filter(s -> s.userId().equals(user)
-                        && s.parentSessionId() == null)
+        return all()
+                .filter(s -> s.userId().equals(user) && s.parentSessionId() == null)
                 .sorted(NEWEST_FIRST)
                 .toList();
     }
 
     @Override
     public List<AgentSession> findByParentSession(SessionId parent) {
-        return allSessionDirs()
-                .map(d -> d.resolve(FILE_NAME))
-                .filter(Files::exists)
-                .map(f -> read(f))
+        return all()
                 .filter(s -> parent.equals(s.parentSessionId()))
-                .sorted(java.util.Comparator.comparing(AgentSession::startedAt))
+                .sorted(OLDEST_FIRST)
                 .toList();
     }
 
+    /**
+     * Deletes {@code session.json} first — under its lock, so an update running
+     * meanwhile finds no session and writes nothing — then the rest of the
+     * directory: working memory, workspace.
+     */
     @Override
     public void deleteById(SessionId id) {
-        findById(id).ifPresent(session -> {
-            Path sessionDir = userSessionsDir(session.userId()).resolve(id.value());
-            if (!Files.isDirectory(sessionDir)) return;
-            try {
-                deleteRecursively(sessionDir);
-                log.info("Deleted session directory: " + sessionDir);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        });
-    }
-
-    // ── layout: users/<user>/sessions/<session>/session.json ────────────────
-
-    /** Every session directory of every user. */
-    private java.util.stream.Stream<Path> allSessionDirs() {
-        Path usersDir = baseDir.resolve("users");
-        if (!Files.exists(usersDir)) return java.util.stream.Stream.empty();
-        try (var userStream = Files.list(usersDir)) {
-            return userStream
-                    .filter(Files::isDirectory)
-                    .flatMap(userDir -> {
-                        Path sessionsDir = userDir.resolve("sessions");
-                        if (!Files.exists(sessionsDir)) return java.util.stream.Stream.empty();
-                        try (var sessions = Files.list(sessionsDir)) {
-                            return sessions.filter(Files::isDirectory).toList().stream();
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                    })
-                    .toList().stream();
+        if (!sessions.delete(id)) return;
+        Path dir = repo.resolve(SESSIONS + "/" + id.value());
+        try (Stream<Path> files = Files.walk(dir)) {
+            files.sorted(Comparator.reverseOrder()).forEach(FileAgentSessionRepository::deleteQuietly);
+            log.info("Deleted session directory: " + dir);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    /** The sessions under one user's directory, read in {@code namespace}. */
-    private java.util.stream.Stream<AgentSession> userSessions(UserId user) {
-        Path sessionsDir = userSessionsDir(user);
-        if (!Files.exists(sessionsDir)) return java.util.stream.Stream.empty();
-        try (var stream = Files.list(sessionsDir)) {
-            return stream
-                    .filter(Files::isDirectory)
-                    .map(d -> d.resolve(FILE_NAME))
-                    .filter(Files::exists)
-                    .map(f -> read(f))
-                    .toList().stream();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    private Stream<AgentSession> all() {
+        return sessions.findAll(SESSIONS, FILE_NAME).stream();
     }
 
-    /** Reads a session in {@code namespace}; one written before the namespace was recorded takes it from here. */
-    private AgentSession read(Path file) {
+    private static void deleteQuietly(Path file) {
         try {
-            return objectMapper.readerFor(AgentSession.class)
-                    .readValue(file.toFile());
+            Files.deleteIfExists(file);
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            log.warning("Could not delete " + file + ": " + e.getMessage());
         }
     }
 
-    private Path fileFor(AgentSession session) {
-        return userSessionsDir(session.userId())
-                .resolve(session.id().value())
-                .resolve(FILE_NAME);
-    }
-
-    private Path userSessionsDir(UserId user) {
-        return baseDir.resolve("users").resolve(sanitize(user.value())).resolve("sessions");
-    }
-
-    private String sanitize(String value) {
-        return value.replaceAll("[^a-zA-Z0-9_\\-]", "_");
-    }
-
-    private void deleteRecursively(Path dir) throws IOException {
-        try (var stream = Files.walk(dir)) {
-            stream.sorted(java.util.Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(java.io.File::delete);
+    private void warnAboutEarlierLayout() {
+        Path users = repo.resolve("users");
+        if (!Files.isDirectory(users)) return;
+        try (DirectoryStream<Path> userDirs = Files.newDirectoryStream(users)) {
+            for (Path userDir : userDirs) {
+                if (Files.isDirectory(userDir.resolve(SESSIONS))) {
+                    log.warning("Sessions found under the earlier layout " + users
+                            + "/<user>/sessions/ — they are not read any more; sessions now live under "
+                            + repo.resolve(SESSIONS));
+                    return;
+                }
+            }
+        } catch (IOException e) {
+            // only a hint — nothing depends on it
         }
     }
 }

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileConversationSummaryRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileConversationSummaryRepository.java
@@ -1,104 +1,70 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
-import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
-import ai.mindconnect.message.domain.ConversationId;
-
 import ai.mindconnect.agent.runtime.memory.domain.ConversationSummary;
 import ai.mindconnect.agent.runtime.memory.port.out.ConversationSummaryRepository;
-import com.fasterxml.jackson.core.type.TypeReference;
+import ai.mindconnect.filerepo.FileRepo;
+import ai.mindconnect.filerepo.FileRepoException;
+import ai.mindconnect.filerepo.RecordLog;
+import ai.mindconnect.message.domain.ConversationId;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 /**
- * Stores conversation summaries under:
- *   {base}/conversations/{conversationId}/summaries.json
+ * Stores conversation summaries one file per summary:
+ *   {base}/conversations/{conversationId}/summaries/{fromSequenceNum}_{summaryId}.json
  *
- * The file is a JSON array of {@link ConversationSummary} records,
- * ordered by {@code fromSequenceNum} ascending.
+ * <p>Saving a summary writes its own file and touches no other, so two
+ * compactions of the same conversation cannot drop each other's summary — the
+ * earlier layout, one {@code summaries.json} array rewritten on every save, could.
+ * Summaries stored in that file are not read any more.
  */
 public class FileConversationSummaryRepository implements ConversationSummaryRepository {
 
     private static final Logger log = LoggerFactory.getLogger(FileConversationSummaryRepository.class);
-    private static final String FILE_NAME = "summaries.json";
-    private static final TypeReference<List<ConversationSummary>> LIST_TYPE = new TypeReference<>() {};
 
-    private final Path baseDir;
-    private final ObjectMapper mapper;
+    private final RecordLog<ConversationId, ConversationSummary> summaries;
 
     public FileConversationSummaryRepository(Path baseDir, Namespace namespace) {
-        this.baseDir = baseDir.resolve(namespace.value()).toAbsolutePath().normalize();
-        this.mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        this.summaries = RecordLog.of(ConversationSummary.class)
+                .dir((ConversationId conversation) -> "conversations/" + conversation.value() + "/summaries")
+                .key(ConversationSummary::fromSequenceNum)
+                .id(s -> s.id().value())
+                .prettyPrint()
+                .build(FileRepo.open(baseDir, namespace.value()), mapper);
     }
 
     @Override
     public void save(ConversationSummary summary) {
-        Path file = fileFor(summary.conversationId());
-        try {
-            // Read strictly: rewriting the file from a list that failed to load
-            // would replace every earlier summary with just this one.
-            List<ConversationSummary> existing = Files.exists(file) ? read(file) : new ArrayList<>();
-            existing.add(summary);
-            existing.sort(Comparator.comparingInt(ConversationSummary::fromSequenceNum));
-            AtomicFiles.write(file, out -> mapper.writerWithDefaultPrettyPrinter().writeValue(out, existing));
-            log.debug("Saved summary {} for conversation {} (seq {}-{})",
-                    summary.id(), summary.conversationId(),
-                    summary.fromSequenceNum(), summary.toSequenceNum());
-        } catch (IOException e) {
-            log.warn("Failed to save summary for conversation {} (existing summaries left untouched): {}",
-                    summary.conversationId(), e.getMessage());
-        }
+        summaries.put(summary.conversationId(), summary);
+        log.debug("Saved summary {} for conversation {} (seq {}-{})",
+                summary.id(), summary.conversationId(),
+                summary.fromSequenceNum(), summary.toSequenceNum());
     }
 
+    /**
+     * Ordered by {@code fromSequenceNum}. An unreadable summary counts as none —
+     * the turn goes on without the summaries rather than failing; nothing is
+     * rewritten from what failed to load.
+     */
     @Override
     public List<ConversationSummary> findByConversation(ConversationId conversationId) {
-        Path file = fileFor(conversationId);
-        if (!Files.exists(file)) return List.of();
-        return load(file);
+        try {
+            return summaries.all(conversationId);
+        } catch (FileRepoException e) {
+            log.warn("Failed to read summaries of conversation {}: {}", conversationId, e.getMessage());
+            return List.of();
+        }
     }
 
     @Override
     public void deleteByConversation(ConversationId conversationId) {
-        Path file = fileFor(conversationId);
-        try {
-            Files.deleteIfExists(file);
-        } catch (IOException e) {
-            log.warn("Failed to delete summaries for conversation {}: {}", conversationId, e.getMessage());
-        }
-    }
-
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private Path fileFor(ConversationId conversationId) {
-        return baseDir
-                .resolve("conversations")
-                .resolve(conversationId.value())
-                .resolve(FILE_NAME);
-    }
-
-    /** For reading: an unreadable file counts as no summaries, the turn goes on without them. */
-    private List<ConversationSummary> load(Path file) {
-        if (!Files.exists(file)) return new ArrayList<>();
-        try {
-            return read(file);
-        } catch (IOException e) {
-            log.warn("Failed to read summaries from {}: {}", file, e.getMessage());
-            return new ArrayList<>();
-        }
-    }
-
-    private List<ConversationSummary> read(Path file) throws IOException {
-        List<ConversationSummary> list = mapper.readerFor(LIST_TYPE).readValue(file.toFile());
-        list.sort(Comparator.comparingInt(ConversationSummary::fromSequenceNum));
-        return new ArrayList<>(list);
+        summaries.deleteAll(conversationId);
     }
 }

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkingMemoryRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkingMemoryRepository.java
@@ -17,11 +17,10 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 /**
- * Stores internal session data under:
- *   {base}/users/{userId}/sessions/{sessionId}/working-memory.json
- *   {base}/users/{userId}/sessions/{sessionId}/summary.md
- *
- * No in-memory index needed — userId is taken from {@link AuthenticationInfo}.
+ * Stores internal session data in the session's directory, beside its
+ * {@code session.json}:
+ *   {base}/sessions/{sessionId}/working-memory.json
+ *   {base}/sessions/{sessionId}/summary.md
  */
 public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
 
@@ -38,7 +37,7 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
 
     @Override
     public void save(SessionId sessionId, AuthenticationInfo auth, WorkingMemory memory) {
-        Path file = sessionDir(auth.userId().value(), sessionId).resolve(MEMORY_FILE);
+        Path file = sessionDir(sessionId).resolve(MEMORY_FILE);
         try {
             Files.createDirectories(file.getParent());
             AtomicFiles.write(file, out -> mapper.writerWithDefaultPrettyPrinter().writeValue(out, memory));
@@ -50,7 +49,7 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
 
     @Override
     public Optional<WorkingMemory> findBySession(SessionId sessionId, AuthenticationInfo auth) {
-        Path file = sessionDir(auth.userId().value(), sessionId).resolve(MEMORY_FILE);
+        Path file = sessionDir(sessionId).resolve(MEMORY_FILE);
         if (!Files.exists(file)) return Optional.empty();
         try {
             return Optional.of(mapper.readValue(file.toFile(), WorkingMemory.class));
@@ -62,13 +61,13 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
 
     @Override
     public void delete(SessionId sessionId, AuthenticationInfo auth) {
-        deleteFile(sessionDir(auth.userId().value(), sessionId).resolve(MEMORY_FILE));
-        deleteFile(sessionDir(auth.userId().value(), sessionId).resolve(SUMMARY_FILE));
+        deleteFile(sessionDir(sessionId).resolve(MEMORY_FILE));
+        deleteFile(sessionDir(sessionId).resolve(SUMMARY_FILE));
     }
 
     @Override
     public void saveSummary(SessionId sessionId, AuthenticationInfo auth, String summary) {
-        Path file = sessionDir(auth.userId().value(), sessionId).resolve(SUMMARY_FILE);
+        Path file = sessionDir(sessionId).resolve(SUMMARY_FILE);
         try {
             Files.createDirectories(file.getParent());
             AtomicFiles.writeString(file, summary);
@@ -80,7 +79,7 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
 
     @Override
     public Optional<String> loadSummary(SessionId sessionId, AuthenticationInfo auth) {
-        Path file = sessionDir(auth.userId().value(), sessionId).resolve(SUMMARY_FILE);
+        Path file = sessionDir(sessionId).resolve(SUMMARY_FILE);
         if (!Files.exists(file)) return Optional.empty();
         try {
             String content = Files.readString(file).strip();
@@ -93,15 +92,13 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
 
     @Override
     public void deleteSummary(SessionId sessionId, AuthenticationInfo auth) {
-        deleteFile(sessionDir(auth.userId().value(), sessionId).resolve(SUMMARY_FILE));
+        deleteFile(sessionDir(sessionId).resolve(SUMMARY_FILE));
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    private Path sessionDir(String userId, SessionId sessionId) {
+    private Path sessionDir(SessionId sessionId) {
         return baseDir
-                .resolve("users")
-                .resolve(sanitize(userId))
                 .resolve("sessions")
                 .resolve(sessionId.value());
     }
@@ -112,9 +109,5 @@ public class FileWorkingMemoryRepository implements WorkingMemoryRepository {
         } catch (IOException e) {
             log.warn("Failed to delete {}: {}", file, e.getMessage());
         }
-    }
-
-    private static String sanitize(String value) {
-        return value.replaceAll("[^a-zA-Z0-9_\\-]", "_");
     }
 }

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkspaceStore.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileWorkspaceStore.java
@@ -18,7 +18,7 @@ import java.util.Optional;
  * Directory layout mirrors the three scope types:
  *   {base}/users/{userId}/workspace/
  *   {base}/users/{userId}/agents/{agentId}/workspace/
- *   {base}/users/{userId}/sessions/{sessionId}/workspace/
+ *   {base}/sessions/{sessionId}/workspace/     (beside the session's session.json)
  *
  * Swap for an S3 or JPA implementation without touching any service code.
  */
@@ -137,8 +137,6 @@ public class FileWorkspaceStore implements WorkspaceStore {
                                 .resolve(scope.agentId().value())
                                 .resolve("workspace");
             case SESSION    -> baseDir
-                                .resolve("users")
-                                .resolve(sanitize(scope.userId().value()))
                                 .resolve("sessions")
                                 .resolve(scope.sessionId().value())
                                 .resolve("workspace");

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/repo/memory/InMemoryAgentSessionRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/repo/memory/InMemoryAgentSessionRepository.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.UnaryOperator;
 
 /** In-memory {@link AgentSessionRepository} — process-lifetime storage, no persistence. */
 public class InMemoryAgentSessionRepository implements AgentSessionRepository {
@@ -28,9 +29,18 @@ public class InMemoryAgentSessionRepository implements AgentSessionRepository {
                     java.util.Comparator.nullsLast(java.util.Comparator.reverseOrder()));
 
     @Override
-    public AgentSession save(AgentSession session) {
-        store.put(session.id(), session);
+    public AgentSession create(AgentSession session) {
+        if (store.putIfAbsent(session.id(), session) != null) {
+            throw new IllegalStateException("Session " + session.id().value() + " exists already");
+        }
         return session;
+    }
+
+    /** {@code computeIfPresent} runs the change while holding the entry, so updates of one session take turns. */
+    @Override
+    public Optional<AgentSession> update(SessionId id, UnaryOperator<AgentSession> change) {
+        return Optional.ofNullable(store.computeIfPresent(id, (key, current) ->
+                Objects.requireNonNull(change.apply(current), "update: the change returned null")));
     }
 
     @Override

--- a/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentSessionRepositoryConcurrencyTest.java
+++ b/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentSessionRepositoryConcurrencyTest.java
@@ -12,34 +12,41 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * A session is read while other threads save it — a tool task loads it while
- * the title generator or a tool activation writes it. A reader must never see
- * a half-written file: that surfaced as tool tasks failing without a result.
+ * A session is read and written from many threads at once — tool tasks
+ * activate tools while the title generator names the chat and an upload
+ * attaches a file. A reader must never see a half-written file, and no
+ * writer may overwrite what another one wrote.
  */
 class FileAgentSessionRepositoryConcurrencyTest {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
     @Test
-    void readsWhileSavingNeverSeeAHalfWrittenSession(@TempDir Path dir) throws Exception {
-        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        FileAgentSessionRepository repo = new FileAgentSessionRepository(dir, mapper, new Namespace("test"));
-        AgentSession session = repo.save(AgentSession.startSubAgent(AgentId.random(), UserId.of("alice"),
-                ConversationId.random(), null, null, null));
+    void readsWhileUpdatingNeverSeeAHalfWrittenSession(@TempDir Path dir) throws Exception {
+        FileAgentSessionRepository repo = new FileAgentSessionRepository(dir, MAPPER, new Namespace("test"));
+        AgentSession session = repo.create(newSession());
 
         AtomicBoolean writing = new AtomicBoolean(true);
         Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
         Thread writer = Thread.ofPlatform().start(() -> {
             try {
                 for (int i = 0; i < 400; i++) {
-                    repo.save(session.withActivatedTools(List.of("tool_" + i)));
+                    String tool = "tool_" + i;
+                    repo.update(session.id(), s -> s.withActivatedTools(List.of(tool)));
                 }
             } catch (Throwable t) {
                 failures.add(t);
@@ -63,5 +70,30 @@ class FileAgentSessionRepositoryConcurrencyTest {
         assertThat(reads).isPositive();
         assertThat(repo.findById(session.id())).map(AgentSession::activatedTools)
                 .hasValueSatisfying(tools -> assertThat(tools).contains("tool_399"));
+    }
+
+    @Test
+    void concurrentUpdatesOfOneSessionAllLand(@TempDir Path dir) throws Exception {
+        FileAgentSessionRepository repo = new FileAgentSessionRepository(dir, MAPPER, new Namespace("test"));
+        AgentSession session = repo.create(newSession());
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                String tool = "tool_" + i;
+                futures.add(pool.submit(() -> repo.update(session.id(), s -> s.withActivatedTools(List.of(tool)))));
+                futures.add(pool.submit(() -> repo.update(session.id(), s -> s.withApprovedTool(tool))));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        AgentSession stored = repo.findById(session.id()).orElseThrow();
+        String[] all = IntStream.range(0, 200).mapToObj(i -> "tool_" + i).toArray(String[]::new);
+        assertThat(stored.activatedTools()).containsExactlyInAnyOrder(all);
+        assertThat(stored.approvedTools()).containsExactlyInAnyOrder(all);
+    }
+
+    private static AgentSession newSession() {
+        return AgentSession.startSubAgent(AgentId.random(), UserId.of("alice"), ConversationId.random(), null, null, null);
     }
 }

--- a/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/file/FileConversationSummaryRepositoryTest.java
+++ b/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/file/FileConversationSummaryRepositoryTest.java
@@ -1,0 +1,90 @@
+package ai.mindconnect.agent.runtime.adapter.file;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.runtime.memory.domain.ConversationSummary;
+import ai.mindconnect.message.domain.ConversationId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * One file per summary: a compaction after the turn and one started from the UI
+ * save into the same conversation without dropping each other's summary.
+ */
+class FileConversationSummaryRepositoryTest {
+
+    @Test
+    void summariesComeBackInSequenceOrderEachInItsOwnFile(@TempDir Path dir) {
+        FileConversationSummaryRepository repo = new FileConversationSummaryRepository(dir, new Namespace("test"));
+        ConversationId conversation = ConversationId.random();
+        ConversationSummary later = ConversationSummary.create(conversation, 11, 20, 10, "later");
+        ConversationSummary earlier = ConversationSummary.create(conversation, 1, 10, 10, "earlier");
+
+        repo.save(later);
+        repo.save(earlier);
+
+        assertThat(repo.findByConversation(conversation)).containsExactly(earlier, later);
+        assertThat(dir.resolve("test/conversations/" + conversation.value() + "/summaries/0000000001_"
+                + earlier.id().value() + ".json")).exists();
+        assertThat(repo.findByConversation(ConversationId.random())).isEmpty();
+    }
+
+    @Test
+    void concurrentSavesAllLand(@TempDir Path dir) throws Exception {
+        FileConversationSummaryRepository repo = new FileConversationSummaryRepository(dir, new Namespace("test"));
+        ConversationId conversation = ConversationId.random();
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                int from = i * 10 + 1;
+                futures.add(pool.submit(() ->
+                        repo.save(ConversationSummary.create(conversation, from, from + 9, 10, "part " + from))));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(repo.findByConversation(conversation)).extracting(ConversationSummary::fromSequenceNum)
+                .containsExactlyElementsOf(IntStream.range(0, 50).map(i -> i * 10 + 1).boxed().toList());
+    }
+
+    @Test
+    void deletingAConversationsSummariesLeavesOthersAlone(@TempDir Path dir) {
+        FileConversationSummaryRepository repo = new FileConversationSummaryRepository(dir, new Namespace("test"));
+        ConversationId gone = ConversationId.random();
+        ConversationId kept = ConversationId.random();
+        repo.save(ConversationSummary.create(gone, 1, 5, 5, "gone"));
+        ConversationSummary keep = ConversationSummary.create(kept, 1, 5, 5, "kept");
+        repo.save(keep);
+
+        repo.deleteByConversation(gone);
+
+        assertThat(repo.findByConversation(gone)).isEmpty();
+        assertThat(repo.findByConversation(kept)).containsExactly(keep);
+    }
+
+    @Test
+    void anUnreadableSummaryCountsAsNoneAndIsNotOverwritten(@TempDir Path dir) throws Exception {
+        FileConversationSummaryRepository repo = new FileConversationSummaryRepository(dir, new Namespace("test"));
+        ConversationId conversation = ConversationId.random();
+        ConversationSummary summary = ConversationSummary.create(conversation, 1, 5, 5, "gist");
+        repo.save(summary);
+        Path file = dir.resolve("test/conversations/" + conversation.value() + "/summaries/0000000001_"
+                + summary.id().value() + ".json");
+        Files.writeString(file, "{\"id\":");
+
+        assertThat(repo.findByConversation(conversation)).isEmpty();
+        repo.save(ConversationSummary.create(conversation, 6, 10, 5, "next"));
+        assertThat(Files.readString(file)).isEqualTo("{\"id\":");
+    }
+}

--- a/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/repo/memory/SessionsByUserTest.java
+++ b/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/repo/memory/SessionsByUserTest.java
@@ -27,7 +27,7 @@ class SessionsByUserTest {
                 startedAt, base.completedAt(), base.parentSessionId(), base.parentTurnId(),
                 base.parentToolCallId(), base.activatedTools(), base.attachedFiles(),
                 base.approvedTools(), base.sessionAgents());
-        return repo.save(withTime);
+        return repo.create(withTime);
     }
 
     @Test

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/port/out/MessageRepository.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/port/out/MessageRepository.java
@@ -8,6 +8,7 @@ import ai.mindconnect.message.domain.MessageId;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.IntFunction;
+import java.util.function.UnaryOperator;
 
 /**
  * Storage of messages. A message is a child of its conversation, so it is
@@ -17,11 +18,23 @@ import java.util.function.IntFunction;
 public interface MessageRepository {
 
     /**
-     * Persists a message. If a message with the same {@code id} already exists
-     * in its conversation it is overwritten (upsert) — this allows updating the
-     * compressed flag.
+     * Stores a message with the sequence number it carries, replacing a message
+     * of the same {@code id} — for importing and for tests. A new message of a
+     * running conversation goes through {@link #append}, a change to a stored
+     * one through {@link #update}.
      */
     Message save(Message message);
+
+    /**
+     * Applies {@code change} to the stored message and stores the result, as one
+     * step: the turn setting a token count and a memory strategy compressing the
+     * same message never overwrite each other. {@code change} runs while the store
+     * holds the message and may run more than once — build the changed message,
+     * nothing else; it must keep the id and the sequence number.
+     *
+     * @return the message as stored afterwards, or empty when there is none
+     */
+    Optional<Message> update(ConversationId conversation, MessageId id, UnaryOperator<Message> change);
 
     List<Message> findByConversation(ConversationId conversation, PageRequest page);
 

--- a/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/service/ConversationService.java
+++ b/agents/core/mc-message-repository-core/src/main/java/ai/mindconnect/message/service/ConversationService.java
@@ -85,23 +85,17 @@ public class ConversationService implements ConversationManager {
 
     @Override
     public void compressMessage(ConversationId conversation, MessageId message, String stub, Integer compressedTokenCount) {
-        messageRepository.findById(conversation, message)
-                .map(m -> m.withCompressed(stub, compressedTokenCount))
-                .ifPresent(messageRepository::save);
+        messageRepository.update(conversation, message, m -> m.withCompressed(stub, compressedTokenCount));
     }
 
     @Override
     public void updateTokenCount(ConversationId conversation, MessageId message, int tokenCount) {
-        messageRepository.findById(conversation, message)
-                .map(m -> m.withTokenCount(tokenCount))
-                .ifPresent(messageRepository::save);
+        messageRepository.update(conversation, message, m -> m.withTokenCount(tokenCount));
     }
 
     @Override
     public void updateDurationMs(ConversationId conversation, MessageId message, long durationMs) {
-        messageRepository.findById(conversation, message)
-                .map(m -> m.withDurationMs(durationMs))
-                .ifPresent(messageRepository::save);
+        messageRepository.update(conversation, message, m -> m.withDurationMs(durationMs));
     }
 
     @Override

--- a/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/service/ConversationServiceTest.java
+++ b/agents/core/mc-message-repository-core/src/test/java/ai/mindconnect/message/service/ConversationServiceTest.java
@@ -170,6 +170,20 @@ class ConversationServiceTest {
         public Message save(Message m) { store.add(m); return m; }
 
         @Override
+        public synchronized java.util.Optional<Message> update(ConversationId conversation, MessageId id,
+                                                             java.util.function.UnaryOperator<Message> change) {
+            for (int i = 0; i < store.size(); i++) {
+                Message m = store.get(i);
+                if (m.conversationId().equals(conversation) && m.id().equals(id)) {
+                    Message changed = change.apply(m);
+                    store.set(i, changed);
+                    return java.util.Optional.of(changed);
+                }
+            }
+            return java.util.Optional.empty();
+        }
+
+        @Override
         public List<Message> findByConversation(ConversationId id, PageRequest page) {
             return store.stream()
                     .filter(m -> m.conversationId().equals(id))

--- a/agents/core/mc-message-repository/pom.xml
+++ b/agents/core/mc-message-repository/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>mc-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-file-repo</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileMessageRepository.java
+++ b/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/file/FileMessageRepository.java
@@ -1,194 +1,76 @@
 package ai.mindconnect.message.adapter.file;
 
-import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
-import ai.mindconnect.message.domain.ConversationId;
-import ai.mindconnect.message.domain.MessageId;
-
 import ai.mindconnect.common.PageRequest;
+import ai.mindconnect.filerepo.FileRepo;
+import ai.mindconnect.filerepo.RecordLog;
+import ai.mindconnect.message.domain.ConversationId;
 import ai.mindconnect.message.domain.Message;
+import ai.mindconnect.message.domain.MessageId;
 import ai.mindconnect.message.port.out.MessageRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.IntFunction;
+import java.util.function.UnaryOperator;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
-import java.nio.file.PathMatcher;
 
 /**
  * Stores messages under:
- *   {base}/conversations/{conversationId}/messages/{seq}_{messageId}.json
+ *   {base}/{namespace}/conversations/{conversationId}/messages/{seq}_{messageId}.json
  *
- * Co-located with the conversation.json written by FileConversationRepository.
+ * <p>Co-located with the conversation.json written by FileConversationRepository.
+ * The directory is a {@link RecordLog}: the next sequence number comes from its
+ * in-memory index under the conversation's write lock, so appending lists
+ * nothing and two appends never share a number — not even after the newest
+ * messages were deleted. A history page reads only its own messages, and
+ * finding a message by id opens one file.
  */
 public class FileMessageRepository implements MessageRepository {
 
     private static final Logger log = Logger.getLogger(FileMessageRepository.class.getName());
 
-    /**
-     * Locks for {@link #append}, one bucket per conversation by hash. A
-     * fixed set rather than one per conversation: nothing to create, and
-     * nothing that grows for as long as the process lives. Two
-     * conversations sharing a bucket wait for each other now and then,
-     * which costs a moment and breaks nothing.
-     *
-     * <p>Process-wide, which is what a directory of files is: two JVMs
-     * writing into the same store would still hand out the same number.
-     */
-    private static final int APPEND_LOCKS = 64;
-
-    private final ReentrantLock[] appendLocks = Stream.generate(ReentrantLock::new)
-            .limit(APPEND_LOCKS).toArray(ReentrantLock[]::new);
-
-    private final Path baseDir;
-    private final ObjectMapper objectMapper;
+    private final RecordLog<ConversationId, Message> messages;
 
     public FileMessageRepository(Path messageStorageDir, ObjectMapper objectMapper, Namespace namespace) {
-        this.baseDir = messageStorageDir.resolve(namespace.value()).resolve("conversations").toAbsolutePath();
-        this.objectMapper = objectMapper;
-        log.info("MessageRepository storage: " + this.baseDir);
+        FileRepo repo = FileRepo.open(messageStorageDir, namespace.value());
+        this.messages = RecordLog.of(Message.class)
+                .dir((ConversationId conversation) -> "conversations/" + conversation.value() + "/messages")
+                .key(Message::sequenceNum)
+                .id(m -> m.id().value())
+                .build(repo, objectMapper);
+        log.info("MessageRepository storage: " + repo.resolve("conversations"));
     }
 
     @Override
     public Message save(Message message) {
-        try {
-            Path dir = messagesDir(message.conversationId());
-            Files.createDirectories(dir);
-            Path file = fileFor(message);
-            boolean isUpdate = Files.exists(file);
-            AtomicFiles.write(file, out -> objectMapper.writeValue(out, message));
-            if (!isUpdate) {
-                log.fine("Saved new message " + message.id());
-            } else {
-                log.fine("Updated existing message " + message.id());
-            }
-            return message;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return messages.put(message.conversationId(), message);
     }
 
     @Override
-    public List<Message> findByConversation(ConversationId conversationId, PageRequest page) {
-        Path dir = messagesDir(conversationId);
-        if (!Files.exists(dir)) return List.of();
-        try (var stream = Files.list(dir)) {
-            return stream
-                    .filter(p -> p.toString().endsWith(".json"))
-                    .sorted()
-                    .map(p -> read(p, conversationId))
-                    .skip(page.offset())
-                    .limit(page.size())
-                    .toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    public Optional<Message> update(ConversationId conversation, MessageId id, UnaryOperator<Message> change) {
+        return messages.update(conversation, id.value(), change);
     }
 
     @Override
-    public Optional<Message> findById(ConversationId conversationId, MessageId id) {
-        Path dir = messagesDir(conversationId);
-        if (!Files.exists(dir)) return Optional.empty();
-        // Use glob to match "*_{messageId}.json" — avoids full directory scan
-        PathMatcher matcher = dir.getFileSystem()
-                .getPathMatcher("glob:**/*_" + id.value() + ".json");
-        try (var stream = Files.list(dir)) {
-            return stream
-                    .filter(matcher::matches)
-                    .findFirst()
-                    .map(p -> read(p, conversationId));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    public List<Message> findByConversation(ConversationId conversation, PageRequest page) {
+        return messages.page(conversation, page.offset(), page.size());
     }
 
     @Override
-    public Message append(ConversationId conversationId, IntFunction<Message> create) {
-        ReentrantLock lock = appendLocks[Math.floorMod(conversationId.hashCode(), APPEND_LOCKS)];
-        lock.lock();
-        try {
-            return save(create.apply(maxSequenceNum(conversationId) + 1));
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    /**
-     * The highest number in the conversation, 0 when it has no messages.
-     * Read from the file names, which carry it zero-padded in front, so
-     * this costs a directory listing and opens nothing.
-     */
-    private int maxSequenceNum(ConversationId conversationId) {
-        Path dir = messagesDir(conversationId);
-        if (!Files.exists(dir)) return 0;
-        try (var stream = Files.list(dir)) {
-            return stream.filter(p -> p.toString().endsWith(".json"))
-                    .mapToInt(p -> seqOf(p.getFileName().toString()))
-                    .filter(seq -> seq >= 0)
-                    .max().orElse(0);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    /** The leading digits of "0000000012_<uuid>.json"; -1 for a name of another shape. */
-    private static int seqOf(String fileName) {
-        int underscore = fileName.indexOf('_');
-        if (underscore < 1) return -1;
-        try {
-            return Integer.parseInt(fileName.substring(0, underscore));
-        } catch (NumberFormatException e) {
-            return -1;
-        }
+    public Optional<Message> findById(ConversationId conversation, MessageId id) {
+        return messages.find(conversation, id.value());
     }
 
     @Override
-    public void deleteBySequenceRange(ConversationId conversationId, int fromSeq, int toSeq) {
-        Path dir = messagesDir(conversationId);
-        if (!Files.exists(dir)) return;
-        try (var stream = Files.list(dir)) {
-            stream.filter(p -> p.toString().endsWith(".json"))
-                    .forEach(p -> {
-                        int seq = seqOf(p.getFileName().toString());
-                        if (seq >= 0 && seq >= fromSeq && seq <= toSeq) {
-                            try {
-                                Files.delete(p);
-                                log.fine("Deleted message file: " + p.getFileName());
-                            } catch (IOException e) {
-                                throw new UncheckedIOException(e);
-                            }
-                        }
-                    });
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    public Message append(ConversationId conversation, IntFunction<Message> create) {
+        return messages.append(conversation, seq -> create.apply(Math.toIntExact(seq)));
     }
 
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private Path messagesDir(ConversationId conversationId) {
-        return baseDir.resolve(conversationId.value()).resolve("messages");
-    }
-
-    private Path fileFor(Message message) {
-        String name = String.format("%010d_%s.json", message.sequenceNum(), message.id().value());
-        return messagesDir(message.conversationId()).resolve(name);
-    }
-
-    /** A message written before the namespace was recorded takes it from the conversation asked for. */
-    private Message read(Path file, ConversationId conversationId) {
-        try {
-            return objectMapper.readerFor(Message.class)
-                    .readValue(file.toFile());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    @Override
+    public void deleteBySequenceRange(ConversationId conversation, int fromSeq, int toSeq) {
+        messages.deleteKeyRange(conversation, fromSeq, toSeq);
     }
 }

--- a/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/memory/InMemoryMessageRepository.java
+++ b/agents/core/mc-message-repository/src/main/java/ai/mindconnect/message/adapter/memory/InMemoryMessageRepository.java
@@ -30,6 +30,18 @@ public class InMemoryMessageRepository implements MessageRepository {
         return message;
     }
 
+    /** Serialized with {@link #append}, so a change is applied to the message as it is stored. */
+    @Override
+    public synchronized Optional<Message> update(ConversationId conversation, MessageId id,
+                                                 java.util.function.UnaryOperator<Message> change) {
+        Optional<Message> current = findById(conversation, id);
+        if (current.isEmpty()) return Optional.empty();
+        Message changed = java.util.Objects.requireNonNull(change.apply(current.get()),
+                "update: the change returned null");
+        if (changed != current.get()) save(changed);
+        return Optional.of(changed);
+    }
+
     @Override
     public List<Message> findByConversation(ConversationId conversationId, PageRequest page) {
         return store.stream()

--- a/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/file/FileMessageRepositoryConcurrencyTest.java
+++ b/agents/core/mc-message-repository/src/test/java/ai/mindconnect/message/adapter/file/FileMessageRepositoryConcurrencyTest.java
@@ -24,24 +24,27 @@ import static org.assertj.core.api.Assertions.assertThat;
  * the history while its sibling tasks save their results and the turn updates
  * token counts. A reader must never see a half-written message file: that
  * surfaced as tool tasks failing without a result when sub-agents ran in
- * parallel ("No content to map due to end-of-input").
+ * parallel ("No content to map due to end-of-input"). And two changes of one
+ * message must not overwrite each other.
  */
 class FileMessageRepositoryConcurrencyTest {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
     @Test
-    void historyReadsWhileSavingNeverSeeAHalfWrittenMessage(@TempDir Path dir) throws Exception {
-        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        FileMessageRepository repo = new FileMessageRepository(dir, mapper, new Namespace("test"));
+    void historyReadsWhileUpdatingNeverSeeAHalfWrittenMessage(@TempDir Path dir) throws Exception {
+        FileMessageRepository repo = new FileMessageRepository(dir, MAPPER, new Namespace("test"));
         ConversationId conversation = ConversationId.random();
-        Message message = repo.save(Message.of(conversation, "agent", ParticipantType.AGENT,
-                MessageType.TOOL_RESULT, "x".repeat(20_000), 1));
+        Message message = repo.append(conversation, seq -> Message.of(conversation, "agent", ParticipantType.AGENT,
+                MessageType.TOOL_RESULT, "x".repeat(20_000), seq));
 
         AtomicBoolean writing = new AtomicBoolean(true);
         Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
         Thread writer = Thread.ofPlatform().start(() -> {
             try {
                 for (int i = 0; i < 400; i++) {
-                    repo.save(message.withTokenCount(i));
+                    int count = i;
+                    repo.update(conversation, message.id(), m -> m.withTokenCount(count));
                 }
             } catch (Throwable t) {
                 failures.add(t);
@@ -65,5 +68,60 @@ class FileMessageRepositoryConcurrencyTest {
         assertThat(failures).isEmpty();
         assertThat(reads).isPositive();
         assertThat(repo.findById(conversation, message.id())).map(Message::tokenCount).contains(399);
+    }
+
+    @Test
+    void aTokenCountAndADurationSetAtTheSameTimeBothLand(@TempDir Path dir) throws Exception {
+        FileMessageRepository repo = new FileMessageRepository(dir, MAPPER, new Namespace("test"));
+        ConversationId conversation = ConversationId.random();
+        Message message = repo.append(conversation, seq -> Message.of(conversation, "agent", ParticipantType.AGENT,
+                MessageType.TOOL_RESULT, "result", seq));
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+        Thread tokens = Thread.ofPlatform().start(() -> run(failures, () -> {
+            for (int i = 0; i < 200; i++) {
+                int count = i;
+                repo.update(conversation, message.id(), m -> m.withTokenCount(count));
+            }
+        }));
+        Thread durations = Thread.ofPlatform().start(() -> run(failures, () -> {
+            for (long i = 0; i < 200; i++) {
+                long ms = i;
+                repo.update(conversation, message.id(), m -> m.withDurationMs(ms));
+            }
+        }));
+        tokens.join();
+        durations.join();
+
+        assertThat(failures).isEmpty();
+        Message stored = repo.findById(conversation, message.id()).orElseThrow();
+        assertThat(stored.tokenCount()).isEqualTo(199);
+        assertThat(stored.durationMs()).isEqualTo(199L);
+    }
+
+    @Test
+    void theNewestMessagesDeletedDoNotHandTheirNumbersOutAgain(@TempDir Path dir) {
+        FileMessageRepository repo = new FileMessageRepository(dir, MAPPER, new Namespace("test"));
+        ConversationId conversation = ConversationId.random();
+        for (int i = 0; i < 5; i++) {
+            repo.append(conversation, seq -> Message.of(conversation, "user", ParticipantType.USER,
+                    MessageType.CHAT, "m" + seq, seq));
+        }
+
+        repo.deleteBySequenceRange(conversation, 4, 5);
+        Message next = repo.append(conversation, seq -> Message.of(conversation, "user", ParticipantType.USER,
+                MessageType.CHAT, "after", seq));
+
+        assertThat(next.sequenceNum()).isEqualTo(6);
+        assertThat(repo.findByConversation(conversation, new PageRequest(0, 10)))
+                .extracting(Message::sequenceNum).containsExactly(1, 2, 3, 6);
+    }
+
+    private static void run(Queue<Throwable> failures, Runnable body) {
+        try {
+            body.run();
+        } catch (Throwable t) {
+            failures.add(t);
+        }
     }
 }

--- a/agents/mc-agents-parent/pom.xml
+++ b/agents/mc-agents-parent/pom.xml
@@ -48,6 +48,11 @@
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-file-repo</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-llm-gateway-pg</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/agents/pom.xml
+++ b/agents/pom.xml
@@ -25,6 +25,7 @@
         <!-- shared modules pulled in so this area builds standalone -->
         <module>../common/mc-common</module>
         <module>../common/mc-jdbc</module>
+        <module>../common/mc-file-repo</module>
         <module>../taskqueue/mc-task-queue</module>
         <module>core/mc-agent-domain</module>
         <module>vectorstore/mc-vector-store</module>

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/TaskMonitorTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/TaskMonitorTest.java
@@ -70,7 +70,7 @@ class TaskMonitorTest {
                 "assistants", "bot", "prompt", null, "cfg", 5, null,
                 AgentDefinitionStatus.ACTIVE, List.of(), List.of(), null, null, null, null));
         var sessions = new InMemoryAgentSessionRepository();
-        sessions.save(new AgentSession(ALICE_SESSION, AGENT_ID, UserId.of("alice"), ConversationId.random(),
+        sessions.create(new AgentSession(ALICE_SESSION, AGENT_ID, UserId.of("alice"), ConversationId.random(),
                 "Alice asks", SessionStatus.ACTIVE, Instant.now(), null,
                 null, null, null, null, null, null, null));
 

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/UserStreamTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/UserStreamTest.java
@@ -89,7 +89,7 @@ class UserStreamTest {
                 "assistants", "bot", "prompt", null, "cfg", 5, null,
                 AgentDefinitionStatus.ACTIVE, List.of(), List.of(), null, null, null, null));
         var sessions = new InMemoryAgentSessionRepository();
-        sessions.save(new AgentSession(ALICE_SESSION, AGENT_ID, UserId.of("alice"), ConversationId.random(),
+        sessions.create(new AgentSession(ALICE_SESSION, AGENT_ID, UserId.of("alice"), ConversationId.random(),
                 "Alice asks", SessionStatus.ACTIVE, Instant.now(), null,
                 null, null, null, null, null, null, null));
         monitor = new TaskMonitor(queue, sessions, definitions);

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/AgentDetailActionUrlsTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/component/AgentDetailActionUrlsTest.java
@@ -36,7 +36,9 @@ class AgentDetailActionUrlsTest {
 
     /** Renders without a database: the detail header only asks for the session list. */
     private static final AgentSessionRepository NO_SESSIONS = new AgentSessionRepository() {
-        @Override public AgentSession save(AgentSession session) { throw new UnsupportedOperationException(); }
+        @Override public AgentSession create(AgentSession session) { throw new UnsupportedOperationException(); }
+        @Override public Optional<AgentSession> update(SessionId id,
+                java.util.function.UnaryOperator<AgentSession> change) { throw new UnsupportedOperationException(); }
         @Override public Optional<AgentSession> findById(SessionId id) { return Optional.empty(); }
         @Override public List<AgentSession> findByAgent(AgentId agent, UserId user) { return List.of(); }
         @Override public List<AgentSession> findByUser(UserId user) { return List.of(); }

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/service/SessionFileService.java
@@ -127,8 +127,7 @@ public class SessionFileService {
                 }
             }
         }
-        sessions.findById(sessionId).ifPresent(session ->
-                sessions.save(session.withoutAttachedFile(fileName)));
+        sessions.update(sessionId, session -> session.withoutAttachedFile(fileName));
     }
 
     /**
@@ -151,11 +150,9 @@ public class SessionFileService {
             // next message as an image part — or as that part's placeholder
             // when the model does not read images. Recorded on the session,
             // nothing else to do.
-            if (sessions.findById(sessionId).isEmpty()) {
+            if (sessions.update(sessionId, session -> session.withAttachedFiles(List.of(attached))).isEmpty()) {
                 return new AttachResult(stored, null, false, stored.name() + ": unknown session " + sessionId);
             }
-            sessions.findById(sessionId).ifPresent(session ->
-                    sessions.save(session.withAttachedFiles(List.of(attached))));
             activateViewer(sessionId);
             return new AttachResult(stored, null, true,
                     stored.name() + " attached — it goes to the model with your next message.");
@@ -228,8 +225,7 @@ public class SessionFileService {
             if (attached.isPdf()) activateViewer(sessionId);
             // Announce the file in the system prompt (rendered fresh each
             // round) so the model actually reaches for vector_search.
-            sessions.findById(sessionId).ifPresent(session ->
-                    sessions.save(session.withAttachedFiles(List.of(attached))));
+            sessions.update(sessionId, session -> session.withAttachedFiles(List.of(attached)));
             return new AttachResult(stored, storeName, true,
                     stored.name() + " attached — the agent can now search it.");
         } catch (Exception e) {

--- a/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/service/SessionOwnershipTest.java
+++ b/agents/server/mc-agent-chat-ui-rest/src/test/java/ai/mindconnect/chatui/service/SessionOwnershipTest.java
@@ -28,7 +28,7 @@ class SessionOwnershipTest {
     private final InMemoryAgentSessionRepository sessions = new InMemoryAgentSessionRepository();
     private final SessionOwnership ownership = new SessionOwnership(sessions);
 
-    private final AgentSession alices = sessions.save(
+    private final AgentSession alices = sessions.create(
             AgentSession.start(AgentId.of("default-chat"), UserId.of("alice"), ConversationId.random()));
 
     @Test
@@ -40,7 +40,7 @@ class SessionOwnershipTest {
 
     @Test
     void withoutAPrincipalTheRequestRunsAsTheDevUser() {
-        var devs = sessions.save(AgentSession.start(AgentId.of("default-chat"),
+        var devs = sessions.create(AgentSession.start(AgentId.of("default-chat"),
                 UserId.of(SessionOwnership.ANONYMOUS_USER), ConversationId.random()));
         assertThat(SessionOwnership.userIdOf(null)).isEqualTo(SessionOwnership.ANONYMOUS_USER);
         assertThat(ownership.owned(devs.id(), null)).contains(devs);

--- a/agents/vectorstore/mc-vector-store-tools/pom.xml
+++ b/agents/vectorstore/mc-vector-store-tools/pom.xml
@@ -19,10 +19,10 @@
         agents only ever handle text. The ingestion pipeline itself is a workflow seed.</description>
 
     <dependencies>
-        <!-- AtomicFiles: stored files are written whole or not at all. -->
+        <!-- FileWrites and PathLocks: registry files are written whole, one writer at a time. -->
         <dependency>
             <groupId>ai.mindconnect</groupId>
-            <artifactId>mc-common</artifactId>
+            <artifactId>mc-file-repo</artifactId>
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistry.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistry.java
@@ -1,6 +1,7 @@
 package ai.mindconnect.vectorstore.tools;
 
-import ai.mindconnect.common.util.AtomicFiles;
+import ai.mindconnect.filerepo.FileWrites;
+import ai.mindconnect.filerepo.PathLocks;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -22,6 +23,12 @@ import java.util.Optional;
  * {@code <root>/templates} and {@code <root>/instances}, following the same
  * conventions as the agent/workflow stores. Instances are registered on the
  * fly by the tools; templates are managed in the admin UI (or seeded).
+ *
+ * <p>A registry is built wherever vector stores are opened — by the app, by
+ * each tool binding, by an upload — so several instances work on the same
+ * files. Writes take the file's JVM-wide lock ({@link PathLocks}), which is
+ * what lets {@link #registerInstance} decide and write as one step: two
+ * uploads opening the same store register it once.
  */
 public final class FileVectorStoreRegistry {
 
@@ -66,10 +73,20 @@ public final class FileVectorStoreRegistry {
         return read(instancesDir, name, VectorStoreInstance.class);
     }
 
-    /** Registers the instance if unknown; an existing record wins (settings own the store). */
+    /**
+     * Registers the instance if unknown; an existing record wins (settings own the
+     * store). Looking and writing happen under the record's lock, so of two
+     * concurrent registrations of one name exactly one is written and both callers
+     * get it back.
+     */
     public VectorStoreInstance registerInstance(VectorStoreInstance candidate) {
-        return instance(candidate.name()).orElseGet(() -> {
-            write(instancesDir, candidate.name(), candidate);
+        Path file = fileFor(instancesDir, candidate.name());
+        return locked(file, () -> {
+            Optional<VectorStoreInstance> existing = read(instancesDir, candidate.name(), VectorStoreInstance.class);
+            if (existing.isPresent()) {
+                return existing.get();
+            }
+            store(file, candidate);
             log.info("Registered vector store '{}' from template '{}' (scope {})",
                     candidate.name(), candidate.templateName(), candidate.scope());
             return candidate;
@@ -128,19 +145,27 @@ public final class FileVectorStoreRegistry {
     }
 
     private void write(Path dir, String name, Object value) {
-        try {
-            Files.createDirectories(dir);
-            AtomicFiles.write(fileFor(dir, name), out -> MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, value));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Could not write " + fileFor(dir, name), e);
-        }
+        Path file = fileFor(dir, name);
+        locked(file, () -> {
+            store(file, value);
+            return null;
+        });
     }
 
     private void delete(Path dir, String name) {
+        Path file = fileFor(dir, name);
+        locked(file, () -> Files.deleteIfExists(file));
+    }
+
+    private static void store(Path file, Object value) throws IOException {
+        FileWrites.write(file, out -> MAPPER.writerWithDefaultPrettyPrinter().writeValue(out, value));
+    }
+
+    private static <T> T locked(Path file, PathLocks.Action<T> action) {
         try {
-            Files.deleteIfExists(fileFor(dir, name));
+            return PathLocks.withLock(file, PathLocks.DEFAULT_TIMEOUT, action);
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new UncheckedIOException("Could not write " + file, e);
         }
     }
 

--- a/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistryTest.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistryTest.java
@@ -1,0 +1,65 @@
+package ai.mindconnect.vectorstore.tools;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Two uploads into one chat open the same session store at the same moment,
+ * each through its own registry. The store is registered once, and both get
+ * that one record back.
+ */
+class FileVectorStoreRegistryTest {
+
+    @Test
+    void concurrentRegistrationsOfOneStoreAgreeOnOneRecord(@TempDir Path dir) throws Exception {
+        List<Future<VectorStoreInstance>> futures = new ArrayList<>();
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int i = 0; i < 50; i++) {
+                FileVectorStoreRegistry registry = new FileVectorStoreRegistry(dir.resolve("vector-stores"));
+                VectorStoreInstance candidate = new VectorStoreInstance("session-s1", "chat-uploads", "memory",
+                        Map.of(), "embeddings", null, Map.of("attempt", Integer.toString(i)),
+                        VectorStoreInstance.Scope.SESSION, "s1", "alice", Instant.now());
+                futures.add(pool.submit(() -> registry.registerInstance(candidate)));
+            }
+        }
+
+        VectorStoreInstance first = futures.get(0).get();
+        for (Future<VectorStoreInstance> future : futures) {
+            assertThat(future.get()).isEqualTo(first);
+        }
+        FileVectorStoreRegistry registry = new FileVectorStoreRegistry(dir.resolve("vector-stores"));
+        assertThat(registry.instance("session-s1")).contains(first);
+        try (var files = Files.list(dir.resolve("vector-stores/instances"))) {
+            assertThat(files).hasSize(1);
+        }
+    }
+
+    @Test
+    void templatesAndInstancesRoundTrip(@TempDir Path dir) {
+        FileVectorStoreRegistry registry = new FileVectorStoreRegistry(dir.resolve("vector-stores"));
+        VectorStoreTemplate template = new VectorStoreTemplate("Chat Uploads", "memory", Map.of(),
+                "embeddings", null, Map.of("description", "per chat"));
+
+        registry.saveTemplate(template);
+        VectorStoreInstance instance = registry.registerInstance(
+                VectorStoreInstance.fromTemplate("docs", template, VectorStoreInstance.Scope.GLOBAL, null));
+
+        assertThat(registry.template("Chat Uploads")).contains(template);
+        assertThat(registry.templates()).containsExactly(template);
+        assertThat(registry.instances(VectorStoreInstance.Scope.GLOBAL, null)).containsExactly(instance);
+        registry.deleteInstance("docs");
+        assertThat(registry.instance("docs")).isEmpty();
+    }
+}

--- a/agents/vectorstore/mc-vector-store/src/main/java/ai/mindconnect/vectorstore/memory/MemoryVectorStore.java
+++ b/agents/vectorstore/mc-vector-store/src/main/java/ai/mindconnect/vectorstore/memory/MemoryVectorStore.java
@@ -17,6 +17,8 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 /**
  * One store of the memory backend. Persistence is a JSONL file (one chunk per
@@ -24,6 +26,11 @@ import java.util.Map;
  * runs over vectors held on the heap, normalised at load time so cosine
  * similarity is a plain dot product. {@link #unloadIfIdleSince} drops the
  * heap copy — the file stays, the next access reloads.
+ *
+ * <p>Every operation holds one lock. A {@link ReentrantLock} rather than
+ * {@code synchronized}: loading, rewriting the file and scanning every vector
+ * all happen under it, and on Java 21 a virtual thread blocked inside
+ * {@code synchronized} pins its carrier thread for that long.
  */
 final class MemoryVectorStore implements VectorStore {
 
@@ -32,6 +39,7 @@ final class MemoryVectorStore implements VectorStore {
     private final String id;
     private final Path file;
     private final int maxChunks;
+    private final ReentrantLock lock = new ReentrantLock();
 
     /** Loaded chunks by id, vectors normalised; {@code null} = not loaded. */
     private Map<String, VectorChunk> loaded;
@@ -49,71 +57,92 @@ final class MemoryVectorStore implements VectorStore {
     }
 
     @Override
-    public synchronized void upsert(List<VectorChunk> chunks) {
-        Map<String, VectorChunk> current = ensureLoaded();
-        Integer dimension = current.values().stream().findFirst()
-                .map(c -> c.embedding().length).orElse(null);
-        for (VectorChunk chunk : chunks) {
-            if (chunk.embedding() == null || chunk.embedding().length == 0) {
-                throw new IllegalArgumentException("Chunk '" + chunk.id() + "' has no embedding");
+    public void upsert(List<VectorChunk> chunks) {
+        locked(() -> {
+            Map<String, VectorChunk> current = ensureLoaded();
+            Integer dimension = current.values().stream().findFirst()
+                    .map(c -> c.embedding().length).orElse(null);
+            for (VectorChunk chunk : chunks) {
+                if (chunk.embedding() == null || chunk.embedding().length == 0) {
+                    throw new IllegalArgumentException("Chunk '" + chunk.id() + "' has no embedding");
+                }
+                if (dimension == null) {
+                    dimension = chunk.embedding().length;
+                } else if (chunk.embedding().length != dimension) {
+                    throw new IllegalArgumentException("Chunk '" + chunk.id() + "' has dimension "
+                            + chunk.embedding().length + ", store '" + id + "' uses " + dimension);
+                }
+                current.put(chunk.id(), normalised(chunk));
             }
-            if (dimension == null) {
-                dimension = chunk.embedding().length;
-            } else if (chunk.embedding().length != dimension) {
-                throw new IllegalArgumentException("Chunk '" + chunk.id() + "' has dimension "
-                        + chunk.embedding().length + ", store '" + id + "' uses " + dimension);
+            if (current.size() > maxChunks) {
+                throw new IllegalStateException("Vector store '" + id + "' would exceed its memory-backend "
+                        + "limit of " + maxChunks + " chunks — use a server-side backend (pgvector) for "
+                        + "corpora of this size");
             }
-            current.put(chunk.id(), normalised(chunk));
-        }
-        if (current.size() > maxChunks) {
-            throw new IllegalStateException("Vector store '" + id + "' would exceed its memory-backend "
-                    + "limit of " + maxChunks + " chunks — use a server-side backend (pgvector) for "
-                    + "corpora of this size");
-        }
-        persist(current);
-    }
-
-    @Override
-    public synchronized List<SearchHit> search(float[] queryEmbedding, int topK) {
-        Map<String, VectorChunk> current = ensureLoaded();
-        float[] query = normalised(queryEmbedding.clone());
-        List<SearchHit> hits = new ArrayList<>();
-        for (VectorChunk chunk : current.values()) {
-            hits.add(new SearchHit(chunk, dot(query, chunk.embedding())));
-        }
-        hits.sort(Comparator.comparingDouble(SearchHit::score).reversed());
-        return hits.size() > topK ? List.copyOf(hits.subList(0, topK)) : hits;
-    }
-
-    @Override
-    public synchronized void deleteFile(String fileId) {
-        Map<String, VectorChunk> current = ensureLoaded();
-        if (current.values().removeIf(c -> fileId.equals(c.fileId()))) {
             persist(current);
-        }
+            return null;
+        });
     }
 
     @Override
-    public synchronized long chunkCount() {
-        return ensureLoaded().size();
+    public List<SearchHit> search(float[] queryEmbedding, int topK) {
+        return locked(() -> {
+            Map<String, VectorChunk> current = ensureLoaded();
+            float[] query = normalised(queryEmbedding.clone());
+            List<SearchHit> hits = new ArrayList<>();
+            for (VectorChunk chunk : current.values()) {
+                hits.add(new SearchHit(chunk, dot(query, chunk.embedding())));
+            }
+            hits.sort(Comparator.comparingDouble(SearchHit::score).reversed());
+            return hits.size() > topK ? List.copyOf(hits.subList(0, topK)) : hits;
+        });
     }
 
     @Override
-    public synchronized Map<String, Long> listFiles() {
-        Map<String, Long> files = new LinkedHashMap<>();
-        for (VectorChunk chunk : ensureLoaded().values()) {
-            files.merge(chunk.fileId(), 1L, Long::sum);
-        }
-        return files;
+    public void deleteFile(String fileId) {
+        locked(() -> {
+            Map<String, VectorChunk> current = ensureLoaded();
+            if (current.values().removeIf(c -> fileId.equals(c.fileId()))) {
+                persist(current);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public long chunkCount() {
+        return locked(() -> (long) ensureLoaded().size());
+    }
+
+    @Override
+    public Map<String, Long> listFiles() {
+        return locked(() -> {
+            Map<String, Long> files = new LinkedHashMap<>();
+            for (VectorChunk chunk : ensureLoaded().values()) {
+                files.merge(chunk.fileId(), 1L, Long::sum);
+            }
+            return files;
+        });
     }
 
     /** Drops the heap copy when unused since {@code cutoffMs}; file stays. */
-    synchronized boolean unloadIfIdleSince(long cutoffMs) {
-        if (loaded == null || lastUsedMs >= cutoffMs) {
-            return false;
+    boolean unloadIfIdleSince(long cutoffMs) {
+        return locked(() -> {
+            if (loaded == null || lastUsedMs >= cutoffMs) {
+                return false;
+            }
+            loaded = null;
+            return true;
+        });
+    }
+
+    private <T> T locked(Supplier<T> action) {
+        lock.lock();
+        try {
+            return action.get();
+        } finally {
+            lock.unlock();
         }
-        loaded = null;
-        return true;
     }
 
     // ── loading & persistence ──────────────────────────────────────────────

--- a/agents/vectorstore/mc-vector-store/src/test/java/ai/mindconnect/vectorstore/memory/MemoryVectorStoreConcurrencyTest.java
+++ b/agents/vectorstore/mc-vector-store/src/test/java/ai/mindconnect/vectorstore/memory/MemoryVectorStoreConcurrencyTest.java
@@ -1,0 +1,43 @@
+package ai.mindconnect.vectorstore.memory;
+
+import ai.mindconnect.vectorstore.VectorChunk;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Ingestion and search from many virtual threads at once: every chunk lands, every search answers. */
+class MemoryVectorStoreConcurrencyTest {
+
+    @Test
+    void concurrentUpsertsAndSearchesLoseNothing(@TempDir Path dir) throws Exception {
+        MemoryVectorStore store = new MemoryVectorStore("docs", dir.resolve("docs.jsonl"), 10_000);
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                int n = i;
+                futures.add(pool.submit(() -> store.upsert(List.of(chunk("file-" + n, n)))));
+                futures.add(pool.submit(() -> store.search(new float[]{1f, 0f, 0f}, 3)));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(store.chunkCount()).isEqualTo(100);
+        MemoryVectorStore reloaded = new MemoryVectorStore("docs", dir.resolve("docs.jsonl"), 10_000);
+        assertThat(reloaded.chunkCount()).as("every chunk made it into the file").isEqualTo(100);
+    }
+
+    private static VectorChunk chunk(String fileId, int n) {
+        return new VectorChunk("chunk-" + n, fileId, 0, "text " + n, Map.of(),
+                new float[]{1f, n, 0.5f});
+    }
+}

--- a/common/README.md
+++ b/common/README.md
@@ -21,6 +21,7 @@ used on its own — pull in just the one you need.
 | `mc-pathaccessor` | Navigate and read/write nested object & JSON paths |
 | `mc-script-mini` | Minimal embeddable script runner |
 | `mc-jdbc` | Tiny JDBC helper: JSONB document tables, typed rows, transactions — no ORM |
+| `mc-file-repo` | The file counterpart: JSON documents read without locks, written atomically, one writer per file across the JVM |
 
 ## Build
 

--- a/common/mc-file-repo/README.md
+++ b/common/mc-file-repo/README.md
@@ -1,0 +1,76 @@
+# mc-file-repo
+
+The file counterpart of [`mc-jdbc`](../mc-jdbc/README.md): domain objects
+stored as JSON documents in a directory tree, safe to read and write from
+many threads at once. Plain JDK and Jackson — no Spring, no database.
+
+```xml
+<dependency>
+    <groupId>ai.mindconnect</groupId>
+    <artifactId>mc-file-repo</artifactId>
+</dependency>
+```
+
+## What is in it
+
+| Class | Role |
+|-------|------|
+| `FileRepo` | One partition (a namespace) of a data directory — one instance per real path in a JVM; refuses a second process on the same partition and cleans up after interrupted writes |
+| `Documents<K, V>` | One JSON document per key: `find`, `findAll`, `create`, `createIfAbsent`, `update`, `put`, `delete` |
+| `PathLocks` | JVM-wide write locks by file path, one per thread, with a timeout |
+| `FileWrites` | Replace a file in one step: temporary file, then atomic move |
+
+## Documents
+
+```java
+FileRepo repo = FileRepo.open(Path.of("data"), namespace);    // data/<namespace>/
+
+Documents<SessionId, AgentSession> sessions = Documents.of(AgentSession.class)
+        .path((SessionId id) -> "sessions/" + id.value() + "/session.json")
+        .build(repo, objectMapper);
+
+sessions.create(id, session);                              // DocumentExistsException if there is one
+sessions.find(id);                                         // Optional<AgentSession>
+sessions.update(id, s -> s.withTitle("Weekly report"));    // read, change, write — one writer at a time
+sessions.findAll("sessions", "session.json");              // one document per subdirectory
+sessions.delete(id);
+```
+
+The path of a document follows from its key alone; a key that would lead out
+of the partition — into another namespace, say — is refused.
+
+## What it guarantees
+
+- **No half-written files.** Every write goes to a temporary file that is
+  moved over the target in one step. A reader holds the old version or the
+  new one, never a truncated file — so reading takes no lock.
+- **No lost updates.** `update` reads, changes and writes under the
+  document's write lock. Writers of one document take turns; writers of
+  different documents do not wait for each other.
+- **The lock is the path's, not the instance's.** Two `Documents` — or two
+  whole stores — on the same directory serialize against each other.
+- **An unreadable document throws.** It never passes for a missing one.
+
+## Rules for callers
+
+The functions given to `update` and `createIfAbsent` run under the lock. Build
+the new value and nothing else: no model call, no tool, no network, no event.
+
+A write started while the thread already holds a write lock throws
+`NestedWriteException` — that is how deadlocks are ruled out, so it signals a
+bug to fix, not a condition to retry. A lock that stays taken past the
+timeout (10 s by default, `lockTimeout(…)` per `Documents`) throws
+`LockTimeoutException` naming the thread that holds it.
+
+A partition is served by one process. A second process opening the same
+partition gets a `FileRepoException` — the operating-system lock on
+`<partition>/.mc-partition.lock` says so, and is released when the holder ends,
+crashes included. Other partitions of the same data directory stay free, so
+one process per namespace can share a data directory. Several nodes serving
+one namespace share a database instead.
+
+## Tests
+
+```bash
+mvn -f common/mc-file-repo/pom.xml test
+```

--- a/common/mc-file-repo/pom.xml
+++ b/common/mc-file-repo/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-java-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-java-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-file-repo</artifactId>
+    <name>mc-file-repo</name>
+    <packaging>jar</packaging>
+    <description>
+        The file counterpart of mc-jdbc: JSON documents in a directory tree,
+        read without locking and written atomically, one writer per file at a
+        time across the whole JVM. FileRepo (one per data directory), Documents
+        (one document per key), PathLocks and FileWrites. JDK and Jackson only.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/DocumentExistsException.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/DocumentExistsException.java
@@ -1,0 +1,18 @@
+package ai.mindconnect.filerepo;
+
+import java.nio.file.Path;
+
+/** {@link Documents#create} found a document under the key already. */
+public class DocumentExistsException extends FileRepoException {
+
+    private final transient Path file;
+
+    public DocumentExistsException(Path file) {
+        super("Document already exists: " + file);
+        this.file = file;
+    }
+
+    public Path file() {
+        return file;
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/Documents.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/Documents.java
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
  * value, nothing else — no model call, no tool, no network. Writing another
  * document from inside one throws {@link NestedWriteException}.
  */
-public final class Documents<K, V> {
+public class Documents<K, V> {
 
     private final FileRepo repo;
     private final Function<K, String> path;
@@ -240,7 +240,7 @@ public final class Documents<K, V> {
 
     // ── builder ─────────────────────────────────────────────────────────────
 
-    public static final class Builder<K, V> {
+    public static class Builder<K, V> {
 
         private final Class<V> type;
         private final Function<K, String> path;

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/Documents.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/Documents.java
@@ -1,0 +1,282 @@
+package ai.mindconnect.filerepo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+/**
+ * One JSON document per key, one file per document — the file counterpart of
+ * {@code DocumentTable} in {@code mc-jdbc}.
+ *
+ * <pre>{@code
+ * Documents<SessionId, AgentSession> sessions = Documents.of(AgentSession.class)
+ *         .path((SessionId id) -> "sessions/" + id.value() + "/session.json")
+ *         .build(FileRepo.open(dataDir, namespace), objectMapper);
+ *
+ * sessions.create(id, session);                              // refuses an existing one
+ * sessions.find(id);                                         // Optional, no lock
+ * sessions.update(id, s -> s.withTitle("Weekly report"));    // read-change-write, one writer at a time
+ * sessions.delete(id);
+ * }</pre>
+ *
+ * <p><b>Reading</b> takes no lock and never sees a half-written file. A missing
+ * document is {@code Optional.empty()}; an unreadable one throws — it never
+ * passes for "no document", which is how a store once rewrote a list it had
+ * failed to read as empty.
+ *
+ * <p><b>Writing</b> holds the file's {@link PathLocks write lock} for the length
+ * of one small write, so writers of the same document take turns and writers
+ * of different documents do not wait for each other. {@link #update} reads,
+ * changes and writes under that one lock: two concurrent updates both land,
+ * neither overwrites the other.
+ *
+ * <p>The functions handed to {@link #update} and {@link #createIfAbsent} run
+ * under the lock. Keep them short and free of side effects: build the new
+ * value, nothing else — no model call, no tool, no network. Writing another
+ * document from inside one throws {@link NestedWriteException}.
+ */
+public final class Documents<K, V> {
+
+    private final FileRepo repo;
+    private final Function<K, String> path;
+    private final ObjectReader reader;
+    private final ObjectWriter writer;
+    private final Duration lockTimeout;
+
+    private Documents(Builder<K, V> b, FileRepo repo, ObjectMapper mapper) {
+        this.repo = repo;
+        this.path = b.path;
+        this.reader = mapper.readerFor(b.type);
+        ObjectWriter w = mapper.writerFor(b.type);
+        this.writer = b.prettyPrint ? w.withDefaultPrettyPrinter() : w;
+        this.lockTimeout = b.lockTimeout;
+    }
+
+    public static <V> Builder<Object, V> of(Class<V> type) {
+        return new Builder<>(type, null, PathLocks.DEFAULT_TIMEOUT, false);
+    }
+
+    /** The file of the document under {@code key}. */
+    public Path pathOf(K key) {
+        return repo.resolve(path.apply(key));
+    }
+
+    // ── reading ─────────────────────────────────────────────────────────────
+
+    public Optional<V> find(K key) {
+        return read(pathOf(key));
+    }
+
+    public boolean exists(K key) {
+        return Files.exists(pathOf(key));
+    }
+
+    /**
+     * Every document stored as a {@code *.json} file directly in {@code dir}, by
+     * file name — for layouts like {@code agents/<id>.json}. Temporary files and
+     * documents deleted while listing are skipped.
+     */
+    public List<V> findAll(String dir) {
+        List<V> found = new ArrayList<>();
+        for (Path file : list(repo.resolve(dir))) {
+            String name = file.getFileName().toString();
+            if (name.endsWith(".json") && !name.startsWith(".") && Files.isRegularFile(file)) {
+                read(file).ifPresent(found::add);
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Every document stored as {@code fileName} in a subdirectory of {@code dir},
+     * by directory name — for layouts like {@code sessions/<id>/session.json}.
+     */
+    public List<V> findAll(String dir, String fileName) {
+        List<V> found = new ArrayList<>();
+        for (Path sub : list(repo.resolve(dir))) {
+            if (Files.isDirectory(sub)) {
+                read(sub.resolve(fileName)).ifPresent(found::add);
+            }
+        }
+        return found;
+    }
+
+    // ── writing ─────────────────────────────────────────────────────────────
+
+    /**
+     * Stores a new document.
+     *
+     * @throws DocumentExistsException when there is one under {@code key} already
+     */
+    public V create(K key, V value) {
+        Objects.requireNonNull(value, "value");
+        Path file = pathOf(key);
+        return locked(file, () -> {
+            if (Files.exists(file)) {
+                throw new DocumentExistsException(file);
+            }
+            store(file, value);
+            return value;
+        });
+    }
+
+    /**
+     * The document under {@code key}; if there is none, the one {@code value}
+     * builds, stored. Deciding and storing happen under one lock, so two callers
+     * racing for the same key end up with the same document.
+     */
+    public V createIfAbsent(K key, Supplier<V> value) {
+        Path file = pathOf(key);
+        return locked(file, () -> {
+            Optional<V> existing = read(file);
+            if (existing.isPresent()) {
+                return existing.get();
+            }
+            V created = Objects.requireNonNull(value.get(), "createIfAbsent: the supplier returned null");
+            store(file, created);
+            return created;
+        });
+    }
+
+    /**
+     * Reads the document, applies {@code change} and writes the result, all under
+     * the document's write lock — concurrent updates of one document take turns
+     * and each sees the result of the one before.
+     *
+     * <p>Returning the very instance it was given means "no change": nothing is
+     * written.
+     *
+     * @return the changed document, or empty when there is no document under {@code key}
+     */
+    public Optional<V> update(K key, UnaryOperator<V> change) {
+        Path file = pathOf(key);
+        return locked(file, () -> {
+            Optional<V> current = read(file);
+            if (current.isEmpty()) {
+                return Optional.<V>empty();
+            }
+            V changed = Objects.requireNonNull(change.apply(current.get()), "update: the change returned null");
+            if (changed != current.get()) {
+                store(file, changed);
+            }
+            return Optional.of(changed);
+        });
+    }
+
+    /**
+     * Stores {@code value} under {@code key}, replacing whatever is there. For
+     * documents that are rebuilt whole rather than changed — a snapshot, a list
+     * a tool replaces. For anything else, {@link #update} does not lose a
+     * concurrent change and this does.
+     */
+    public V put(K key, V value) {
+        Objects.requireNonNull(value, "value");
+        Path file = pathOf(key);
+        return locked(file, () -> {
+            store(file, value);
+            return value;
+        });
+    }
+
+    /** Deletes the document's file; its directory stays. Returns whether there was one. */
+    public boolean delete(K key) {
+        Path file = pathOf(key);
+        return locked(file, () -> Files.deleteIfExists(file));
+    }
+
+    // ── files ───────────────────────────────────────────────────────────────
+
+    private Optional<V> read(Path file) {
+        V value;
+        try (InputStream in = Files.newInputStream(file)) {
+            value = reader.readValue(in);
+        } catch (NoSuchFileException e) {
+            return Optional.empty();
+        } catch (IOException e) {
+            throw new FileRepoException("Cannot read document " + file, e);
+        }
+        if (value == null) {
+            throw new FileRepoException("Document " + file + " contains null");
+        }
+        return Optional.of(value);
+    }
+
+    private void store(Path file, V value) throws IOException {
+        FileWrites.write(file, out -> writer.writeValue(out, value));
+    }
+
+    private <T> T locked(Path file, PathLocks.Action<T> action) {
+        try {
+            return PathLocks.withLock(file, lockTimeout, action);
+        } catch (IOException e) {
+            throw new FileRepoException("Cannot write document " + file, e);
+        }
+    }
+
+    private static List<Path> list(Path dir) {
+        try (Stream<Path> entries = Files.list(dir)) {
+            return entries.sorted().toList();
+        } catch (NoSuchFileException e) {
+            return List.of();
+        } catch (IOException e) {
+            throw new FileRepoException("Cannot list " + dir, e);
+        }
+    }
+
+    // ── builder ─────────────────────────────────────────────────────────────
+
+    public static final class Builder<K, V> {
+
+        private final Class<V> type;
+        private final Function<K, String> path;
+        private final Duration lockTimeout;
+        private final boolean prettyPrint;
+
+        private Builder(Class<V> type, Function<K, String> path, Duration lockTimeout, boolean prettyPrint) {
+            this.type = type;
+            this.path = path;
+            this.lockTimeout = lockTimeout;
+            this.prettyPrint = prettyPrint;
+        }
+
+        /**
+         * Where the document of a key lives, relative to the data directory. It must
+         * follow from the key alone — that is what lets a write lock the right file
+         * without looking anything up. Give the lambda parameter its type:
+         * {@code .path((SessionId id) -> "sessions/" + id.value() + "/session.json")}.
+         */
+        public <K2> Builder<K2, V> path(Function<K2, String> path) {
+            return new Builder<>(type, Objects.requireNonNull(path, "path"), lockTimeout, prettyPrint);
+        }
+
+        /** How long a write waits for the document's lock; {@link PathLocks#DEFAULT_TIMEOUT} by default. */
+        public Builder<K, V> lockTimeout(Duration lockTimeout) {
+            return new Builder<>(type, path, Objects.requireNonNull(lockTimeout, "lockTimeout"), prettyPrint);
+        }
+
+        /** Indented JSON, for documents people read by hand. */
+        public Builder<K, V> prettyPrint() {
+            return new Builder<>(type, path, lockTimeout, true);
+        }
+
+        public Documents<K, V> build(FileRepo repo, ObjectMapper mapper) {
+            if (path == null) throw new IllegalStateException("path() is required");
+            return new Documents<>(this, Objects.requireNonNull(repo, "repo"), Objects.requireNonNull(mapper, "mapper"));
+        }
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepo.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepo.java
@@ -1,0 +1,167 @@
+package ai.mindconnect.filerepo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * One partition of a data directory — {@code <base>/<partition>}, where the
+ * partition is typically a namespace. There is exactly one instance per
+ * partition directory in a JVM: {@link #open} resolves the real path — a
+ * relative spelling, a {@code ..} or a symlink all lead to the same instance.
+ *
+ * <p>Opening a partition
+ * <ul>
+ *   <li>locks {@value #LOCK_FILE} in the partition directory with an
+ *       operating-system file lock, so a second process on the same partition
+ *       fails at once instead of quietly overwriting this one's files. The base
+ *       directory itself is never locked: processes serving different
+ *       partitions share it freely;</li>
+ *   <li>deletes, in the background, the temporary files of writes that a
+ *       crash interrupted ({@link FileWrites#isTemporary}), leaving any younger
+ *       than a minute alone because they may belong to a write in progress.</li>
+ * </ul>
+ *
+ * <p>The operating system releases the lock when the process ends, a crash
+ * included. Do not open {@value #LOCK_FILE} anywhere else: on POSIX systems
+ * closing any channel to the file releases the process's lock on it.
+ */
+public final class FileRepo {
+
+    private static final Logger log = LoggerFactory.getLogger(FileRepo.class);
+
+    static final String LOCK_FILE = ".mc-partition.lock";
+
+    private static final Duration STALE_TEMPORARY = Duration.ofMinutes(1);
+
+    private static final ConcurrentHashMap<Path, FileRepo> OPEN = new ConcurrentHashMap<>();
+
+    private final Path root;
+
+    @SuppressWarnings({"unused", "FieldCanBeLocal"}) // held for the lifetime of the JVM
+    private final FileLock processLock;
+
+    private FileRepo(Path root) {
+        this.root = root;
+        this.processLock = lockAgainstOtherProcesses(root);
+        Thread.ofVirtual().name("mc-file-repo-cleanup").start(() -> deleteTemporaryFilesOlderThan(STALE_TEMPORARY));
+    }
+
+    /**
+     * The partition {@code partition} of the data directory {@code base}, created
+     * if missing.
+     *
+     * @param partition one directory name — a namespace, typically; no separators, not {@code .} or {@code ..}
+     * @throws FileRepoException when another process has the partition open
+     */
+    public static FileRepo open(Path base, String partition) {
+        requireDirectoryName(partition);
+        Path real;
+        try {
+            Path dir = base.resolve(partition);
+            Files.createDirectories(dir);
+            real = dir.toRealPath();
+        } catch (IOException e) {
+            throw new FileRepoException("Cannot open partition '" + partition + "' of data directory " + base, e);
+        }
+        return OPEN.computeIfAbsent(real, FileRepo::new);
+    }
+
+    /** The real path of the partition directory. */
+    public Path root() {
+        return root;
+    }
+
+    /**
+     * {@code relative} resolved against the partition directory. A path that leads
+     * out of it — {@code ../other-namespace/…}, an absolute path — is refused:
+     * keys come from ids, and ids come from requests.
+     */
+    public Path resolve(String relative) {
+        Path file = root.resolve(relative).normalize();
+        if (!file.startsWith(root)) {
+            throw new IllegalArgumentException("Path leads out of the partition " + root + ": " + relative);
+        }
+        return file;
+    }
+
+    /** Deletes the temporary files of interrupted writes that are older than {@code age}; returns how many. */
+    int deleteTemporaryFilesOlderThan(Duration age) {
+        Instant cutoff = Instant.now().minus(age);
+        int[] deleted = {0};
+        try {
+            Files.walkFileTree(root, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (FileWrites.isTemporary(file) && attrs.lastModifiedTime().toInstant().isBefore(cutoff)) {
+                        try {
+                            if (Files.deleteIfExists(file)) deleted[0]++;
+                        } catch (IOException e) {
+                            log.warn("Could not delete leftover temporary file {}: {}", file, e.getMessage());
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException e) {
+                    return FileVisitResult.CONTINUE;   // deleted while walking — nothing to clean there
+                }
+            });
+        } catch (IOException e) {
+            log.warn("Could not look for leftover temporary files in {}: {}", root, e.getMessage());
+        }
+        if (deleted[0] > 0) {
+            log.info("Deleted {} temporary file(s) of interrupted writes in {}", deleted[0], root);
+        }
+        return deleted[0];
+    }
+
+    private static void requireDirectoryName(String partition) {
+        if (partition == null || partition.isBlank() || partition.equals(".") || partition.equals("..")
+                || partition.contains("/") || partition.contains("\\")) {
+            throw new IllegalArgumentException("A partition is one directory name, got: " + partition);
+        }
+    }
+
+    private static FileLock lockAgainstOtherProcesses(Path root) {
+        Path lockFile = root.resolve(LOCK_FILE);
+        FileChannel channel = null;
+        try {
+            channel = FileChannel.open(lockFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            FileLock lock = channel.tryLock();
+            if (lock == null) {
+                channel.close();
+                throw new FileRepoException("Partition " + root + " is in use by another process ("
+                        + LOCK_FILE + " is locked). One process serves a partition; stop the other one "
+                        + "or give this one a partition of its own.");
+            }
+            return lock;
+        } catch (IOException | OverlappingFileLockException e) {
+            closeQuietly(channel);
+            throw new FileRepoException("Cannot lock partition " + root + " via " + lockFile, e);
+        }
+    }
+
+    private static void closeQuietly(FileChannel channel) {
+        if (channel == null) return;
+        try {
+            channel.close();
+        } catch (IOException ignored) {
+            // nothing left to release
+        }
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepo.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepo.java
@@ -15,6 +15,9 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -49,10 +52,25 @@ public final class FileRepo {
 
     private static final ConcurrentHashMap<Path, FileRepo> OPEN = new ConcurrentHashMap<>();
 
+    /** How many {@link RecordLog} directories keep their index in memory; the least recently used go first. */
+    private static final int MAX_LOG_STATES = 1024;
+
     private final Path root;
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"}) // held for the lifetime of the JVM
     private final FileLock processLock;
+
+    /**
+     * The indexes of the {@link RecordLog} directories, shared by every log on this
+     * partition. A dropped index is read again from the file names on next use.
+     */
+    private final Map<Path, LogState> logStates = Collections.synchronizedMap(
+            new LinkedHashMap<>(64, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<Path, LogState> eldest) {
+                    return size() > MAX_LOG_STATES;
+                }
+            });
 
     private FileRepo(Path root) {
         this.root = root;
@@ -96,6 +114,19 @@ public final class FileRepo {
             throw new IllegalArgumentException("Path leads out of the partition " + root + ": " + relative);
         }
         return file;
+    }
+
+    LogState logState(Path dir) {
+        return logStates.get(dir);
+    }
+
+    void putLogState(Path dir, LogState state) {
+        logStates.put(dir, state);
+    }
+
+    /** Drops every in-memory index, as a restart would. */
+    void forgetLogStates() {
+        logStates.clear();
     }
 
     /** Deletes the temporary files of interrupted writes that are older than {@code age}; returns how many. */

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepo.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepo.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * included. Do not open {@value #LOCK_FILE} anywhere else: on POSIX systems
  * closing any channel to the file releases the process's lock on it.
  */
-public final class FileRepo {
+public class FileRepo {
 
     private static final Logger log = LoggerFactory.getLogger(FileRepo.class);
 

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepoException.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileRepoException.java
@@ -1,0 +1,13 @@
+package ai.mindconnect.filerepo;
+
+/** The unchecked exception this library throws; where an {@code IOException} caused it, that is the cause. */
+public class FileRepoException extends RuntimeException {
+
+    public FileRepoException(String message) {
+        super(message);
+    }
+
+    public FileRepoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileWrites.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileWrites.java
@@ -22,7 +22,7 @@ import java.nio.file.StandardCopyOption;
  * {@code .tmp}; {@link #isTemporary} recognises it, and {@link FileRepo}
  * deletes the ones a crash left behind.
  */
-public final class FileWrites {
+public class FileWrites {
 
     /** Writes the content into the stream it is handed; the stream is closed afterwards either way. */
     @FunctionalInterface

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileWrites.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/FileWrites.java
@@ -1,0 +1,69 @@
+package ai.mindconnect.filerepo;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Writes a file so that nobody ever reads it half-written.
+ *
+ * <p>The content goes into a temporary file beside the target, and that file is
+ * moved over the target in one step. A reader sees the old content or the new,
+ * never an empty or truncated file. Every replacement is a new file, which is
+ * also why a reader needs no lock: the file it opened stays whole even while
+ * the next version is moved into place.
+ *
+ * <p>This covers torn reads, not lost updates — serializing writers is
+ * {@link PathLocks}' job. The temporary file starts with a dot and ends in
+ * {@code .tmp}; {@link #isTemporary} recognises it, and {@link FileRepo}
+ * deletes the ones a crash left behind.
+ */
+public final class FileWrites {
+
+    /** Writes the content into the stream it is handed; the stream is closed afterwards either way. */
+    @FunctionalInterface
+    public interface Content {
+        void writeTo(OutputStream out) throws IOException;
+    }
+
+    private static final String TEMP_SUFFIX = ".tmp";
+
+    private FileWrites() {
+    }
+
+    /** Replaces {@code target} with what {@code content} writes, creating the parent directories. */
+    public static void write(Path target, Content content) throws IOException {
+        Path file = target.toAbsolutePath();
+        Path dir = file.getParent();
+        Files.createDirectories(dir);
+        Path tmp = Files.createTempFile(dir, "." + file.getFileName() + ".", TEMP_SUFFIX);
+        try {
+            try (OutputStream out = Files.newOutputStream(tmp)) {
+                content.writeTo(out);
+            }
+            try {
+                Files.move(tmp, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                // A file system without atomic rename: still better than truncating in place.
+                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    /** Replaces {@code target} with {@code text}, UTF-8. */
+    public static void writeString(Path target, String text) throws IOException {
+        write(target, out -> out.write(text.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /** Whether {@code file} is the temporary file of a write — in progress, or left behind by a crash. */
+    public static boolean isTemporary(Path file) {
+        String name = file.getFileName().toString();
+        return name.startsWith(".") && name.endsWith(TEMP_SUFFIX);
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/LockTimeoutException.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/LockTimeoutException.java
@@ -1,0 +1,16 @@
+package ai.mindconnect.filerepo;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+/**
+ * The write lock on a file stayed taken longer than the timeout. A write holds
+ * its lock for one small file, so this means something hangs while holding it;
+ * the message names the thread that did.
+ */
+public class LockTimeoutException extends FileRepoException {
+
+    public LockTimeoutException(Path file, Duration timeout, String holder) {
+        super("No write lock on " + file + " within " + timeout + " — held by " + holder);
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/LogState.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/LogState.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
  * ever handed out. Immutable — a writer publishes a new state, a reader keeps
  * the one it took.
  */
-final class LogState {
+class LogState {
 
     /** The file that keeps the highest key once the records holding it are deleted. */
     static final String SEQUENCE_FILE = ".sequence";

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/LogState.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/LogState.java
@@ -1,0 +1,120 @@
+package ai.mindconnect.filerepo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * What a {@link RecordLog} knows about one directory without opening a record:
+ * the record files in key order, which file holds which id, and the highest key
+ * ever handed out. Immutable — a writer publishes a new state, a reader keeps
+ * the one it took.
+ */
+final class LogState {
+
+    /** The file that keeps the highest key once the records holding it are deleted. */
+    static final String SEQUENCE_FILE = ".sequence";
+
+    private static final Pattern RECORD_FILE = Pattern.compile("(\\d+)_(.+)\\.json");
+
+    record Entry(long key, String id, String fileName) { }
+
+    private final List<Entry> entries;
+    private final Map<String, Entry> byId;
+    private final long highWater;
+
+    private LogState(List<Entry> entries, long highWater) {
+        this.entries = List.copyOf(entries);
+        this.byId = new HashMap<>();
+        for (Entry e : this.entries) byId.put(e.id(), e);
+        this.highWater = highWater;
+    }
+
+    /** Lists the directory; a directory that does not exist yet is an empty log. */
+    static LogState load(Path dir) throws IOException {
+        List<Entry> entries = new ArrayList<>();
+        long highWater = 0;
+        List<Path> files;
+        try (Stream<Path> listing = Files.list(dir)) {
+            files = listing.toList();
+        } catch (NoSuchFileException e) {
+            files = List.of();
+        }
+        for (Path file : files) {
+            Entry entry = parse(file.getFileName().toString());
+            if (entry != null) {
+                entries.add(entry);
+                highWater = Math.max(highWater, entry.key());
+            }
+        }
+        Path sequence = dir.resolve(SEQUENCE_FILE);
+        try {
+            highWater = Math.max(highWater, Long.parseLong(Files.readString(sequence).trim()));
+        } catch (NoSuchFileException e) {
+            // no deleted tail to remember
+        } catch (NumberFormatException e) {
+            throw new FileRepoException("Unreadable " + sequence, e);
+        }
+        entries.sort(Comparator.comparing(Entry::fileName));
+        return new LogState(entries, highWater);
+    }
+
+    /** The entry a record file name stands for, or null for any other file — temporary files included. */
+    static Entry parse(String fileName) {
+        if (fileName.startsWith(".")) return null;
+        Matcher m = RECORD_FILE.matcher(fileName);
+        if (!m.matches()) return null;
+        try {
+            return new Entry(Long.parseLong(m.group(1)), m.group(2), fileName);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    List<Entry> entries() {
+        return entries;
+    }
+
+    Entry byId(String id) {
+        return byId.get(id);
+    }
+
+    long highWater() {
+        return highWater;
+    }
+
+    /** This state with {@code entry} in it, replacing an earlier entry of the same id. */
+    LogState with(Entry entry) {
+        List<Entry> next = new ArrayList<>(entries.size() + 1);
+        for (Entry e : entries) {
+            if (!e.id().equals(entry.id())) next.add(e);
+        }
+        int at = 0;
+        while (at < next.size() && next.get(at).fileName().compareTo(entry.fileName()) < 0) at++;
+        next.add(at, entry);
+        return new LogState(next, Math.max(highWater, entry.key()));
+    }
+
+    /** This state without {@code removed}; the highest key stays where it was. */
+    LogState without(Collection<Entry> removed) {
+        Set<String> gone = new HashSet<>();
+        for (Entry e : removed) gone.add(e.fileName());
+        List<Entry> next = new ArrayList<>(entries.size());
+        for (Entry e : entries) {
+            if (!gone.contains(e.fileName())) next.add(e);
+        }
+        return new LogState(next, highWater);
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/NestedWriteException.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/NestedWriteException.java
@@ -1,0 +1,20 @@
+package ai.mindconnect.filerepo;
+
+import java.nio.file.Path;
+
+/**
+ * A thread asked for a write lock while it already held one — typically a
+ * store written from inside an {@link Documents#update update} function.
+ *
+ * <p>This is a programming error, not a condition to retry: two threads that
+ * each hold one lock and wait for the other's are a deadlock, and refusing the
+ * second lock outright is what makes that impossible. Move the second write
+ * after the first one returns.
+ */
+public class NestedWriteException extends FileRepoException {
+
+    public NestedWriteException(Path requested, Path held) {
+        super("Write to " + requested + " requested while this thread holds the write lock on " + held
+                + " — write it after the first write has returned");
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/PathLocks.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/PathLocks.java
@@ -33,7 +33,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * step, so a reader always holds a whole version. {@code ReentrantLock} rather
  * than {@code synchronized} lets a waiting virtual thread unmount from its carrier.
  */
-public final class PathLocks {
+public class PathLocks {
 
     /** The action run under the lock. */
     @FunctionalInterface
@@ -102,7 +102,7 @@ public final class PathLocks {
     }
 
     /** A fair lock that tells who holds it. */
-    private static final class OwnedLock extends ReentrantLock {
+    private static class OwnedLock extends ReentrantLock {
 
         OwnedLock() {
             super(true);

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/PathLocks.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/PathLocks.java
@@ -1,0 +1,115 @@
+package ai.mindconnect.filerepo;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Write locks by file path, shared by the whole JVM.
+ *
+ * <p>The lock belongs to the path, not to whoever writes it: two store
+ * instances on the same directory — built by two runtimes, or opened afresh
+ * by a tool — serialize against each other without knowing of each other.
+ * Paths map onto a fixed set of lock stripes, so nothing grows and nothing
+ * needs cleaning up; two paths sharing a stripe merely wait for each other
+ * for the length of one small write.
+ *
+ * <p>Three rules keep this free of deadlocks and hangs:
+ * <ul>
+ *   <li><b>One write lock per thread.</b> Asking for a second one while
+ *       holding the first throws {@link NestedWriteException}. No thread
+ *       ever waits while holding a lock, so no two threads can wait for
+ *       each other.</li>
+ *   <li><b>Waiting has a limit.</b> A lock still taken after the timeout
+ *       throws {@link LockTimeoutException} naming the holder, instead of
+ *       parking the caller forever.</li>
+ *   <li><b>Fair order.</b> Waiting writers get the lock in arrival order, so
+ *       under a burst no writer times out while later ones keep cutting in.</li>
+ * </ul>
+ *
+ * <p>Readers take no lock at all; {@link FileWrites} replaces a file in one
+ * step, so a reader always holds a whole version. {@code ReentrantLock} rather
+ * than {@code synchronized} lets a waiting virtual thread unmount from its carrier.
+ */
+public final class PathLocks {
+
+    /** The action run under the lock. */
+    @FunctionalInterface
+    public interface Action<T> {
+        T run() throws IOException;
+    }
+
+    /** How long a writer waits by default before {@link LockTimeoutException}. */
+    public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
+
+    static final int STRIPES = 4096;
+
+    private static final OwnedLock[] LOCKS = new OwnedLock[STRIPES];
+
+    static {
+        for (int i = 0; i < STRIPES; i++) {
+            LOCKS[i] = new OwnedLock();
+        }
+    }
+
+    private static final ThreadLocal<Path> HELD = new ThreadLocal<>();
+
+    private PathLocks() {
+    }
+
+    /**
+     * Runs {@code action} holding the write lock of {@code file}.
+     *
+     * @throws NestedWriteException  when this thread already holds a write lock
+     * @throws LockTimeoutException  when the lock stays taken for {@code timeout}
+     */
+    public static <T> T withLock(Path file, Duration timeout, Action<T> action) throws IOException {
+        Path key = file.toAbsolutePath().normalize();
+        Path held = HELD.get();
+        if (held != null) {
+            throw new NestedWriteException(key, held);
+        }
+        OwnedLock lock = LOCKS[stripeOf(key)];
+        boolean acquired;
+        try {
+            acquired = lock.tryLock(timeout.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new FileRepoException("Interrupted while waiting for the write lock on " + key, e);
+        }
+        if (!acquired) {
+            Thread owner = lock.owner();
+            throw new LockTimeoutException(key, timeout, owner == null ? "nobody any more" : owner.toString());
+        }
+        HELD.set(key);
+        try {
+            return action.run();
+        } finally {
+            HELD.remove();
+            lock.unlock();
+        }
+    }
+
+    /** Whether the current thread is inside {@link #withLock}. */
+    public static boolean isHeldByCurrentThread() {
+        return HELD.get() != null;
+    }
+
+    static int stripeOf(Path file) {
+        return Math.floorMod(file.toAbsolutePath().normalize().hashCode(), STRIPES);
+    }
+
+    /** A fair lock that tells who holds it. */
+    private static final class OwnedLock extends ReentrantLock {
+
+        OwnedLock() {
+            super(true);
+        }
+
+        Thread owner() {
+            return getOwner();
+        }
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/RecordLog.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/RecordLog.java
@@ -58,7 +58,7 @@ import java.util.function.UnaryOperator;
  * <p>The function given to {@link #append} and {@link #update} runs under the
  * lock: build the record, nothing else.
  */
-public final class RecordLog<P, R> {
+public class RecordLog<P, R> {
 
     private final FileRepo repo;
     private final Function<P, String> dir;
@@ -325,7 +325,7 @@ public final class RecordLog<P, R> {
 
     // ── builder ─────────────────────────────────────────────────────────────
 
-    public static final class Builder<P, R> {
+    public static class Builder<P, R> {
 
         private final Class<R> type;
         private Function<P, String> dir;

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/RecordLog.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/RecordLog.java
@@ -1,0 +1,390 @@
+package ai.mindconnect.filerepo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.LongFunction;
+import java.util.function.ToLongFunction;
+import java.util.function.UnaryOperator;
+
+/**
+ * An ordered log of records under a parent key — the messages of a
+ * conversation, its summaries — one JSON file per record, named by the record's
+ * key and id: {@code 0000000012_<id>.json}.
+ *
+ * <pre>{@code
+ * RecordLog<ConversationId, Message> messages = RecordLog.of(Message.class)
+ *         .dir((ConversationId c) -> "conversations/" + c.value() + "/messages")
+ *         .key(Message::sequenceNum)
+ *         .id(m -> m.id().value())
+ *         .build(FileRepo.open(dataDir, namespace), objectMapper);
+ *
+ * messages.append(conversation, seq -> Message.of(…, (int) seq));   // the next key, handed out under the lock
+ * messages.page(conversation, 0, 50);
+ * messages.update(conversation, id, m -> m.withTokenCount(42));
+ * messages.deleteKeyRange(conversation, 10, 15);
+ * }</pre>
+ *
+ * <p><b>The index.</b> What files a directory holds — keys, ids, the highest key
+ * ever handed out — lives in memory beside the {@link FileRepo}, shared by
+ * every log on that directory in the JVM. It is read from the file names once,
+ * under the directory's write lock, and every write publishes the next version.
+ * Appending therefore lists nothing, a page reads only its own records, and
+ * finding a record by id opens exactly one file. A long log is not held in
+ * memory, only its names.
+ *
+ * <p><b>Reading</b> takes no lock once the index is there, and never sees a
+ * half-written record. <b>Writing</b> — append, put, update, delete — holds the
+ * directory's write lock ({@link PathLocks}): records of one parent are written
+ * one at a time, different parents in parallel.
+ *
+ * <p><b>Keys are never handed out twice.</b> When the records holding the
+ * highest key are deleted, that key is kept in {@value LogState#SEQUENCE_FILE}
+ * beside them, so the next append continues above it — also after a restart.
+ *
+ * <p>The function given to {@link #append} and {@link #update} runs under the
+ * lock: build the record, nothing else.
+ */
+public final class RecordLog<P, R> {
+
+    private final FileRepo repo;
+    private final Function<P, String> dir;
+    private final ToLongFunction<R> key;
+    private final Function<R, String> id;
+    private final int keyWidth;
+    private final ObjectReader reader;
+    private final ObjectWriter writer;
+    private final Duration lockTimeout;
+
+    private RecordLog(Builder<P, R> b, FileRepo repo, ObjectMapper mapper) {
+        this.repo = repo;
+        this.dir = b.dir;
+        this.key = b.key;
+        this.id = b.id;
+        this.keyWidth = b.keyWidth;
+        this.reader = mapper.readerFor(b.type);
+        ObjectWriter w = mapper.writerFor(b.type);
+        this.writer = b.prettyPrint ? w.withDefaultPrettyPrinter() : w;
+        this.lockTimeout = b.lockTimeout;
+    }
+
+    public static <R> Builder<Object, R> of(Class<R> type) {
+        return new Builder<>(type);
+    }
+
+    /** The directory holding the records of {@code parent}. */
+    public Path dirOf(P parent) {
+        return repo.resolve(dir.apply(parent));
+    }
+
+    // ── reading ─────────────────────────────────────────────────────────────
+
+    /** Up to {@code limit} records in key order, skipping the first {@code offset}. */
+    public List<R> page(P parent, long offset, int limit) {
+        if (offset < 0 || limit < 0) {
+            throw new IllegalArgumentException("offset and limit must not be negative");
+        }
+        Path d = dirOf(parent);
+        List<LogState.Entry> entries = state(d).entries();
+        int from = (int) Math.min(offset, entries.size());
+        int to = (int) Math.min((long) from + limit, entries.size());
+        return read(d, entries.subList(from, to));
+    }
+
+    /** Every record, in key order. */
+    public List<R> all(P parent) {
+        Path d = dirOf(parent);
+        return read(d, state(d).entries());
+    }
+
+    public Optional<R> find(P parent, String recordId) {
+        Path d = dirOf(parent);
+        LogState.Entry entry = state(d).byId(recordId);
+        return entry == null ? Optional.empty() : read(d.resolve(entry.fileName()));
+    }
+
+    public int count(P parent) {
+        return state(dirOf(parent)).entries().size();
+    }
+
+    // ── writing ─────────────────────────────────────────────────────────────
+
+    /**
+     * Stores the record {@code create} builds for the next key — one above the
+     * highest ever handed out in this log. Two appends never get the same key.
+     *
+     * @throws IllegalStateException when the record does not carry the key it was handed
+     */
+    public R append(P parent, LongFunction<R> create) {
+        Path d = dirOf(parent);
+        return locked(d, () -> {
+            LogState state = loaded(d);
+            long next = state.highWater() + 1;
+            R record = Objects.requireNonNull(create.apply(next), "append: the record was null");
+            if (key.applyAsLong(record) != next) {
+                throw new IllegalStateException("append: the record must carry the key it was handed ("
+                        + next + "), it carries " + key.applyAsLong(record));
+            }
+            store(d, state, record);
+            return record;
+        });
+    }
+
+    /**
+     * Stores {@code record} under its own key, replacing the record of the same
+     * id — for importing, and for records whose key is their own (a summary's
+     * first message, say). To change a stored record, use {@link #update}.
+     */
+    public R put(P parent, R record) {
+        Objects.requireNonNull(record, "record");
+        Path d = dirOf(parent);
+        return locked(d, () -> {
+            store(d, loaded(d), record);
+            return record;
+        });
+    }
+
+    /**
+     * Reads the record, applies {@code change} and writes the result under the
+     * directory's lock. Returning the given instance writes nothing.
+     *
+     * @return the changed record, or empty when there is none with this id
+     * @throws IllegalStateException when the change alters the record's key or id
+     */
+    public Optional<R> update(P parent, String recordId, UnaryOperator<R> change) {
+        Path d = dirOf(parent);
+        return locked(d, () -> {
+            LogState.Entry entry = loaded(d).byId(recordId);
+            if (entry == null) {
+                return Optional.<R>empty();
+            }
+            Path file = d.resolve(entry.fileName());
+            Optional<R> current = read(file);
+            if (current.isEmpty()) {
+                return Optional.<R>empty();
+            }
+            R changed = Objects.requireNonNull(change.apply(current.get()), "update: the change returned null");
+            if (changed != current.get()) {
+                if (key.applyAsLong(changed) != entry.key() || !entry.id().equals(id.apply(changed))) {
+                    throw new IllegalStateException("update must not change the key or id of " + file);
+                }
+                FileWrites.write(file, out -> writer.writeValue(out, changed));
+            }
+            return Optional.of(changed);
+        });
+    }
+
+    /** Deletes the records whose key lies in [{@code fromKey}, {@code toKey}]; returns how many. */
+    public int deleteKeyRange(P parent, long fromKey, long toKey) {
+        Path d = dirOf(parent);
+        return locked(d, () -> {
+            LogState state = loaded(d);
+            return remove(d, state, state.entries().stream()
+                    .filter(e -> e.key() >= fromKey && e.key() <= toKey)
+                    .toList());
+        });
+    }
+
+    /** Deletes all but the {@code keep} records with the highest keys; returns how many went. */
+    public int retainLast(P parent, int keep) {
+        Path d = dirOf(parent);
+        return locked(d, () -> {
+            LogState state = loaded(d);
+            List<LogState.Entry> entries = state.entries();
+            return remove(d, state, entries.subList(0, Math.max(0, entries.size() - Math.max(0, keep))));
+        });
+    }
+
+    /** Deletes every record of {@code parent}; returns how many. */
+    public int deleteAll(P parent) {
+        Path d = dirOf(parent);
+        return locked(d, () -> {
+            LogState state = loaded(d);
+            return remove(d, state, state.entries());
+        });
+    }
+
+    // ── index and files ─────────────────────────────────────────────────────
+
+    /**
+     * The index for reading. Loaded under the directory's lock the first time —
+     * unless this thread is inside a write already, where taking a second lock is
+     * refused; then the directory is listed for this one read.
+     */
+    private LogState state(Path d) {
+        LogState state = repo.logState(d);
+        if (state != null) {
+            return state;
+        }
+        if (PathLocks.isHeldByCurrentThread()) {
+            try {
+                return LogState.load(d);
+            } catch (IOException e) {
+                throw new FileRepoException("Cannot list " + d, e);
+            }
+        }
+        return locked(d, () -> loaded(d));
+    }
+
+    /** The index, loading and publishing it if needed. The caller holds the directory's lock. */
+    private LogState loaded(Path d) throws IOException {
+        LogState state = repo.logState(d);
+        if (state == null) {
+            state = LogState.load(d);
+            repo.putLogState(d, state);
+        }
+        return state;
+    }
+
+    private void store(Path d, LogState state, R record) throws IOException {
+        long k = key.applyAsLong(record);
+        String recordId = id.apply(record);
+        String name = fileName(k, recordId);
+        FileWrites.write(d.resolve(name), out -> writer.writeValue(out, record));
+        LogState.Entry previous = state.byId(recordId);
+        if (previous != null && !previous.fileName().equals(name)) {
+            Files.deleteIfExists(d.resolve(previous.fileName()));
+        }
+        repo.putLogState(d, state.with(new LogState.Entry(k, recordId, name)));
+    }
+
+    private int remove(Path d, LogState state, List<LogState.Entry> gone) throws IOException {
+        if (gone.isEmpty()) {
+            return 0;
+        }
+        if (gone.stream().anyMatch(e -> e.key() == state.highWater())) {
+            // Written before the files go: a crash in between still remembers the key.
+            FileWrites.writeString(d.resolve(LogState.SEQUENCE_FILE), Long.toString(state.highWater()));
+        }
+        for (LogState.Entry e : gone) {
+            Files.deleteIfExists(d.resolve(e.fileName()));
+        }
+        repo.putLogState(d, state.without(gone));
+        return gone.size();
+    }
+
+    private String fileName(long k, String recordId) {
+        if (k < 0) {
+            throw new IllegalArgumentException("A record key must not be negative: " + k);
+        }
+        String digits = Long.toString(k);
+        if (digits.length() > keyWidth) {
+            throw new IllegalArgumentException("Key " + k + " is wider than " + keyWidth + " digits");
+        }
+        if (recordId == null || recordId.isEmpty() || recordId.contains("/") || recordId.contains("\\")
+                || recordId.startsWith(".")) {
+            throw new IllegalArgumentException("A record id must be usable in a file name: " + recordId);
+        }
+        return "0".repeat(keyWidth - digits.length()) + digits + "_" + recordId + ".json";
+    }
+
+    private List<R> read(Path d, List<LogState.Entry> entries) {
+        List<R> records = new ArrayList<>(entries.size());
+        for (LogState.Entry e : entries) {
+            read(d.resolve(e.fileName())).ifPresent(records::add);
+        }
+        return records;
+    }
+
+    /** A record deleted meanwhile is empty; an unreadable one throws. */
+    private Optional<R> read(Path file) {
+        R value;
+        try (InputStream in = Files.newInputStream(file)) {
+            value = reader.readValue(in);
+        } catch (NoSuchFileException e) {
+            return Optional.empty();
+        } catch (IOException e) {
+            throw new FileRepoException("Cannot read record " + file, e);
+        }
+        if (value == null) {
+            throw new FileRepoException("Record " + file + " contains null");
+        }
+        return Optional.of(value);
+    }
+
+    private <T> T locked(Path d, PathLocks.Action<T> action) {
+        try {
+            return PathLocks.withLock(d, lockTimeout, action);
+        } catch (IOException e) {
+            throw new FileRepoException("Cannot write records in " + d, e);
+        }
+    }
+
+    // ── builder ─────────────────────────────────────────────────────────────
+
+    public static final class Builder<P, R> {
+
+        private final Class<R> type;
+        private Function<P, String> dir;
+        private ToLongFunction<R> key;
+        private Function<R, String> id;
+        private int keyWidth = 10;
+        private Duration lockTimeout = PathLocks.DEFAULT_TIMEOUT;
+        private boolean prettyPrint;
+
+        private Builder(Class<R> type) {
+            this.type = type;
+        }
+
+        /**
+         * The directory of a parent's records, relative to the data directory. Give
+         * the lambda parameter its type: {@code .dir((ConversationId c) -> …)}.
+         */
+        @SuppressWarnings("unchecked")
+        public <P2> Builder<P2, R> dir(Function<P2, String> dir) {
+            Builder<P2, R> self = (Builder<P2, R>) (Builder<?, R>) this;
+            self.dir = Objects.requireNonNull(dir, "dir");
+            return self;
+        }
+
+        /** The record's key: its position in the log, the number in front of its file name. */
+        public Builder<P, R> key(ToLongFunction<R> key) {
+            this.key = Objects.requireNonNull(key, "key");
+            return this;
+        }
+
+        /** The record's id, unique within its parent; part of its file name. */
+        public Builder<P, R> id(Function<R, String> id) {
+            this.id = Objects.requireNonNull(id, "id");
+            return this;
+        }
+
+        /** How many digits the key is padded to in the file name; 10 by default. */
+        public Builder<P, R> keyWidth(int keyWidth) {
+            if (keyWidth < 1 || keyWidth > 19) throw new IllegalArgumentException("keyWidth must be 1..19");
+            this.keyWidth = keyWidth;
+            return this;
+        }
+
+        public Builder<P, R> lockTimeout(Duration lockTimeout) {
+            this.lockTimeout = Objects.requireNonNull(lockTimeout, "lockTimeout");
+            return this;
+        }
+
+        /** Indented JSON, for records people read by hand. */
+        public Builder<P, R> prettyPrint() {
+            this.prettyPrint = true;
+            return this;
+        }
+
+        public RecordLog<P, R> build(FileRepo repo, ObjectMapper mapper) {
+            if (dir == null) throw new IllegalStateException("dir() is required");
+            if (key == null) throw new IllegalStateException("key() is required");
+            if (id == null) throw new IllegalStateException("id() is required");
+            return new RecordLog<>(this, Objects.requireNonNull(repo, "repo"), Objects.requireNonNull(mapper, "mapper"));
+        }
+    }
+}

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/DocumentsTest.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/DocumentsTest.java
@@ -1,0 +1,245 @@
+package ai.mindconnect.filerepo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class DocumentsTest {
+
+    record Counter(String id, int value) {
+        Counter increment() {
+            return new Counter(id, value + 1);
+        }
+    }
+
+    record Note(String id, String text) { }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path dir;
+
+    private FileRepo repo;
+    private Documents<String, Counter> counters;
+
+    @BeforeEach
+    void setUp() {
+        repo = FileRepo.open(dir.resolve("data"), "ns");
+        counters = counters(repo);
+    }
+
+    private static Documents<String, Counter> counters(FileRepo repo) {
+        return Documents.of(Counter.class)
+                .path((String id) -> "counters/" + id + ".json")
+                .lockTimeout(Duration.ofMinutes(1))
+                .build(repo, MAPPER);
+    }
+
+    @Test
+    void createsFindsUpdatesAndDeletes() {
+        counters.create("a", new Counter("a", 0));
+        assertThat(counters.find("a")).contains(new Counter("a", 0));
+
+        assertThat(counters.update("a", Counter::increment)).contains(new Counter("a", 1));
+        assertThat(counters.find("a")).contains(new Counter("a", 1));
+
+        assertThat(counters.delete("a")).isTrue();
+        assertThat(counters.find("a")).isEmpty();
+        assertThat(counters.delete("a")).isFalse();
+    }
+
+    @Test
+    void createRefusesAnExistingDocument() {
+        counters.create("a", new Counter("a", 0));
+
+        assertThatThrownBy(() -> counters.create("a", new Counter("a", 7)))
+                .isInstanceOf(DocumentExistsException.class);
+        assertThat(counters.find("a")).contains(new Counter("a", 0));
+    }
+
+    @Test
+    void createIfAbsentBuildsOnlyTheFirstDocument() {
+        assertThat(counters.createIfAbsent("a", () -> new Counter("a", 1))).isEqualTo(new Counter("a", 1));
+        assertThat(counters.createIfAbsent("a", () -> {
+            throw new AssertionError("must not build a second document");
+        })).isEqualTo(new Counter("a", 1));
+    }
+
+    @Test
+    void updatingAMissingDocumentWritesNothing() {
+        assertThat(counters.update("missing", Counter::increment)).isEmpty();
+        assertThat(counters.exists("missing")).isFalse();
+    }
+
+    @Test
+    void anUpdateThatReturnsTheSameInstanceWritesNothing() throws Exception {
+        counters.put("a", new Counter("a", 0));
+        Path file = counters.pathOf("a");
+        Object before = fileKey(file);
+        assumeTrue(before != null, "the file system reports no file keys");
+
+        counters.update("a", c -> c);
+        assertThat(fileKey(file)).isEqualTo(before);
+
+        counters.update("a", Counter::increment);
+        assertThat(fileKey(file)).isNotEqualTo(before);
+    }
+
+    @Test
+    void anUnreadableDocumentThrowsInsteadOfPassingForMissing() throws Exception {
+        Path file = counters.pathOf("broken");
+        Files.createDirectories(file.getParent());
+
+        Files.writeString(file, "");
+        assertThatThrownBy(() -> counters.find("broken"))
+                .isInstanceOf(FileRepoException.class)
+                .hasMessageContaining("broken.json");
+
+        Files.writeString(file, "{\"id\":");
+        assertThatThrownBy(() -> counters.find("broken")).isInstanceOf(FileRepoException.class);
+        assertThatThrownBy(() -> counters.update("broken", Counter::increment)).isInstanceOf(FileRepoException.class);
+        assertThat(Files.readString(file)).isEqualTo("{\"id\":");
+    }
+
+    @Test
+    void findAllReadsDocumentsByNameAndSkipsEverythingElse() throws Exception {
+        counters.put("b", new Counter("b", 2));
+        counters.put("a", new Counter("a", 1));
+        Path counterDir = repo.resolve("counters");
+        Files.writeString(counterDir.resolve(".a.json.4711.tmp"), "{");
+        Files.writeString(counterDir.resolve("readme.txt"), "not a document");
+
+        assertThat(counters.findAll("counters")).containsExactly(new Counter("a", 1), new Counter("b", 2));
+        assertThat(counters.findAll("nothing-here")).isEmpty();
+    }
+
+    @Test
+    void findAllReadsOneDocumentPerSubdirectory() throws Exception {
+        Documents<String, Counter> perSession = Documents.of(Counter.class)
+                .path((String id) -> "sessions/" + id + "/counter.json")
+                .build(repo, MAPPER);
+        perSession.put("s2", new Counter("s2", 2));
+        perSession.put("s1", new Counter("s1", 1));
+        Files.createDirectories(repo.resolve("sessions/without-document"));
+
+        assertThat(perSession.findAll("sessions", "counter.json"))
+                .containsExactly(new Counter("s1", 1), new Counter("s2", 2));
+    }
+
+    @Test
+    void concurrentUpdatesAllLandEvenThroughSeparateInstances() throws Exception {
+        counters.create("shared", new Counter("shared", 0));
+        Documents<String, Counter> second = counters(FileRepo.open(dir.resolve("./data"), "ns"));
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                Documents<String, Counter> docs = i % 2 == 0 ? counters : second;
+                futures.add(pool.submit(() -> docs.update("shared", Counter::increment)));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(counters.find("shared")).contains(new Counter("shared", 1000));
+    }
+
+    @Test
+    void readersNeverSeeAHalfWrittenDocument() throws Exception {
+        Documents<String, Note> notes = Documents.of(Note.class)
+                .path((String id) -> "notes/" + id + ".json")
+                .build(repo, MAPPER);
+        String a = "a".repeat(64_000);
+        String b = "b".repeat(64_000);
+        notes.put("n", new Note("n", a));
+        AtomicBoolean done = new AtomicBoolean();
+        AtomicInteger reads = new AtomicInteger();
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int r = 0; r < 4; r++) {
+                pool.submit(() -> {
+                    while (!done.get()) {
+                        try {
+                            String text = notes.find("n").orElseThrow().text();
+                            if (!text.equals(a) && !text.equals(b)) {
+                                failures.add(new AssertionError("read " + text.length() + " chars"));
+                            }
+                            reads.incrementAndGet();
+                        } catch (Throwable t) {
+                            failures.add(t);
+                            return;
+                        }
+                    }
+                });
+            }
+            try {
+                for (int i = 0; i < 300; i++) {
+                    notes.put("n", new Note("n", i % 2 == 0 ? b : a));
+                }
+            } finally {
+                done.set(true);
+            }
+        }
+
+        assertThat(failures).isEmpty();
+        assertThat(reads.get()).isPositive();
+    }
+
+    @Test
+    void writingInsideAnUpdateIsRefusedAndChangesNothing() {
+        counters.create("a", new Counter("a", 0));
+
+        assertThatThrownBy(() -> counters.update("a", c -> {
+            counters.put("b", new Counter("b", 0));
+            return c.increment();
+        })).isInstanceOf(NestedWriteException.class);
+
+        assertThat(counters.find("a")).contains(new Counter("a", 0));
+        assertThat(counters.exists("b")).isFalse();
+        assertThat(counters.update("a", c -> new Counter("a", c.value() + 1 + counters.find("a").orElseThrow().value())))
+                .as("reading inside an update is fine, and the lock was released")
+                .contains(new Counter("a", 1));
+    }
+
+    @Test
+    void aKeyThatLeadsOutOfTheDirectoryIsRefused() {
+        assertThatThrownBy(() -> counters.put("../../escape", new Counter("x", 0)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(dir.resolve("data/escape.json")).doesNotExist();
+    }
+
+    @Test
+    void prettyPrintIndents() throws Exception {
+        Documents<String, Counter> pretty = Documents.of(Counter.class)
+                .path((String id) -> "pretty/" + id + ".json")
+                .prettyPrint()
+                .build(repo, MAPPER);
+
+        pretty.put("a", new Counter("a", 1));
+
+        assertThat(Files.readString(pretty.pathOf("a"))).contains("\n");
+        assertThat(pretty.find("a")).contains(new Counter("a", 1));
+    }
+
+    private static Object fileKey(Path file) throws Exception {
+        return Files.readAttributes(file, BasicFileAttributes.class).fileKey();
+    }
+}

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/FileRepoTest.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/FileRepoTest.java
@@ -1,0 +1,131 @@
+package ai.mindconnect.filerepo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileRepoTest {
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void everySpellingOfAPartitionOpensTheSameInstance() throws Exception {
+        Path data = dir.resolve("data");
+        FileRepo repo = FileRepo.open(data, "ns");
+        Files.createDirectories(dir.resolve("other"));
+        Path link = Files.createSymbolicLink(dir.resolve("link"), data);
+
+        assertThat(FileRepo.open(dir.resolve("other/../data"), "ns")).isSameAs(repo);
+        assertThat(FileRepo.open(link, "ns")).isSameAs(repo);
+        assertThat(FileRepo.open(data, "other-ns")).isNotSameAs(repo);
+        assertThat(repo.root()).isEqualTo(data.resolve("ns").toRealPath());
+    }
+
+    @Test
+    void aPartitionIsOneDirectoryName() {
+        Path data = dir.resolve("data");
+
+        for (String bad : new String[]{"", " ", ".", "..", "a/b", "a\\b", null}) {
+            assertThatThrownBy(() -> FileRepo.open(data, bad))
+                    .as("partition %s", bad)
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void pathsLeadingOutOfThePartitionAreRefused() {
+        FileRepo repo = FileRepo.open(dir.resolve("data"), "ns");
+
+        assertThat(repo.resolve("sessions/s1/session.json")).startsWithRaw(repo.root());
+        assertThatThrownBy(() -> repo.resolve("../other-ns/sessions/s1/session.json"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> repo.resolve("sessions/../../escape.json")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> repo.resolve("/etc/passwd")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void deletesOnlyTemporaryFilesOldEnoughToBeLeftovers() throws Exception {
+        FileRepo repo = FileRepo.open(dir.resolve("data"), "ns");
+        Instant longAgo = Instant.now().minus(Duration.ofMinutes(5));
+        Path leftover = file(repo.resolve("sessions/s1/.session.json.1.tmp"), longAgo);
+        Path inProgress = file(repo.resolve("sessions/s1/.session.json.2.tmp"), Instant.now());
+        Path document = file(repo.resolve("sessions/s1/session.json"), longAgo);
+
+        repo.deleteTemporaryFilesOlderThan(Duration.ofMinutes(1));
+
+        assertThat(leftover).doesNotExist();
+        assertThat(inProgress).exists();
+        assertThat(document).exists();
+        assertThat(repo.resolve(FileRepo.LOCK_FILE)).exists();
+    }
+
+    @Test
+    void aSecondProcessOnTheSamePartitionIsRefused() throws Exception {
+        Path data = dir.resolve("data");
+        FileRepo.open(data, "ns");
+
+        ChildRun run = openInChildProcess(data, "ns");
+
+        assertThat(run.exitCode()).as(run.output()).isEqualTo(3);
+        assertThat(run.output()).contains("in use by another process");
+    }
+
+    @Test
+    void anotherPartitionOfTheSameDataDirectoryOpensInASecondProcess() throws Exception {
+        Path data = dir.resolve("data");
+        FileRepo.open(data, "ns");
+
+        ChildRun run = openInChildProcess(data, "other-ns");
+
+        assertThat(run.exitCode()).as(run.output()).isZero();
+        assertThat(data.resolve(FileRepo.LOCK_FILE)).as("the data directory itself is never locked").doesNotExist();
+    }
+
+    private record ChildRun(int exitCode, String output) { }
+
+    private static ChildRun openInChildProcess(Path base, String partition) throws Exception {
+        String java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+        String classpath = Arrays.stream(new Class<?>[]{FileRepo.class, OpenDataDirectory.class, LoggerFactory.class})
+                .map(FileRepoTest::locationOf)
+                .distinct()
+                .collect(Collectors.joining(File.pathSeparator));
+        Process process = new ProcessBuilder(java, "-cp", classpath, OpenDataDirectory.class.getName(),
+                base.toString(), partition)
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(process.waitFor(30, TimeUnit.SECONDS)).as("child JVM finished").isTrue();
+        return new ChildRun(process.exitValue(), output);
+    }
+
+    private static String locationOf(Class<?> type) {
+        try {
+            return Path.of(type.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Path file(Path path, Instant modified) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, "{}");
+        Files.setLastModifiedTime(path, FileTime.from(modified));
+        return path;
+    }
+}

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/FileWritesTest.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/FileWritesTest.java
@@ -1,0 +1,55 @@
+package ai.mindconnect.filerepo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileWritesTest {
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void writesAndReplacesAndLeavesNoTemporaryFile() throws Exception {
+        Path target = dir.resolve("sub/state.json");
+
+        FileWrites.writeString(target, "{\"v\":1}");
+        FileWrites.writeString(target, "{\"v\":2}");
+
+        assertThat(Files.readString(target)).isEqualTo("{\"v\":2}");
+        try (Stream<Path> files = Files.list(target.getParent())) {
+            assertThat(files).containsExactly(target);
+        }
+    }
+
+    @Test
+    void aFailingWriteLeavesTheOldContentAndNoTemporaryFile() throws Exception {
+        Path target = dir.resolve("state.json");
+        FileWrites.writeString(target, "old");
+
+        assertThatThrownBy(() -> FileWrites.write(target, out -> {
+            out.write("half".getBytes());
+            throw new IOException("disk full");
+        })).hasMessage("disk full");
+
+        assertThat(Files.readString(target)).isEqualTo("old");
+        try (Stream<Path> files = Files.list(dir)) {
+            assertThat(files).containsExactly(target);
+        }
+    }
+
+    @Test
+    void recognisesItsOwnTemporaryFilesOnly() {
+        assertThat(FileWrites.isTemporary(Path.of("sessions/.session.json.4711.tmp"))).isTrue();
+        assertThat(FileWrites.isTemporary(Path.of("sessions/session.json"))).isFalse();
+        assertThat(FileWrites.isTemporary(Path.of("notes.tmp"))).isFalse();
+        assertThat(FileWrites.isTemporary(Path.of(FileRepo.LOCK_FILE))).isFalse();
+    }
+}

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/OpenDataDirectory.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/OpenDataDirectory.java
@@ -1,0 +1,25 @@
+package ai.mindconnect.filerepo;
+
+import java.nio.file.Path;
+
+/**
+ * Run in a separate JVM by {@link FileRepoTest}: opens partition {@code args[1]}
+ * of the data directory {@code args[0]}. Exit code 0 when that worked, 3 when it
+ * was refused.
+ */
+public final class OpenDataDirectory {
+
+    private OpenDataDirectory() {
+    }
+
+    public static void main(String[] args) {
+        try {
+            FileRepo.open(Path.of(args[0]), args[1]);
+            System.out.println("opened");
+            System.exit(0);
+        } catch (FileRepoException e) {
+            System.out.println(e.getMessage());
+            System.exit(3);
+        }
+    }
+}

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/OpenDataDirectory.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/OpenDataDirectory.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
  * of the data directory {@code args[0]}. Exit code 0 when that worked, 3 when it
  * was refused.
  */
-public final class OpenDataDirectory {
+public class OpenDataDirectory {
 
     private OpenDataDirectory() {
     }

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/PathLocksTest.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/PathLocksTest.java
@@ -1,0 +1,137 @@
+package ai.mindconnect.filerepo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PathLocksTest {
+
+    private static final Duration SHORT = Duration.ofMillis(100);
+    private static final Duration LONG = Duration.ofMinutes(1);
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void aSecondLockOnTheSameThreadIsRefusedAndTheFirstOneReleased() throws Exception {
+        Path a = dir.resolve("a.json");
+        Path b = dir.resolve("b.json");
+
+        assertThatThrownBy(() -> PathLocks.withLock(a, LONG, () -> PathLocks.withLock(b, LONG, () -> "never")))
+                .isInstanceOf(NestedWriteException.class)
+                .hasMessageContaining("a.json")
+                .hasMessageContaining("b.json");
+
+        assertThat(PathLocks.isHeldByCurrentThread()).isFalse();
+        assertThat(onOtherThread(() -> PathLocks.withLock(a, SHORT, () -> "a free"))).isEqualTo("a free");
+        assertThat(onOtherThread(() -> PathLocks.withLock(b, SHORT, () -> "b free"))).isEqualTo("b free");
+    }
+
+    @Test
+    void theSameFileTwiceIsRefusedToo() {
+        Path a = dir.resolve("a.json");
+
+        assertThatThrownBy(() -> PathLocks.withLock(a, LONG, () -> PathLocks.withLock(a, LONG, () -> "never")))
+                .isInstanceOf(NestedWriteException.class);
+    }
+
+    @Test
+    void aLockHeldTooLongTimesOutAndNamesTheHolder() throws Exception {
+        Path file = dir.resolve("slow.json");
+        CountDownLatch holding = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Thread holder = Thread.ofPlatform().name("slow-writer").start(() -> holdUntil(file, holding, release));
+        assertThat(holding.await(10, TimeUnit.SECONDS)).isTrue();
+
+        try {
+            assertThatThrownBy(() -> PathLocks.withLock(file, SHORT, () -> "never"))
+                    .isInstanceOf(LockTimeoutException.class)
+                    .hasMessageContaining("slow.json")
+                    .hasMessageContaining("slow-writer");
+        } finally {
+            release.countDown();
+            holder.join();
+        }
+    }
+
+    @Test
+    void writersOfDifferentFilesDoNotWaitForEachOther() throws Exception {
+        Path a = dir.resolve("a.json");
+        Path b = dir.resolve("b.json");
+        for (int i = 0; PathLocks.stripeOf(b) == PathLocks.stripeOf(a); i++) {
+            b = dir.resolve("b" + i + ".json");
+        }
+        CountDownLatch holding = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Thread holder = Thread.ofVirtual().start(() -> holdUntil(a, holding, release));
+        assertThat(holding.await(10, TimeUnit.SECONDS)).isTrue();
+
+        try {
+            assertThat(PathLocks.withLock(b, SHORT, () -> "written")).isEqualTo("written");
+        } finally {
+            release.countDown();
+            holder.join();
+        }
+    }
+
+    @Test
+    void writersOfOneFileTakeTurns() throws Exception {
+        Path file = dir.resolve("counter.json");
+        int[] counter = {0};
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<Object>> futures = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                futures.add(pool.submit(() -> PathLocks.withLock(file, LONG, () -> {
+                    int seen = counter[0];
+                    Thread.yield();
+                    counter[0] = seen + 1;
+                    return null;
+                })));
+            }
+            for (Future<Object> future : futures) future.get();
+        }
+
+        assertThat(counter[0]).isEqualTo(1000);
+    }
+
+    private static void holdUntil(Path file, CountDownLatch holding, CountDownLatch release) {
+        try {
+            PathLocks.withLock(file, LONG, () -> {
+                holding.countDown();
+                awaitQuietly(release);
+                return null;
+            });
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static <T> T onOtherThread(Callable<T> call) throws Exception {
+        FutureTask<T> task = new FutureTask<>(call);
+        Thread.ofVirtual().start(task);
+        return task.get(10, TimeUnit.SECONDS);
+    }
+}

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/RecordLogTest.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/RecordLogTest.java
@@ -1,0 +1,180 @@
+package ai.mindconnect.filerepo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecordLogTest {
+
+    record Line(String id, long seq, String text) {
+        Line withText(String text) {
+            return new Line(id, seq, text);
+        }
+    }
+
+    record Counter(String id, int value) { }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path dir;
+
+    private FileRepo repo;
+    private RecordLog<String, Line> lines;
+
+    @BeforeEach
+    void setUp() {
+        repo = FileRepo.open(dir.resolve("data"), "ns");
+        lines = log(repo);
+    }
+
+    private static RecordLog<String, Line> log(FileRepo repo) {
+        return RecordLog.of(Line.class)
+                .dir((String conversation) -> "conversations/" + conversation + "/lines")
+                .key(Line::seq)
+                .id(Line::id)
+                .lockTimeout(Duration.ofMinutes(1))
+                .build(repo, MAPPER);
+    }
+
+    private Line append(String conversation, String text) {
+        return lines.append(conversation, seq -> new Line("id-" + seq, seq, text));
+    }
+
+    @Test
+    void appendNumbersTheRecordsAndPagesReadOnlyTheirOwn() {
+        for (int i = 1; i <= 5; i++) append("c", "line " + i);
+
+        assertThat(lines.count("c")).isEqualTo(5);
+        assertThat(lines.page("c", 1, 2)).extracting(Line::seq).containsExactly(2L, 3L);
+        assertThat(lines.page("c", 4, 10)).extracting(Line::seq).containsExactly(5L);
+        assertThat(lines.page("c", 9, 10)).isEmpty();
+        assertThat(lines.find("c", "id-3")).map(Line::text).contains("line 3");
+        assertThat(lines.find("c", "nope")).isEmpty();
+        assertThat(lines.all("other")).isEmpty();
+        assertThat(lines.dirOf("c").resolve("0000000003_id-3.json")).exists();
+    }
+
+    @Test
+    void concurrentAppendsThroughTwoLogsGetDistinctKeys() throws Exception {
+        RecordLog<String, Line> second = log(FileRepo.open(dir.resolve("./data"), "ns"));
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 400; i++) {
+                RecordLog<String, Line> log = i % 2 == 0 ? lines : second;
+                futures.add(pool.submit(() -> log.append("c", seq -> new Line("id-" + seq, seq, "x"))));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(lines.all("c")).extracting(Line::seq)
+                .containsExactlyElementsOf(LongStream.rangeClosed(1, 400).boxed().toList());
+    }
+
+    @Test
+    void appendRefusesARecordThatIgnoresItsKey() {
+        assertThatThrownBy(() -> lines.append("c", seq -> new Line("x", seq + 1, "wrong")))
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(lines.count("c")).isZero();
+    }
+
+    @Test
+    void concurrentUpdatesOfOneRecordAllLandAndTheKeyStays() throws Exception {
+        Line line = append("c", "");
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                futures.add(pool.submit(() -> lines.update("c", line.id(), l -> l.withText(l.text() + "."))));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(lines.find("c", line.id())).map(Line::text).contains(".".repeat(200));
+        assertThatThrownBy(() -> lines.update("c", line.id(), l -> new Line(l.id(), 99, l.text())))
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(lines.update("c", "nope", l -> l.withText("never"))).isEmpty();
+    }
+
+    @Test
+    void aDeletedTailIsNotNumberedAgainNotEvenAfterARestart() {
+        for (int i = 1; i <= 5; i++) append("c", "line " + i);
+
+        assertThat(lines.deleteKeyRange("c", 4, 5)).isEqualTo(2);
+        assertThat(append("c", "after delete").seq()).isEqualTo(6);
+
+        assertThat(lines.deleteKeyRange("c", 6, 6)).isEqualTo(1);
+        repo.forgetLogStates();
+        assertThat(append("c", "after restart").seq()).isEqualTo(7);
+        assertThat(lines.all("c")).extracting(Line::seq).containsExactly(1L, 2L, 3L, 7L);
+    }
+
+    @Test
+    void putStoresUnderTheRecordsOwnKeyAndMovesARecordWhoseKeyChanged() {
+        lines.put("c", new Line("a", 3, "first"));
+        lines.put("c", new Line("a", 5, "moved"));
+
+        assertThat(lines.all("c")).containsExactly(new Line("a", 5, "moved"));
+        assertThat(lines.dirOf("c").resolve("0000000003_a.json")).doesNotExist();
+        assertThat(append("c", "next").seq()).isEqualTo(6);
+    }
+
+    @Test
+    void retainLastAndDeleteAllKeepTheNumbering() {
+        for (int i = 1; i <= 5; i++) append("c", "line " + i);
+
+        assertThat(lines.retainLast("c", 2)).isEqualTo(3);
+        assertThat(lines.all("c")).extracting(Line::seq).containsExactly(4L, 5L);
+        assertThat(lines.deleteAll("c")).isEqualTo(2);
+        assertThat(append("c", "again").seq()).isEqualTo(6);
+    }
+
+    @Test
+    void recordsWrittenBeforeAreFoundAndOtherFilesIgnored() throws Exception {
+        Path d = lines.dirOf("c");
+        Files.createDirectories(d);
+        Files.writeString(d.resolve("0000000002_old.json"), MAPPER.writeValueAsString(new Line("old", 2, "before")));
+        Files.writeString(d.resolve(".0000000003_x.json.123.tmp"), "{");
+        Files.writeString(d.resolve("readme.txt"), "not a record");
+
+        assertThat(lines.all("c")).containsExactly(new Line("old", 2, "before"));
+        assertThat(append("c", "new").seq()).isEqualTo(3);
+    }
+
+    @Test
+    void anUnreadableRecordThrows() throws Exception {
+        Line line = append("c", "fine");
+        Files.writeString(lines.dirOf("c").resolve("0000000001_" + line.id() + ".json"), "{\"id\":");
+
+        assertThatThrownBy(() -> lines.all("c")).isInstanceOf(FileRepoException.class);
+    }
+
+    @Test
+    void readingALogInsideAnotherWriteWorks() {
+        Documents<String, Counter> counters = Documents.of(Counter.class)
+                .path((String id) -> "counters/" + id + ".json")
+                .build(repo, MAPPER);
+        counters.create("n", new Counter("n", 0));
+        append("c", "one");
+        append("c", "two");
+        repo.forgetLogStates();
+
+        assertThat(counters.update("n", c -> new Counter("n", lines.count("c"))))
+                .contains(new Counter("n", 2));
+    }
+}

--- a/common/mc-jdbc/src/main/java/ai/mindconnect/jdbc/DocumentTable.java
+++ b/common/mc-jdbc/src/main/java/ai/mindconnect/jdbc/DocumentTable.java
@@ -1,9 +1,12 @@
 package ai.mindconnect.jdbc;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -23,6 +26,8 @@ import java.util.stream.Collectors;
  *
  * configs.createSchema();                 // CREATE TABLE IF NOT EXISTS …
  * configs.save(config);                   // upsert on id
+ * configs.insert(config);                 // false when the id exists
+ * configs.update(id, c -> c.withName(n)); // SELECT … FOR UPDATE, change, write — one transaction
  * configs.findById(id);
  * configs.find("WHERE name = ?", name);   // the tail after FROM <table>
  * configs.find("ORDER BY name");
@@ -58,6 +63,7 @@ public final class DocumentTable<T> {
     private final List<Index> indexes;
     private final RowMapper<T> mapper;
     private final String upsert;
+    private final String insert;
 
     private DocumentTable(Builder<T> b) {
         this.sql = b.sql;
@@ -69,6 +75,7 @@ public final class DocumentTable<T> {
         this.indexes = List.copyOf(b.indexes);
         this.mapper = row -> row.json("doc", type);
         this.upsert = buildUpsert();
+        this.insert = buildInsert();
     }
 
     public static <T> Builder<T> of(Class<T> type) {
@@ -181,6 +188,64 @@ public final class DocumentTable<T> {
 
     /** Insert or, if a row with this id exists, replace its columns and document. */
     public T save(T entity) {
+        sql.update(upsert, params(entity));
+        return entity;
+    }
+
+    /**
+     * Inserts the row of a new entity; when a row with its key exists already,
+     * nothing is written.
+     *
+     * @return whether the row was inserted
+     */
+    public boolean insert(T entity) {
+        return sql.update(insert, params(entity)) > 0;
+    }
+
+    /**
+     * Reads the row {@code FOR UPDATE}, applies {@code change} and writes the
+     * result, in one transaction: concurrent updates of the same row take turns,
+     * each applied to what the one before wrote. Returning the instance it was
+     * given writes nothing. {@code change} runs while the row is locked — build
+     * the new value, nothing else; it must not change the key.
+     *
+     * @return the changed entity, or empty when there is no such row
+     */
+    public Optional<T> update(Object idValue, UnaryOperator<T> change) {
+        requireNoPartition("update");
+        return update(select("WHERE " + id.name() + " = ? FOR UPDATE"), change, idValue);
+    }
+
+    /** {@link #update(Object, UnaryOperator)} for a table with a {@link Builder#partitionKey partition key}. */
+    public Optional<T> update(Object partitionValue, Object idValue, UnaryOperator<T> change) {
+        requirePartition("update");
+        return update(select(whereKey() + " FOR UPDATE"), change, partitionValue, idValue);
+    }
+
+    private Optional<T> update(String selectForUpdate, UnaryOperator<T> change, Object... key) {
+        return sql.inTransaction(tx -> {
+            Optional<T> current = tx.queryOne(selectForUpdate, mapper, key);
+            if (current.isEmpty()) {
+                return Optional.<T>empty();
+            }
+            T changed = Objects.requireNonNull(change.apply(current.get()), "update: the change returned null");
+            if (changed != current.get()) {
+                if (!sameKey(current.get(), changed)) {
+                    throw new JdbcException("update() must not change the key of the " + table
+                            + " row " + Arrays.toString(key));
+                }
+                tx.update(upsert, params(changed));
+            }
+            return Optional.of(changed);
+        });
+    }
+
+    private boolean sameKey(T a, T b) {
+        return Objects.equals(id.value().apply(a), id.value().apply(b))
+                && (partition == null || Objects.equals(partition.value().apply(a), partition.value().apply(b)));
+    }
+
+    private Object[] params(T entity) {
         int keys = partition == null ? 1 : 2;
         Object[] params = new Object[columns.size() + keys + 1];
         if (partition != null) params[0] = partition.value().apply(entity);
@@ -189,8 +254,7 @@ public final class DocumentTable<T> {
             params[i + keys] = columns.get(i).value().apply(entity);
         }
         params[params.length - 1] = sql.json().jsonb(entity);
-        sql.update(upsert, params);
-        return entity;
+        return params;
     }
 
     public boolean deleteById(Object idValue) {
@@ -251,22 +315,35 @@ public final class DocumentTable<T> {
         }
     }
 
-    private String buildUpsert() {
+    private String insertInto() {
         List<String> names = keyNames();
         columns.forEach(c -> names.add(c.name()));
         String placeholders = names.stream().map(n -> "?").collect(Collectors.joining(", "));
+        return "INSERT INTO " + table + " (" + String.join(", ", names) + ", updated_at, doc) VALUES ("
+                + placeholders + ", now(), ?) ON CONFLICT (" + String.join(", ", keyNames()) + ")";
+    }
+
+    private String buildUpsert() {
         String updates = columns.stream()
                 .map(c -> c.name() + " = EXCLUDED." + c.name())
                 .collect(Collectors.joining(", "));
-        return "INSERT INTO " + table + " (" + String.join(", ", names) + ", updated_at, doc) VALUES ("
-                + placeholders + ", now(), ?) ON CONFLICT (" + String.join(", ", keyNames()) + ") DO UPDATE SET "
+        return insertInto() + " DO UPDATE SET "
                 + (updates.isEmpty() ? "" : updates + ", ")
                 + "updated_at = now(), doc = EXCLUDED.doc";
+    }
+
+    private String buildInsert() {
+        return insertInto() + " DO NOTHING";
     }
 
     /** The statement {@link #save} runs — visible so a test or a reader can check it. */
     public String upsertSql() {
         return upsert;
+    }
+
+    /** The statement {@link #insert} runs. */
+    public String insertSql() {
+        return insert;
     }
 
     // ── builder ─────────────────────────────────────────────────────────────

--- a/common/mc-jdbc/src/test/java/ai/mindconnect/jdbc/DocumentTablePostgresTest.java
+++ b/common/mc-jdbc/src/test/java/ai/mindconnect/jdbc/DocumentTablePostgresTest.java
@@ -4,10 +4,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Round trips against a real Postgres; skipped when none is reachable. */
 class DocumentTablePostgresTest {
@@ -121,6 +126,50 @@ class DocumentTablePostgresTest {
                 "WHERE namespace = ? ORDER BY name", "ns");
         assertThat(headers).containsExactly(
                 new Header(a.id(), "a", Kind.CHAT), new Header(b.id(), "b", Kind.CHAT));
+    }
+
+    @Test
+    void insertWritesANewRowOnly() {
+        Thing t = thing("ns", "one");
+
+        assertThat(things.insert(t)).isTrue();
+        assertThat(things.insert(new Thing(t.id(), "ns", "other", Kind.TOOL, t.createdAt(), List.of()))).isFalse();
+        assertThat(things.findById(t.id())).contains(t);
+    }
+
+    @Test
+    void concurrentUpdatesOfOneRowAllLand() throws Exception {
+        Thing t = thing("ns", "counter");
+        things.save(new Thing(t.id(), t.namespace(), t.name(), t.kind(), t.createdAt(), List.of()));
+
+        try (ExecutorService pool = Executors.newFixedThreadPool(8)) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                String tag = "tag-" + i;
+                futures.add(pool.submit(() -> things.update(t.id(), x -> withTag(x, tag))));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(things.findById(t.id()).orElseThrow().tags()).hasSize(50).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void updateOfAMissingRowIsEmptyAndAChangedKeyIsRefused() {
+        assertThat(things.update(UUID.randomUUID(), x -> withTag(x, "never"))).isEmpty();
+
+        Thing t = thing("ns", "one");
+        things.save(t);
+        assertThatThrownBy(() -> things.update(t.id(),
+                x -> new Thing(UUID.randomUUID(), x.namespace(), x.name(), x.kind(), x.createdAt(), x.tags())))
+                .isInstanceOf(JdbcException.class);
+        assertThat(things.findAll()).containsExactly(t);
+    }
+
+    private static Thing withTag(Thing t, String tag) {
+        List<String> tags = new ArrayList<>(t.tags());
+        tags.add(tag);
+        return new Thing(t.id(), t.namespace(), t.name(), t.kind(), t.createdAt(), tags);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <module>common/mc-initial-data</module>
         <module>common/mc-common</module>
         <module>common/mc-jdbc</module>
+        <module>common/mc-file-repo</module>
 
         <!-- Task queue — its own tree; more modules follow (remote queue, dispatcher UI) -->
         <module>taskqueue/mc-task-queue</module>

--- a/website/docs/agents/cli.md
+++ b/website/docs/agents/cli.md
@@ -103,7 +103,13 @@ In local mode the CLI persists under one root, `mindconnect.data.base-dir`
 - `data/system/agents` — agent definitions
 - `data/system/llm-configs` — LLM configs
 - `data/conversations/<conversationId>/` — conversation history, incl. `traces/`
-- `data/users/<userId>/sessions/<sessionId>/workspace` — workspace files
+- `data/<namespace>/sessions/<sessionId>/` — a session: `session.json`, its
+  working memory and its `workspace` files
+- `data/<namespace>/users/<userId>/workspace` — the user's own workspace files
+
+One process serves a namespace: a second process opening the same namespace of
+the same data directory (the Admin UI, say, while the CLI runs in local mode)
+stops at startup with a message saying so.
 
 The user id defaults to `mindconnect.user.id` from `application.yaml` — override
 it to keep data per user.


### PR DESCRIPTION
## What does this PR do?

With the file persistence, stores were written from many threads at once — parallel tool tasks, sub-agents, the title generator, uploads, the admin UI — and every store read a file, changed a copy and wrote it back. #62 made the writes atomic, so nobody reads a half-written file any more; this PR closes the lost updates that remained.

- **`common/mc-file-repo` (new)** — the file counterpart of `mc-jdbc`. `Documents` (one JSON document per key) reads without a lock and lets one writer at a time change a file, across the whole JVM: the lock belongs to the path, so the several store instances that exist today on one directory take turns too. `update(key, change)` reads, changes and writes under that lock. A write started while holding another write lock throws instead of risking a deadlock; a lock held past its timeout throws naming the holder. `RecordLog` is an ordered log of records per parent with an in-memory index of the file names.
- **Sessions** — `AgentSessionRepository` loses `save` and gains `create` and `update(id, change)`. Tool activations from parallel `tool_search` calls, an "allow for this session", attached files and the title no longer overwrite each other. File: under the session file's lock; Postgres: `SELECT … FOR UPDATE` in one transaction (`DocumentTable.update`); in-memory: `computeIfPresent`. The generated title only names a session that is still untitled.
- **Messages** — a `RecordLog`: the sequence number comes from the index under the conversation's lock (no directory listing per append), a history page reads only its own messages, and deleting the newest messages no longer hands their numbers out again (they are kept in `.sequence`, as Postgres already did). `MessageRepository.update` replaces read-change-save for the compressed form, token count and duration.
- **Summaries** — one file per summary instead of one array rewritten on every save.
- **Vector stores** — `registerInstance` decides and writes under the record's lock, so two uploads register a store once; `MemoryVectorStore` uses a `ReentrantLock` instead of `synchronized`, so a waiting virtual thread no longer pins its carrier.

### Behaviour changes to look at

- **File layout of a session:** `data/<namespace>/sessions/<sessionId>/` holds `session.json`, working memory and the session workspace. Sessions under the earlier `users/<userId>/sessions/` are not read (a warning in the log says where they are); summaries in an old `summaries.json` are not read either. No migration — the file persistence holds development data only.
- **One process per namespace:** opening a namespace takes an OS lock on `data/<namespace>/.mc-partition.lock`; a second process on the same namespace of the same data directory (e.g. the CLI in local mode next to the admin UI) stops at startup with a message. Different namespaces share the directory as before.
- **Port changes** for implementors: `AgentSessionRepository.save` → `create`/`update`; `MessageRepository.update` added. `DocumentTable` gains `insert` and `update`.

Not in this PR: LLM call traces (atomic since #62, never changed after writing), caches, and optimistic locking with a version for agent definitions, LLM configs and vector-store templates (edited as forms — next).

## Affected area

agent runtime · common · docs

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [x] I added/updated tests where it makes sense.
- [x] I updated docs/README if behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

## Verification

- Full reactor after rebasing onto `main`: 2258 tests, 0 failures, 28 skipped (the live OpenAI and example tests, which skip without keys). Postgres tests ran against a local `pgvector/pgvector:pg17-trixie`.
- New concurrency tests: 1000 parallel `update`s on one document through two store instances; 200 parallel session updates (file) and 40 (Postgres) with every activation and approval landing; 400 parallel appends through two logs get 400 distinct numbers; a token count and a duration set at the same time both land; 50 concurrent vector-store registrations agree on one record; a second JVM on the same namespace is refused, on another namespace it starts.
- Manual run in the admin UI (file persistence, OpenAI, before the rebase onto the latest `main`): `research-lead` with one `run_agents` call fanning out to three `web-researcher`s — 0 of 13 tool results failed across 7 sessions, where the run of 2026-09-11 lost the first tool call of every sub-session with `MismatchedInputException`; ten image uploads into one chat at the same time — all ten attached.

## Related issues

Follows #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
