### PR TITLE
Fix the agents build on main

### DIFF
--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/auth/CurrentUsersTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/auth/CurrentUsersTest.java
@@ -51,7 +51,7 @@ class CurrentUsersTest {
     @Test
     void aSessionOpensOnlyForItsOwner() {
         var repo = new InMemoryAgentSessionRepository();
-        AgentSession alices = repo.save(AgentSession.start(AgentId.of("default-chat"), UserId.of("alice"),
+        AgentSession alices = repo.create(AgentSession.start(AgentId.of("default-chat"), UserId.of("alice"),
                 ConversationId.random()));
         var access = new SessionAccess(repo);
 

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SessionFilesApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SessionFilesApiControllerOwnershipTest.java
@@ -84,7 +84,7 @@ class SessionFilesApiControllerOwnershipTest {
     }
 
     private String session(String owner) {
-        AgentSession session = sessions.save(AgentSession.start(AgentId.of("default-chat"), UserId.of(owner),
+        AgentSession session = sessions.create(AgentSession.start(AgentId.of("default-chat"), UserId.of(owner),
                 ConversationId.random()));
         return session.id().value();
     }

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/WorkspaceApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/WorkspaceApiControllerOwnershipTest.java
@@ -86,6 +86,6 @@ class WorkspaceApiControllerOwnershipTest {
     }
 
     private AgentSession session(String owner) {
-        return sessions.save(AgentSession.start(AGENT, UserId.of(owner), ConversationId.random()));
+        return sessions.create(AgentSession.start(AGENT, UserId.of(owner), ConversationId.random()));
     }
 }


### PR DESCRIPTION
`main` does not compile: `build (agents)` fails in `mc-agent-api-rest` with
`cannot find symbol: method save(AgentSession)` in three test files.

Two merges collided semantically. #71 added ownership tests that call
`AgentSessionRepository.save`; #73 replaced that port with `create` and
`update` so a session write can no longer silently overwrite a concurrent
one. Each PR was green against the `main` it branched from, so neither CI
run saw the other's change.

The fix is one call per file — `save` → `create`, same signature, same
return value.

Verified locally: `mvn install -DskipTests` over the whole reactor, then
`mvn -f agents/server/mc-agent-api-rest test` — all green.

No changelog entry: tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)