### PR TITLE
Refuse a save made against a stale version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,21 @@ fresh empty one, so nothing has to be moved by hand at release time.
 - **common:** `DocumentTable.insert` (writes a new row, `false` when the key
   exists) and `DocumentTable.update(key, change)`, which reads the row
   `FOR UPDATE` and writes the change in the same transaction.
+- **agents:** saving an agent, an LLM config or a vector-store template from a
+  form that was opened before someone else saved it is refused instead of
+  silently overwriting the other change. Agent definitions, LLM configs and
+  templates carry a `version` that every save raises; the admin UI forms send
+  the version they were opened with and answer a stale save with "was changed
+  by someone else in the meantime — your changes were not saved", keeping the
+  form on screen. Over REST the check is opt-in: send the `version` you read
+  (in the body of `POST /api/llm-configs`, `POST /api/vector-stores/templates`,
+  `PUT /api/agents/{id}`) to get `409 Conflict` for a stale save; without it a
+  save overwrites as before. A new template no longer replaces an existing one
+  of the same name, and adding, editing or removing an agent's tool no longer
+  drops a tool changed at the same time.
+- **common:** `Versions` and `StaleVersionException` in `mc-common` for such
+  checks, and `compute(key, change)` in `Documents` and `DocumentTable`: decide
+  on the stored document, or its absence, and write — under one lock.
 
 ### Changed
 

--- a/agents/adapter/postgres/mc-agent-runtime-pg/src/main/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentDefinitionRepository.java
+++ b/agents/adapter/postgres/mc-agent-runtime-pg/src/main/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentDefinitionRepository.java
@@ -48,8 +48,12 @@ public final class PgAgentDefinitionRepository implements AgentDefinitionReposit
     }
 
     @Override
+    /** Checks the version against the row read {@code FOR UPDATE} and stores it one higher, in one transaction. */
     public AgentDefinition save(AgentDefinition definition) {
-        return definitions.save(definition);
+        return definitions.compute(namespace.value(), definition.id().value(), current ->
+                definition.withVersion(ai.mindconnect.common.Versions.next(
+                        current.map(AgentDefinition::version).orElse(null), definition.version(),
+                        "AgentDefinition", definition.id().value())));
     }
 
     @Override

--- a/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentDefinitionRepositoryTest.java
+++ b/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentDefinitionRepositoryTest.java
@@ -25,14 +25,14 @@ class PgAgentDefinitionRepositoryTest {
     @Test
     void aDefinitionSurvivesTheRoundTrip() {
         AgentDefinition d = def("default-chat");
-        repo.save(d);
-        assertThat(repo.findById(d.id())).contains(d);
+        AgentDefinition saved = repo.save(d);
+        assertThat(saved).isEqualTo(d.withVersion(1L));
+        assertThat(repo.findById(d.id())).contains(saved);
     }
 
     @Test
     void findByNameIgnoresCase() {
-        AgentDefinition d = def("Web-Researcher");
-        repo.save(d);
+        AgentDefinition d = repo.save(def("Web-Researcher"));
 
         assertThat(repo.findByName("web-researcher")).contains(d);
         assertThat(repo.findByName("WEB-RESEARCHER")).contains(d);
@@ -41,10 +41,8 @@ class PgAgentDefinitionRepositoryTest {
 
     @Test
     void findAllListsByNameAndDeleteRemoves() {
-        AgentDefinition b = def("b");
-        AgentDefinition a = def("a");
-        repo.save(b);
-        repo.save(a);
+        AgentDefinition b = repo.save(def("b"));
+        AgentDefinition a = repo.save(def("a"));
 
         assertThat(repo.findAll()).containsExactly(a, b);
         repo.deleteById(a.id());

--- a/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentDefinitionVersioningTest.java
+++ b/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgAgentDefinitionVersioningTest.java
@@ -1,0 +1,61 @@
+package ai.mindconnect.agent.runtime.adapter.pg;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.common.StaleVersionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Versions on Postgres: the same checks as the file store, the row read {@code FOR UPDATE}. */
+class PgAgentDefinitionVersioningTest {
+
+    private PgAgentDefinitionRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = new PgAgentDefinitionRepository(TestDb.fresh("mc_agent_definition"), new Namespace("test")).initSchema();
+    }
+
+    @Test
+    void aSaveAgainstAStaleVersionIsRefused() throws Exception {
+        AgentDefinition created = repo.save(AgentDefinition.create("scout", "d", "prompt", "hi", "cfg"));
+        assertThat(created.version()).isEqualTo(1L);
+        AgentDefinition renamed = repo.save(created.withBasicFields("scout-2", "d", "prompt", "hi", "cfg"));
+        assertThat(renamed.version()).isEqualTo(2L);
+
+        assertThatThrownBy(() -> repo.save(created.withBasicFields("stale", "d", "prompt", "hi", "cfg")))
+                .isInstanceOf(StaleVersionException.class);
+        assertThat(repo.findById(created.id())).map(AgentDefinition::name).contains("scout-2");
+        assertThat(repo.save(created.withVersion(null)).version()).as("no version: no check").isEqualTo(3L);
+
+        AgentDefinition read = repo.findById(created.id()).orElseThrow();
+        AtomicInteger landed = new AtomicInteger();
+        try (ExecutorService pool = Executors.newFixedThreadPool(8)) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 20; i++) {
+                String name = "edit-" + i;
+                futures.add(pool.submit(() -> {
+                    try {
+                        repo.save(read.withBasicFields(name, "d", "prompt", "hi", "cfg"));
+                        landed.incrementAndGet();
+                    } catch (StaleVersionException e) {
+                        // the others were first
+                    }
+                }));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+        assertThat(landed.get()).isEqualTo(1);
+        assertThat(repo.findById(created.id())).map(AgentDefinition::version).contains(4L);
+    }
+}

--- a/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgNamespaceIsolationTest.java
+++ b/agents/adapter/postgres/mc-agent-runtime-pg/src/test/java/ai/mindconnect/agent/runtime/adapter/pg/PgNamespaceIsolationTest.java
@@ -49,8 +49,7 @@ class PgNamespaceIsolationTest {
     void agentDefinitions() {
         var a = new PgAgentDefinitionRepository(sql, A).initSchema();
         var b = new PgAgentDefinitionRepository(sql, B).initSchema();
-        AgentDefinition d = AgentDefinition.create("web-researcher", "desc", "prompt", "hello", "agent-default");
-        a.save(d);
+        AgentDefinition d = a.save(AgentDefinition.create("web-researcher", "desc", "prompt", "hello", "agent-default"));
 
         assertThat(b.findById(d.id())).isEmpty();
         assertThat(b.findByName("web-researcher")).isEmpty();

--- a/agents/adapter/postgres/mc-llm-gateway-pg/src/main/java/ai/mindconnect/llm/adapter/pg/PgLlmConfigRepository.java
+++ b/agents/adapter/postgres/mc-llm-gateway-pg/src/main/java/ai/mindconnect/llm/adapter/pg/PgLlmConfigRepository.java
@@ -53,8 +53,12 @@ public final class PgLlmConfigRepository implements LlmConfigRepository {
     }
 
     @Override
+    /** Checks the version against the row read {@code FOR UPDATE} and stores it one higher, in one transaction. */
     public void save(LlmConfig config) {
-        configs.save(config);
+        configs.compute(namespace.value(), config.id().value(), current ->
+                config.withVersion(ai.mindconnect.common.Versions.next(
+                        current.map(LlmConfig::version).orElse(null), config.version(),
+                        "LlmConfig", config.id().value())));
     }
 
     @Override

--- a/agents/adapter/postgres/mc-llm-gateway-pg/src/test/java/ai/mindconnect/llm/adapter/pg/PgLlmConfigRepositoryTest.java
+++ b/agents/adapter/postgres/mc-llm-gateway-pg/src/test/java/ai/mindconnect/llm/adapter/pg/PgLlmConfigRepositoryTest.java
@@ -47,8 +47,8 @@ class PgLlmConfigRepositoryTest {
         assertThat(other.findAll()).isEmpty();
         other.deleteById(config.id());
 
-        assertThat(repo.findById(config.id())).contains(config);
-        assertThat(repo.findAll()).containsExactly(config);
+        assertThat(repo.findById(config.id())).contains(config.withVersion(1L));
+        assertThat(repo.findAll()).containsExactly(config.withVersion(1L));
     }
 
     @Test
@@ -61,8 +61,8 @@ class PgLlmConfigRepositoryTest {
                         ai.mindconnect.llm.domain.LlmCapability.VISION));
         repo.save(config);
 
-        assertThat(repo.findById(config.id())).contains(config);
-        assertThat(repo.findByName("claude")).contains(config);
+        assertThat(repo.findById(config.id())).contains(config.withVersion(1L));
+        assertThat(repo.findByName("claude")).contains(config.withVersion(1L));
     }
 
     @Test
@@ -70,12 +70,12 @@ class PgLlmConfigRepositoryTest {
         LlmConfig first = LlmConfig.lmStudio("local", "qwen", "http://localhost:1234");
         repo.save(first);
         LlmConfig renamed = LlmConfig.fromJson(first.id().value(), "local-qwen", first.provider(), "qwen-2",
-                first.baseUrl(), first.apiKey(), 0.1, 1024, Map.of(), null, false, null, null, null, null, null);
+                first.baseUrl(), first.apiKey(), 0.1, 1024, Map.of(), null, false, null, null, null, null, null, null);
         repo.save(renamed);
 
-        assertThat(repo.findAll()).containsExactly(renamed);
+        assertThat(repo.findAll()).containsExactly(renamed.withVersion(2L));
         assertThat(repo.findByName("local")).isEmpty();
-        assertThat(repo.findByName("local-qwen")).contains(renamed);
+        assertThat(repo.findByName("local-qwen")).contains(renamed.withVersion(2L));
     }
 
     @Test
@@ -87,7 +87,7 @@ class PgLlmConfigRepositoryTest {
 
         assertThat(repo.findAll()).extracting(LlmConfig::name).containsExactly("a-claude", "b-ollama");
         repo.deleteById(b.id());
-        assertThat(repo.findAll()).containsExactly(a);
+        assertThat(repo.findAll()).containsExactly(a.withVersion(1L));
         assertThat(repo.findById(b.id())).isEmpty();
         repo.deleteById(b.id()); // deleting what is gone is not an error
     }

--- a/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/InitialDataLoader.java
+++ b/agents/client/mc-agent-cli/src/main/java/ai/mindconnect/cli/InitialDataLoader.java
@@ -131,8 +131,9 @@ public class InitialDataLoader {
         try {
             JsonNode storedNode  = objectMapper.valueToTree(stored);
             JsonNode incomingNode = objectMapper.valueToTree(incoming);
-            // Strip timestamp fields that are expected to differ
-            for (String field : List.of("createdAt", "updatedAt")) {
+            // Strip the fields that are expected to differ: timestamps, and the
+            // version, which counts saves — a seed never carries one.
+            for (String field : List.of("createdAt", "updatedAt", "version")) {
                 ((com.fasterxml.jackson.databind.node.ObjectNode) storedNode).remove(field);
                 ((com.fasterxml.jackson.databind.node.ObjectNode) incomingNode).remove(field);
             }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/domain/AgentDefinition.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/domain/AgentDefinition.java
@@ -70,7 +70,14 @@ public record AgentDefinition(
          */
         ToolSearchConfig toolSearch,
         Instant createdAt,
-        Instant updatedAt
+        Instant updatedAt,
+        /**
+         * The stored version this definition was read with — optimistic locking
+         * for edits made as a whole (the admin form, a REST update). A store saves
+         * it only if it is still the stored version and stores it one higher;
+         * {@code null} saves without that check. See {@code ai.mindconnect.common.Versions}.
+         */
+        Long version
 ) {
 
     /**
@@ -104,6 +111,26 @@ public record AgentDefinition(
         }
 
         public static final ToolSearchConfig OFF = new ToolSearchConfig(false, List.of());
+    }
+
+    /**
+     * Without a version: the definition saves without a version check.
+     */
+    public AgentDefinition(AgentId id, String name, String description, String group, String icon,
+                           String systemPrompt, String welcomeMessage, String llmConfigName,
+                           int maxIterations, MemoryConfig memoryConfig, AgentDefinitionStatus status,
+                           List<AgentTool> tools, List<String> responseReviewers, List<String> callableAgents,
+                           ToolSearchConfig toolSearch, Instant createdAt, Instant updatedAt) {
+        this(id, name, description, group, icon, systemPrompt, welcomeMessage, llmConfigName,
+                maxIterations, memoryConfig, status, tools, responseReviewers, callableAgents, toolSearch,
+                createdAt, updatedAt, null);
+    }
+
+    /** This definition as read with, or to be saved against, {@code version} — nothing else changes. */
+    public AgentDefinition withVersion(Long version) {
+        return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
+                llmConfigName, maxIterations, memoryConfig, status, tools, responseReviewers,
+                callableAgents, toolSearch, createdAt, updatedAt, version);
     }
 
     /**
@@ -204,7 +231,7 @@ public record AgentDefinition(
     public AgentDefinition withCallableAgents(List<String> callableAgents) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     /**
@@ -213,7 +240,7 @@ public record AgentDefinition(
     public AgentDefinition withIcon(String icon) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     /**
@@ -222,7 +249,7 @@ public record AgentDefinition(
     public AgentDefinition withGroup(String group) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     /**
@@ -231,26 +258,26 @@ public record AgentDefinition(
     public AgentDefinition withToolSearch(ToolSearchConfig toolSearch) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     public AgentDefinition withMemoryConfig(MemoryConfig memoryConfig) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig, status, tools, responseReviewers,
-                callableAgents, toolSearch, createdAt, Instant.now());
+                callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     public AgentDefinition withTools(List<AgentTool> tools) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     public AgentDefinition withBasicFields(String name, String description, String systemPrompt,
                                            String welcomeMessage, String llmConfigName) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     public AgentDefinition withBasicFields(String name, String description,
@@ -258,7 +285,7 @@ public record AgentDefinition(
                                            String llmConfigName, List<String> responseReviewers) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     /**
@@ -274,7 +301,7 @@ public record AgentDefinition(
                                            List<String> responseReviewers) {
         return new AgentDefinition(id, name, description, group, icon, systemPrompt, welcomeMessage,
                 llmConfigName, maxIterations, memoryConfig,
-                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now());
+                status, tools, responseReviewers, callableAgents, toolSearch, createdAt, Instant.now(), version);
     }
 
     public AgentDefinition asCopy() {

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/AgentRegistryService.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/AgentRegistryService.java
@@ -7,16 +7,26 @@ import ai.mindconnect.agent.runtime.domain.AgentSpec;
 import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
 import ai.mindconnect.agent.tool.AgentTool;
 import ai.mindconnect.common.DomainException;
+import ai.mindconnect.common.StaleVersionException;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 /**
  * Use-case service for {@link AgentDefinition} CRUD.
  *
- * <p>Stateless and thread-safe.
+ * <p>Stateless and thread-safe. Saves are versioned (see
+ * {@code ai.mindconnect.common.Versions}): an edit form passes the version it
+ * was opened with and is refused when the agent was saved since; a change
+ * that carries no version is applied to the agent as stored and re-applied if
+ * another save came in between.
  */
 public class AgentRegistryService {
+
+    /** How often a change without a version is re-applied when another save came in between. */
+    private static final int ATTEMPTS = 3;
 
     private final AgentDefinitionRepository definitionRepository;
 
@@ -46,12 +56,27 @@ public class AgentRegistryService {
     }
 
     /**
-     * Applies the patch to the agent. Absent patch fields are left as-is;
-     * present fields overwrite. Throws {@code notFound} if the agent does
-     * not exist.
+     * Applies the patch to the agent as it is stored now. Absent patch fields are
+     * left as-is; present fields overwrite. When another save lands between reading
+     * and writing, the patch is applied again to the newer agent. Throws
+     * {@code notFound} if the agent does not exist.
      */
     public AgentDefinition update(AgentId agentId, AgentPatch patch) {
+        return retrying(() -> update(agentId, patch, null));
+    }
+
+    /**
+     * Applies the patch to the agent the caller read at {@code expectedVersion} — an
+     * edit form's save. With {@code null} nothing is checked and nothing retried.
+     *
+     * @throws StaleVersionException when the agent was saved since; nothing is written
+     */
+    public AgentDefinition update(AgentId agentId, AgentPatch patch, Long expectedVersion) {
         AgentDefinition def = load(agentId);
+        long stored = def.version() == null ? 0 : def.version();
+        if (expectedVersion != null && expectedVersion != stored) {
+            throw new StaleVersionException("AgentDefinition", agentId.value(), expectedVersion, stored);
+        }
 
         AgentDefinition updated = def.withBasicFields(
                 patch.name().orElse(def.name()),
@@ -79,7 +104,21 @@ public class AgentRegistryService {
         if (patch.memoryConfig().isPresent()) {
             updated = updated.withMemoryConfig(patch.memoryConfig().get());
         }
+        // Still carries the version read above: the store refuses it if a save landed since.
         return definitionRepository.save(updated);
+    }
+
+    /**
+     * Replaces the agent's tools with what {@code change} makes of the stored list —
+     * adding, editing or removing one tool without dropping a tool that was added
+     * meanwhile. {@code change} may run more than once.
+     */
+    public AgentDefinition updateTools(AgentId agentId, UnaryOperator<List<AgentTool>> change) {
+        return retrying(() -> {
+            AgentDefinition def = load(agentId);
+            List<AgentTool> tools = def.tools() == null ? List.of() : def.tools();
+            return definitionRepository.save(def.withTools(change.apply(tools)));
+        });
     }
 
     /**
@@ -108,5 +147,15 @@ public class AgentRegistryService {
     private AgentDefinition load(AgentId agentId) {
         return find(agentId)
                 .orElseThrow(() -> DomainException.notFound("AgentDefinition", agentId.toString()));
+    }
+
+    private static AgentDefinition retrying(Supplier<AgentDefinition> save) {
+        for (int attempt = 1; ; attempt++) {
+            try {
+                return save.get();
+            } catch (StaleVersionException e) {
+                if (attempt >= ATTEMPTS) throw e;
+            }
+        }
     }
 }

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/AgentRegistryServiceVersionTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/AgentRegistryServiceVersionTest.java
@@ -1,0 +1,82 @@
+package ai.mindconnect.agent.runtime.service;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.agent.runtime.domain.AgentPatch;
+import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
+import ai.mindconnect.agent.tool.AgentTool;
+import ai.mindconnect.common.StaleVersionException;
+import ai.mindconnect.common.Versions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * An edit form's save is checked against the version the form was opened with; a
+ * change without a version is re-applied when another save came in between.
+ */
+class AgentRegistryServiceVersionTest {
+
+    private final Repo repo = new Repo();
+    private final AgentRegistryService service = new AgentRegistryService(repo);
+
+    @Test
+    void aFormOpenedBeforeAnotherSaveIsRefused() {
+        AgentDefinition agent = repo.save(AgentDefinition.create("scout", "d", "p", "hi", "cfg"));
+        service.update(agent.id(), AgentPatch.of().withDescription("first"), 1L);
+
+        assertThatThrownBy(() -> service.update(agent.id(), AgentPatch.of().withDescription("second"), 1L))
+                .isInstanceOf(StaleVersionException.class);
+        assertThat(repo.findById(agent.id())).map(AgentDefinition::description).contains("first");
+    }
+
+    @Test
+    void aChangeWithoutVersionIsAppliedAgainAfterARacingSave() {
+        AgentDefinition agent = repo.save(AgentDefinition.create("scout", "d", "p", "hi", "cfg"));
+        repo.raceOnce.set(1);
+
+        AgentDefinition updated = service.updateTools(agent.id(), tools -> {
+            List<AgentTool> next = new ArrayList<>(tools);
+            next.add(AgentTool.of("web_search", "Searches the web."));
+            return next;
+        });
+
+        assertThat(updated.tools()).extracting(AgentTool::name).contains("web_search", "raced");
+        assertThat(repo.saves.get()).as("the first attempt lost the race and ran again").isEqualTo(4);
+    }
+
+    /** Versioned like the real stores; {@link #raceOnce} lets another save slip in before the next one. */
+    private static final class Repo implements AgentDefinitionRepository {
+        final Map<AgentId, AgentDefinition> byId = new ConcurrentHashMap<>();
+        final AtomicInteger raceOnce = new AtomicInteger();
+        final AtomicInteger saves = new AtomicInteger();
+
+        @Override
+        public AgentDefinition save(AgentDefinition def) {
+            saves.incrementAndGet();
+            if (raceOnce.getAndSet(0) == 1) {
+                AgentDefinition current = byId.get(def.id());
+                List<AgentTool> tools = new ArrayList<>(current.tools());
+                tools.add(AgentTool.of("raced", "Added by another save."));
+                save(current.withTools(tools));
+            }
+            return byId.compute(def.id(), (id, current) -> def.withVersion(Versions.next(
+                    current == null ? null : current.version(), def.version(), "AgentDefinition", id.value())));
+        }
+
+        @Override public Optional<AgentDefinition> findById(AgentId id) { return Optional.ofNullable(byId.get(id)); }
+        @Override public List<AgentDefinition> findAll() { return List.copyOf(byId.values()); }
+        @Override public Optional<AgentDefinition> findByName(String name) {
+            return byId.values().stream().filter(d -> d.name().equals(name)).findFirst();
+        }
+        @Override public void deleteById(AgentId id) { byId.remove(id); }
+    }
+}

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentDefinitionRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/file/FileAgentDefinitionRepository.java
@@ -1,78 +1,57 @@
 package ai.mindconnect.agent.runtime.adapter.file;
 
-import ai.mindconnect.common.util.AtomicFiles;
-import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.AgentId;
-
+import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.runtime.domain.AgentDefinition;
 import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
+import ai.mindconnect.common.Versions;
+import ai.mindconnect.filerepo.Documents;
+import ai.mindconnect.filerepo.FileRepo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
+/**
+ * Stores agent definitions under {@code {base}/{namespace}/system/agents/{id}.json}.
+ *
+ * <p>{@link #save} checks the version a definition carries against the stored one
+ * and stores it one higher, both under the file's write lock — two edits of the
+ * same agent cannot both pass the check.
+ */
 public class FileAgentDefinitionRepository implements AgentDefinitionRepository {
 
     private static final Logger log = Logger.getLogger(FileAgentDefinitionRepository.class.getName());
+    private static final String DIR = "system/agents";
 
-    private final Path baseDir;
-    private final ObjectMapper objectMapper;
+    private final Documents<AgentId, AgentDefinition> definitions;
 
     public FileAgentDefinitionRepository(Path agentStorageDir, ObjectMapper objectMapper, Namespace namespace) {
-        this.baseDir = agentStorageDir.resolve(namespace.value()).resolve("system").resolve("agents").toAbsolutePath();
-        this.objectMapper = objectMapper;
-        try {
-            Files.createDirectories(this.baseDir);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        log.info("AgentDefinitionRepository storage: " + this.baseDir);
+        FileRepo repo = FileRepo.open(agentStorageDir, namespace.value());
+        this.definitions = Documents.of(AgentDefinition.class)
+                .path((AgentId id) -> DIR + "/" + id.value() + ".json")
+                .build(repo, objectMapper);
+        log.info("AgentDefinitionRepository storage: " + repo.resolve(DIR));
     }
 
     @Override
     public AgentDefinition save(AgentDefinition def) {
-        try {
-            AtomicFiles.write(fileFor(def.id().value()), out -> objectMapper.writeValue(out, def));
-            return def;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return definitions.compute(def.id(), current -> def.withVersion(Versions.next(
+                current.map(AgentDefinition::version).orElse(null), def.version(),
+                "AgentDefinition", def.id().value())));
     }
 
     @Override
     public Optional<AgentDefinition> findById(AgentId id) {
-        Path file = fileFor(id.value());
-        if (!Files.exists(file)) return Optional.empty();
-        try {
-            AgentDefinition def = read(file, AgentDefinition.class);
-            // The directory is flat: a file of another tenant with the same value is not this agent.
-            return def.id().equals(id) ? Optional.of(def) : Optional.empty();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        // The directory is flat: a file of another tenant with the same value is not this agent.
+        return definitions.find(id).filter(def -> def.id().equals(id));
     }
 
     @Override
     public List<AgentDefinition> findAll() {
-        try (var stream = Files.list(baseDir)) {
-            return stream
-                    .filter(p -> p.toString().endsWith(".json"))
-                    .map(p -> {
-                        try {
-                            return read(p, AgentDefinition.class);
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
-                    })
-                    .toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return definitions.findAll(DIR);
     }
 
     @Override
@@ -84,21 +63,6 @@ public class FileAgentDefinitionRepository implements AgentDefinitionRepository 
 
     @Override
     public void deleteById(AgentId id) {
-        if (findById(id).isEmpty()) return;
-        try {
-            Files.deleteIfExists(fileFor(id.value()));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private Path fileFor(String id) {
-        return baseDir.resolve(id + ".json");
-    }
-
-    /** Reads a document in {@code namespace}; one written before the namespace was recorded takes it from here. */
-    private <T> T read(Path file, Class<T> type) throws IOException {
-        return objectMapper.readerFor(type)
-                .readValue(file.toFile());
+        definitions.delete(id);
     }
 }

--- a/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/repo/memory/InMemoryAgentDefinitionRepository.java
+++ b/agents/core/mc-agent-runtime/src/main/java/ai/mindconnect/agent/runtime/adapter/repo/memory/InMemoryAgentDefinitionRepository.java
@@ -17,8 +17,8 @@ public class InMemoryAgentDefinitionRepository implements AgentDefinitionReposit
 
     @Override
     public AgentDefinition save(AgentDefinition definition) {
-        store.put(definition.id(), definition);
-        return definition;
+        return store.compute(definition.id(), (id, current) -> definition.withVersion(ai.mindconnect.common.Versions.next(
+                current == null ? null : current.version(), definition.version(), "AgentDefinition", id.value())));
     }
 
     @Override

--- a/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/AgentDefinitionVersioningTest.java
+++ b/agents/core/mc-agent-runtime/src/test/java/ai/mindconnect/agent/runtime/adapter/AgentDefinitionVersioningTest.java
@@ -1,0 +1,87 @@
+package ai.mindconnect.agent.runtime.adapter;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.runtime.adapter.file.FileAgentDefinitionRepository;
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemoryAgentDefinitionRepository;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
+import ai.mindconnect.common.StaleVersionException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Two admins edit the same agent: the second save, made against the version both
+ * opened, is refused instead of overwriting the first. File and in-memory stores
+ * behave the same.
+ */
+class AgentDefinitionVersioningTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Test
+    void theFileStoreChecksVersions(@TempDir Path dir) throws Exception {
+        versionsAreChecked(new FileAgentDefinitionRepository(dir, MAPPER, new Namespace("test")));
+    }
+
+    @Test
+    void theInMemoryStoreChecksVersions() throws Exception {
+        versionsAreChecked(new InMemoryAgentDefinitionRepository());
+    }
+
+    static void versionsAreChecked(AgentDefinitionRepository repo) throws Exception {
+        AgentDefinition created = repo.save(AgentDefinition.create("scout", "d", "prompt", "hi", "cfg"));
+        assertThat(created.version()).isEqualTo(1L);
+
+        AgentDefinition renamed = repo.save(created.withBasicFields("scout-2", "d", "prompt", "hi", "cfg"));
+        assertThat(renamed.version()).isEqualTo(2L);
+        assertThat(repo.findById(created.id())).map(AgentDefinition::version).contains(2L);
+
+        // A form still showing version 1.
+        assertThatThrownBy(() -> repo.save(created.withBasicFields("stale", "d", "prompt", "hi", "cfg")))
+                .isInstanceOf(StaleVersionException.class);
+        assertThat(repo.findById(created.id())).map(AgentDefinition::name).contains("scout-2");
+
+        // No version: no check, as a seed or an import saves.
+        AgentDefinition seeded = repo.save(created.withVersion(null)
+                .withBasicFields("seeded", "d", "prompt", "hi", "cfg"));
+        assertThat(seeded.version()).isEqualTo(3L);
+
+        // Twenty saves from the same read: exactly one lands.
+        AgentDefinition read = repo.findById(created.id()).orElseThrow();
+        AtomicInteger landed = new AtomicInteger();
+        AtomicInteger refused = new AtomicInteger();
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 20; i++) {
+                String name = "edit-" + i;
+                futures.add(pool.submit(() -> {
+                    try {
+                        repo.save(read.withBasicFields(name, "d", "prompt", "hi", "cfg"));
+                        landed.incrementAndGet();
+                    } catch (StaleVersionException e) {
+                        refused.incrementAndGet();
+                    }
+                }));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+        assertThat(landed.get()).isEqualTo(1);
+        assertThat(refused.get()).isEqualTo(19);
+        assertThat(repo.findById(created.id())).map(AgentDefinition::version).contains(4L);
+    }
+}

--- a/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
+++ b/agents/core/mc-llm-gateway-core/src/main/java/ai/mindconnect/llm/domain/LlmConfig.java
@@ -65,8 +65,33 @@ public record LlmConfig(
          * applies; see {@link #effectiveCapabilities()}. A declared set, the
          * empty set included, always wins over that default.
          */
-        Set<LlmCapability> capabilities
+        Set<LlmCapability> capabilities,
+        /**
+         * The stored version this config was read with — optimistic locking for
+         * edits made as a whole (the admin form, a REST save). A store saves it only
+         * if it is still the stored version and stores it one higher; {@code null}
+         * saves without that check. See {@code ai.mindconnect.common.Versions}.
+         */
+        Long version
 ) {
+    /** Without a version: the config saves without a version check. */
+    public LlmConfig(LlmConfigId id, String name, LlmProvider provider, String model, String baseUrl,
+                     String apiKey, double defaultTemperature, int maxOutputTokens,
+                     Map<String, Object> additionalParams, Integer contextWindowTokens, boolean isAlias,
+                     String delegatesTo, RetryConfig retry, RateLimitConfig rateLimit, LlmConfigType type,
+                     Set<LlmCapability> capabilities) {
+        this(id, name, provider, model, baseUrl, apiKey, defaultTemperature, maxOutputTokens,
+                additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type,
+                capabilities, null);
+    }
+
+    /** This config as read with, or to be saved against, {@code version} — nothing else changes. */
+    public LlmConfig withVersion(Long version) {
+        return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
+                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo,
+                retry, rateLimit, type, capabilities, version);
+    }
+
     /**
      * Normalises the type ({@code null} reads as CHAT) and keeps a declared
      * capability set as an unmodifiable copy in declaration order, so JSON
@@ -134,11 +159,12 @@ public record LlmConfig(
             @JsonProperty("retry")                RetryConfig retry,
             @JsonProperty("rateLimit")            RateLimitConfig rateLimit,
             @JsonProperty("type")                 LlmConfigType type,
-            @JsonProperty("capabilities")         Set<LlmCapability> capabilities) {
+            @JsonProperty("capabilities")         Set<LlmCapability> capabilities,
+            @JsonProperty("version")              Long version) {
         return new LlmConfig(new LlmConfigId(id), name, provider, model, baseUrl, apiKey,
                 defaultTemperature, maxOutputTokens,
                 additionalParams != null ? additionalParams : Map.of(),
-                contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
+                contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities, version);
     }
 
     /**
@@ -268,18 +294,18 @@ public record LlmConfig(
 
     public LlmConfig withContextWindowTokens(Integer contextWindowTokens) {
         return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
-                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
+                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities, version);
     }
 
     public LlmConfig withApiKey(String apiKey) {
         return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
-                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
+                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities, version);
     }
 
     /** Returns a copy declaring exactly the given capabilities ({@code null}: not declared, the provider's default applies). */
     public LlmConfig withCapabilities(Set<LlmCapability> capabilities) {
         return new LlmConfig(id, name, provider, model, baseUrl, apiKey,
-                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities);
+                defaultTemperature, maxOutputTokens, additionalParams, contextWindowTokens, isAlias, delegatesTo, retry, rateLimit, type, capabilities, version);
     }
 
     /**
@@ -319,7 +345,8 @@ public record LlmConfig(
                 retry,
                 rateLimit,
                 type,
-                capabilities);
+                capabilities,
+                version);
     }
 
     /**

--- a/agents/core/mc-llm-gateway/pom.xml
+++ b/agents/core/mc-llm-gateway/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>mc-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-file-repo</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/file/FileLlmConfigRepository.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/file/FileLlmConfigRepository.java
@@ -1,55 +1,53 @@
 package ai.mindconnect.llm.adapter.file;
 
-import ai.mindconnect.common.util.AtomicFiles;
 import ai.mindconnect.agent.Namespace;
-import ai.mindconnect.llm.domain.LlmConfigId;
-
+import ai.mindconnect.common.Versions;
+import ai.mindconnect.filerepo.Documents;
+import ai.mindconnect.filerepo.FileRepo;
 import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigId;
 import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Stores LLM configs under {@code {base}/{namespace}/system/llm-configs/{id}.json}.
+ *
+ * <p>{@link #save} checks the version a config carries against the stored one and
+ * stores it one higher, both under the file's write lock.
+ */
 public class FileLlmConfigRepository implements LlmConfigRepository {
 
-    private final Path baseDir;
-    private final ObjectMapper objectMapper;
+    private static final String DIR = "system/llm-configs";
+
+    private final Documents<LlmConfigId, LlmConfig> configs;
 
     public FileLlmConfigRepository(Path storageDir, Namespace namespace) {
-        this.baseDir = storageDir.resolve(namespace.value()).resolve("system").resolve("llm-configs");
         // Lenient on unknown fields so configs written by newer (or older)
         // versions still load — removed fields must never brick the store.
-        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule())
-                .disable(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        try {
-            Files.createDirectories(this.baseDir);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule())
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        this.configs = Documents.of(LlmConfig.class)
+                .path((LlmConfigId id) -> DIR + "/" + id.value() + ".json")
+                .build(FileRepo.open(storageDir, namespace.value()), objectMapper);
     }
 
     @Override
     public void save(LlmConfig config) {
-        try {
-            AtomicFiles.write(fileFor(config.id().value()), out -> objectMapper.writeValue(out, config));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        configs.compute(config.id(), current -> config.withVersion(Versions.next(
+                current.map(LlmConfig::version).orElse(null), config.version(),
+                "LlmConfig", config.id().value())));
     }
 
     @Override
     public Optional<LlmConfig> findById(LlmConfigId id) {
-        Path file = fileFor(id.value());
-        if (!Files.exists(file)) return Optional.empty();
-        LlmConfig config = read(file);
         // The directory is flat: a file of another tenant with the same value is not this config.
-        return config.id().equals(id) ? Optional.of(config) : Optional.empty();
+        return configs.find(id).filter(config -> config.id().equals(id));
     }
 
     @Override
@@ -59,37 +57,11 @@ public class FileLlmConfigRepository implements LlmConfigRepository {
 
     @Override
     public List<LlmConfig> findAll() {
-        try (var stream = Files.list(baseDir)) {
-            return stream
-                    .filter(p -> p.toString().endsWith(".json"))
-                    .map(p -> read(p))
-                    .toList();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return configs.findAll(DIR);
     }
 
     @Override
     public void deleteById(LlmConfigId id) {
-        if (findById(id).isEmpty()) return;
-        try {
-            Files.deleteIfExists(fileFor(id.value()));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    /** A config written before the namespace was recorded takes the one asked for. */
-    private LlmConfig read(Path file) {
-        try {
-            return objectMapper.readerFor(LlmConfig.class)
-                    .readValue(file.toFile());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private Path fileFor(String id) {
-        return baseDir.resolve(id + ".json");
+        configs.delete(id);
     }
 }

--- a/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/memory/InMemoryLlmConfigRepository.java
+++ b/agents/core/mc-llm-gateway/src/main/java/ai/mindconnect/llm/adapter/memory/InMemoryLlmConfigRepository.java
@@ -17,7 +17,8 @@ public class InMemoryLlmConfigRepository implements LlmConfigRepository {
 
     @Override
     public void save(LlmConfig config) {
-        store.put(config.id(), config);
+        store.compute(config.id(), (id, current) -> config.withVersion(ai.mindconnect.common.Versions.next(
+                current == null ? null : current.version(), config.version(), "LlmConfig", id.value())));
     }
 
     @Override

--- a/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/LlmConfigVersioningTest.java
+++ b/agents/core/mc-llm-gateway/src/test/java/ai/mindconnect/llm/adapter/LlmConfigVersioningTest.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.llm.adapter;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.common.StaleVersionException;
+import ai.mindconnect.llm.adapter.file.FileLlmConfigRepository;
+import ai.mindconnect.llm.adapter.memory.InMemoryLlmConfigRepository;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** An LLM config saved from a form opened before another save is refused — file and in-memory alike. */
+class LlmConfigVersioningTest {
+
+    @Test
+    void theFileStoreChecksVersions(@TempDir Path dir) {
+        versionsAreChecked(new FileLlmConfigRepository(dir, new Namespace("test")));
+    }
+
+    @Test
+    void theInMemoryStoreChecksVersions() {
+        versionsAreChecked(new InMemoryLlmConfigRepository());
+    }
+
+    private static void versionsAreChecked(LlmConfigRepository repo) {
+        LlmConfig config = LlmConfig.lmStudio("local", "qwen", "http://localhost:1234");
+        repo.save(config);
+        LlmConfig stored = repo.findById(config.id()).orElseThrow();
+        assertThat(stored.version()).isEqualTo(1L);
+
+        repo.save(stored.withContextWindowTokens(8192));
+        assertThat(repo.findById(config.id())).map(LlmConfig::version).contains(2L);
+
+        assertThatThrownBy(() -> repo.save(stored.withContextWindowTokens(4096)))
+                .isInstanceOf(StaleVersionException.class);
+        assertThat(repo.findById(config.id())).map(LlmConfig::contextWindowTokens).contains(8192);
+
+        repo.save(stored.withVersion(null).withContextWindowTokens(2048));
+        assertThat(repo.findById(config.id()).orElseThrow())
+                .extracting(LlmConfig::version, LlmConfig::contextWindowTokens)
+                .containsExactly(3L, 2048);
+    }
+}

--- a/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/InitialDataLoader.java
+++ b/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/InitialDataLoader.java
@@ -132,8 +132,9 @@ public class InitialDataLoader implements ApplicationRunner {
         try {
             JsonNode storedNode  = objectMapper.valueToTree(stored);
             JsonNode incomingNode = objectMapper.valueToTree(incoming);
-            // Strip timestamp fields that are expected to differ
-            for (String field : List.of("createdAt", "updatedAt")) {
+            // Strip the fields that are expected to differ: timestamps, and the
+            // version, which counts saves — a seed never carries one.
+            for (String field : List.of("createdAt", "updatedAt", "version")) {
                 ((com.fasterxml.jackson.databind.node.ObjectNode) storedNode).remove(field);
                 ((com.fasterxml.jackson.databind.node.ObjectNode) incomingNode).remove(field);
             }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/MigrationService.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/service/MigrationService.java
@@ -269,7 +269,8 @@ public class MigrationService {
         try {
             JsonNode storedNode   = mapper.valueToTree(stored);
             JsonNode incomingNode = mapper.valueToTree(incoming);
-            for (String field : List.of("createdAt", "updatedAt")) {
+            // The version counts saves, not content: a stored agent has one, a bundled one never does.
+            for (String field : List.of("createdAt", "updatedAt", "version")) {
                 ((ObjectNode) storedNode).remove(field);
                 ((ObjectNode) incomingNode).remove(field);
             }

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentFormComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/AgentFormComponent.java
@@ -97,6 +97,11 @@ public final class AgentFormComponent implements UiComponent {
         var form = UiForm.of(id(), null)
                 .field(UiField.text("name", "Name", isNew ? null : agent.name())
                         .asEditable().asRequired())
+                // The version this form was opened with. Hidden, but submitted like
+                // every named input: the save is refused if the agent was saved since.
+                .field(UiField.text("version", "Version",
+                                isNew || agent.version() == null ? "0" : agent.version().toString())
+                        .asEditable().<UiField>hidden())
                 .field(UiField.text("description", "Description", isNew ? null : agent.description())
                         .asEditable())
                 // The rubric this agent is filed under in the list. A choice

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/component/LlmConfigFormComponent.java
@@ -420,6 +420,12 @@ public final class LlmConfigFormComponent implements UiComponent {
 
         return UiForm.of(id(), isNew ? "New LLM Config" : "Edit LLM Config: " + config.name())
                 .field(nameField(isNew ? null : config.name()))
+                // The version this form was opened with — outside the groups the
+                // alias toggle swaps. Hidden, but submitted: the save is refused if
+                // the config was saved since.
+                .field(UiField.text("version", "Version",
+                                isNew || config.version() == null ? "0" : config.version().toString())
+                        .asEditable().<UiField>hidden())
                 .field(UiField.bool("isAlias", "Is Alias", isAlias)
                         .asEditable()
                         .hint("If set, this config just points at another config by name — handy for a swappable 'default'")

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AgentUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/AgentUiController.java
@@ -21,6 +21,7 @@ import ai.mindconnect.agent.runtime.service.AgentRegistryService;
 import ai.mindconnect.llm.port.out.LlmConfigRepository;
 import ai.mindconnect.chatui.ui.controller.FormBody;
 import ai.mindconnect.agent.runtime.memory.domain.MemoryConfig;
+import ai.mindconnect.common.StaleVersionException;
 import ai.mindconnect.ui.model.UiDialog;
 import ai.mindconnect.ui.model.UiPage;
 import ai.mindconnect.ui.model.UiPatch;
@@ -156,35 +157,43 @@ public class AgentUiController {
         return detail(def.id().value(), null, null, user);
     }
 
+    /**
+     * Saves the edit form against the version it was opened with; when the agent
+     * was saved since, the form stays on screen with a toast instead.
+     */
     @PutMapping("/{id}")
-    public ResponseEntity<UiPage> update(@PathVariable("id") String idValue,
-                                         @RequestBody Map<String, Object> raw,
-                                         @AuthenticationPrincipal OidcUser user) {
+    public ResponseEntity<?> update(@PathVariable("id") String idValue,
+                                    @RequestBody Map<String, Object> raw,
+                                    @AuthenticationPrincipal OidcUser user) {
         AgentId id = AgentId.of(idValue);
         var body = new FormBody(raw);
-        return registryService.find(id)
-                .map(existing -> {
-                    AgentPatch patch = AgentPatch.of()
-                            .withName(body.str("name"))
-                            .withDescription(body.str("description"))
-                            .withGroup(body.str("group"))
-                            .withIcon(body.str("icon"))
-                            .withSystemPrompt(body.str("systemPrompt"))
-                            .withWelcomeMessage(body.str("welcomeMessage"))
-                            .withLlmConfigName(body.str("llmConfigName"))
-                            .withMaxIterations(body.num("maxIterations", existing.maxIterations()))
-                            .withResponseReviewers(body.strList("responseReviewers"))
-                            .withCallableAgents(body.strList("callableAgents"))
-                            .withToolSearch(toolSearchFromForm(body));
-                    try {
-                        patch = withMemoryConfig(patch, body);
-                    } catch (IllegalArgumentException e) {
-                        return ResponseEntity.badRequest().<UiPage>build();
-                    }
-                    val def = registryService.update(id, patch);
-                    return detail(def.id().value(), null, null, user);
-                })
-                .orElse(ResponseEntity.notFound().build());
+        AgentDefinition existing = registryService.find(id).orElse(null);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        AgentPatch patch = AgentPatch.of()
+                .withName(body.str("name"))
+                .withDescription(body.str("description"))
+                .withGroup(body.str("group"))
+                .withIcon(body.str("icon"))
+                .withSystemPrompt(body.str("systemPrompt"))
+                .withWelcomeMessage(body.str("welcomeMessage"))
+                .withLlmConfigName(body.str("llmConfigName"))
+                .withMaxIterations(body.num("maxIterations", existing.maxIterations()))
+                .withResponseReviewers(body.strList("responseReviewers"))
+                .withCallableAgents(body.strList("callableAgents"))
+                .withToolSearch(toolSearchFromForm(body));
+        try {
+            patch = withMemoryConfig(patch, body);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+        try {
+            val def = registryService.update(id, patch, VersionedForms.version(body));
+            return detail(def.id().value(), null, null, user);
+        } catch (StaleVersionException e) {
+            return ResponseEntity.ok(VersionedForms.changedMeanwhile("Agent '" + existing.name() + "'"));
+        }
     }
 
     /**
@@ -332,9 +341,11 @@ public class AgentUiController {
         return registryService.find(id)
                 .map(a -> {
                     AgentTool tool = toolFromBody(AgentToolId.random(), new FormBody(raw));
-                    List<AgentTool> tools = new ArrayList<>(a.tools());
-                    tools.add(tool);
-                    registryService.update(id, toolsPatch(tools));
+                    registryService.updateTools(id, tools -> {
+                        List<AgentTool> next = new ArrayList<>(tools);
+                        next.add(tool);
+                        return next;
+                    });
                     return detail(idValue, "tools", tool.id().value(), user);
                 })
                 .orElse(ResponseEntity.notFound().build());
@@ -350,10 +361,9 @@ public class AgentUiController {
         return registryService.find(id)
                 .map(a -> {
                     AgentTool updated = toolFromBody(toolId, new FormBody(raw));
-                    List<AgentTool> tools = a.tools().stream()
+                    registryService.updateTools(id, tools -> tools.stream()
                             .map(t -> t.id().equals(toolId) ? updated : t)
-                            .toList();
-                    registryService.update(id, toolsPatch(tools));
+                            .toList());
                     return detail(idValue, "tools", toolId.value(), user);
                 })
                 .orElse(ResponseEntity.notFound().build());
@@ -368,18 +378,13 @@ public class AgentUiController {
         String userId = user.getPreferredUsername();
         return registryService.find(id)
                 .map(a -> {
-                    List<AgentTool> tools = a.tools().stream()
-                            .filter(t -> !t.id().equals(toolId)).toList();
-                    registryService.update(id, toolsPatch(tools));
+                    registryService.updateTools(id, tools -> tools.stream()
+                            .filter(t -> !t.id().equals(toolId)).toList());
                     return registryService.find(id)
                             .map(updated -> ResponseEntity.ok(new AgentDetailPage(updated, userId, sessionRepository).refreshTools()))
                             .orElse(ResponseEntity.<UiPatch>notFound().build());
                 })
                 .orElse(ResponseEntity.notFound().build());
-    }
-
-    private static AgentPatch toolsPatch(List<AgentTool> tools) {
-        return AgentPatch.of().withTools(tools);
     }
 
     /** The tool the form describes, under {@code toolId} — a fresh id for a new tool. */

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/LlmConfigUiController.java
@@ -2,6 +2,7 @@ package ai.mindconnect.adminui.ui.controller;
 
 import ai.mindconnect.agentrest.service.LlmConfigTestService;
 import ai.mindconnect.adminui.ui.component.LlmConfigFormComponent;
+import ai.mindconnect.common.StaleVersionException;
 import ai.mindconnect.common.util.EnvVarResolver;
 import ai.mindconnect.common.util.encryption.EncryptionHelper;
 import ai.mindconnect.adminui.ui.component.LlmConfigTestComponent;
@@ -300,39 +301,47 @@ public class LlmConfigUiController {
         return list();
     }
 
+    /**
+     * Saves the edit form against the version it was opened with; when the config
+     * was saved since, the form stays on screen with a toast instead.
+     */
     @PutMapping("/{id}")
-    public ResponseEntity<UiPage> update(@PathVariable("id") String idValue,
-                                         @RequestBody Map<String, Object> raw) {
+    public ResponseEntity<?> update(@PathVariable("id") String idValue,
+                                    @RequestBody Map<String, Object> raw) {
         LlmConfigId id = LlmConfigId.of(idValue);
         var body = new FormBody(raw);
-        return repository.findById(id)
-                .map(existing -> {
-                    boolean isAlias = body.bool("isAlias", existing.isAlias());
-                    LlmProvider provider = isAlias ? null : requiredProvider(body);
-                    var updated = new LlmConfig(
-                            existing.id(),
-                            body.str("name"),
-                            provider,
-                            isAlias ? null : body.str("model"),
-                            isAlias ? null : body.str("baseUrl"),
-                            isAlias ? null : apiKeyForUpdate(existing, provider, body.str("apiKey")),
-                            body.dbl("defaultTemperature", existing.defaultTemperature()),
-                            body.num("maxOutputTokens", existing.maxOutputTokens()),
-                            additionalParamsFrom(body, existing.additionalParams(), provider),
-                            body.numOrNull("contextWindowTokens"),
-                            isAlias,
-                            isAlias ? body.str("delegatesTo") : null,
-                            raw.containsKey("retryEnabled") ? retryFrom(body) : existing.retry(),
-                            raw.containsKey("maxConcurrentRequests")
-                                    ? rateLimitFrom(body) : existing.rateLimit(),
-                            raw.containsKey("type")
-                                    ? typeFrom(body, existing.type()) : existing.type(),
-                            raw.containsKey("capabilities")
-                                    ? capabilitiesFrom(body) : existing.capabilities());
-                    repository.save(updated);
-                    return ResponseEntity.ok(list());
-                })
-                .orElse(ResponseEntity.notFound().build());
+        LlmConfig existing = repository.findById(id).orElse(null);
+        if (existing == null) {
+            return ResponseEntity.notFound().build();
+        }
+        boolean isAlias = body.bool("isAlias", existing.isAlias());
+        LlmProvider provider = isAlias ? null : requiredProvider(body);
+        var updated = new LlmConfig(
+                existing.id(),
+                body.str("name"),
+                provider,
+                isAlias ? null : body.str("model"),
+                isAlias ? null : body.str("baseUrl"),
+                isAlias ? null : apiKeyForUpdate(existing, provider, body.str("apiKey")),
+                body.dbl("defaultTemperature", existing.defaultTemperature()),
+                body.num("maxOutputTokens", existing.maxOutputTokens()),
+                additionalParamsFrom(body, existing.additionalParams(), provider),
+                body.numOrNull("contextWindowTokens"),
+                isAlias,
+                isAlias ? body.str("delegatesTo") : null,
+                raw.containsKey("retryEnabled") ? retryFrom(body) : existing.retry(),
+                raw.containsKey("maxConcurrentRequests")
+                        ? rateLimitFrom(body) : existing.rateLimit(),
+                raw.containsKey("type")
+                        ? typeFrom(body, existing.type()) : existing.type(),
+                raw.containsKey("capabilities")
+                        ? capabilitiesFrom(body) : existing.capabilities());
+        try {
+            repository.save(updated.withVersion(VersionedForms.version(body)));
+        } catch (StaleVersionException e) {
+            return ResponseEntity.ok(VersionedForms.changedMeanwhile("LLM config '" + existing.name() + "'"));
+        }
+        return ResponseEntity.ok(list());
     }
 
     /**

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VectorStoreUiController.java
@@ -1,5 +1,6 @@
 package ai.mindconnect.adminui.ui.controller;
 
+import ai.mindconnect.common.StaleVersionException;
 import ai.mindconnect.llm.port.out.LlmConfigRepository;
 import ai.mindconnect.chatui.ui.controller.FormBody;
 import ai.mindconnect.ui.model.UiAction;
@@ -345,6 +346,11 @@ public class VectorStoreUiController {
                 .field(UiField.text("name", "Name", isNew ? null : t.name()).asEditable()
                         .hint(builtIn ? BUILT_IN_NOTE + " Give this copy a name to save it as a template of your own."
                                 : "Unique template name, e.g. knowledge or chat-uploads"))
+                // The version this form was opened with (0 for a new template).
+                // Hidden, but submitted: the save is refused if the template was saved since.
+                .field(UiField.text("version", "Version",
+                                isNew || t.version() == null ? "0" : t.version().toString())
+                        .asEditable().<UiField>hidden())
                 .field(UiField.select("backend", "Backend", t == null ? "memory" : t.backend(), backends)
                         .asEditable()
                         // Switching the backend swaps the backend-config group below.
@@ -396,8 +402,14 @@ public class VectorStoreUiController {
                         backendConfigGroup(body.str("backend"), current)));
     }
 
+    /**
+     * Saves the template form against the version it was opened with. A new
+     * template's form carries 0, so it does not overwrite one that exists under the
+     * same name; an edit that renamed the template finds nothing under the new name
+     * and saves it as a new template, as before.
+     */
     @PostMapping("/templates")
-    public UiPage saveTemplate(@RequestBody Map<String, Object> raw) {
+    public Object saveTemplate(@RequestBody Map<String, Object> raw) {
         var body = new FormBody(raw);
         String name = body.str("name");
         String refusal = saveRefusal(name);
@@ -410,12 +422,28 @@ public class VectorStoreUiController {
         putIfPresent(backendConfig, "password", body.str("password"));
         Map<String, String> metadata = new LinkedHashMap<>();
         putIfPresent(metadata, "description", body.str("description"));
-        stores.registry().saveTemplate(new VectorStoreTemplate(name.trim(),
+        String templateName = name.trim();
+        VectorStoreTemplate template = new VectorStoreTemplate(templateName,
                 body.str("backend") == null ? "memory" : body.str("backend"),
                 backendConfig,
                 body.str("embeddingConfig") == null ? "embeddings" : body.str("embeddingConfig"),
-                body.str("ingestionWorkflow"), metadata));
-        return list("templates").toast(UiToast.success("Template '" + name.trim() + "' saved."));
+                body.str("ingestionWorkflow"), metadata)
+                .withVersion(VersionedForms.version(body));
+        try {
+            stores.registry().saveTemplate(template);
+        } catch (StaleVersionException e) {
+            if (e.expectedVersion() == 0) {
+                return ai.mindconnect.ui.model.UiPatch.of().toast(UiToast.error("A template named '"
+                        + templateName + "' exists already — nothing was saved. Edit that one, or choose "
+                        + "another name.").title("Not saved"));
+            }
+            if (e.storedVersion() != 0) {
+                return VersionedForms.changedMeanwhile("Template '" + templateName + "'");
+            }
+            // Nothing stored under this name: the edit renamed the template — a new one.
+            stores.registry().saveTemplate(template.withVersion(0L));
+        }
+        return list("templates").toast(UiToast.success("Template '" + templateName + "' saved."));
     }
 
     /** Why a template of this name cannot be saved — {@code null} when it can. */

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VersionedForms.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VersionedForms.java
@@ -1,0 +1,39 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.chatui.ui.controller.FormBody;
+import ai.mindconnect.ui.model.UiPatch;
+import ai.mindconnect.ui.model.UiToast;
+
+/**
+ * Optimistic locking in the admin forms. An edit form carries the version it was
+ * opened with in a hidden {@code version} field; the save passes it on, and a
+ * store that finds another version refuses it.
+ *
+ * <p>The refusal is answered with a toast patch, not with an error status: the
+ * client shows only a generic message for a non-2xx answer, and a patch leaves
+ * the form — and what the user typed into it — on screen.
+ */
+final class VersionedForms {
+
+    static final String FIELD = "version";
+
+    private VersionedForms() {
+    }
+
+    /** The version the form was opened with, or {@code null} when it carries none. */
+    static Long version(FormBody body) {
+        String raw = body.str(FIELD);
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** What the save answers when {@code what} (e.g. "Agent 'scout'") was saved by someone else first. */
+    static UiPatch changedMeanwhile(String what) {
+        return UiPatch.of().toast(UiToast.error(what + " was changed by someone else in the meantime — "
+                + "your changes were not saved. Reload to see the current version.").title("Not saved"));
+    }
+}

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VersionedForms.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VersionedForms.java
@@ -13,7 +13,7 @@ import ai.mindconnect.ui.model.UiToast;
  * client shows only a generic message for a non-2xx answer, and a patch leaves
  * the form — and what the user typed into it — on screen.
  */
-final class VersionedForms {
+class VersionedForms {
 
     static final String FIELD = "version";
 

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/AgentApiController.java
@@ -103,16 +103,32 @@ public class AgentApiController {
         return agent;
     }
 
-    /** Partial update: absent (null) fields keep their current value. */
+    /**
+     * Partial update: absent (null) fields keep their current value. {@code version},
+     * when given, is the agent's version as read: the update is refused with 409 if the
+     * agent was saved since.
+     */
     public record UpdateAgentRequest(String name, String description, String systemPrompt,
                                      String welcomeMessage, String llmConfigName,
                                      Integer maxIterations, List<String> responseReviewers,
-                                     AgentDefinition.ToolSearchConfig toolSearch) {}
+                                     AgentDefinition.ToolSearchConfig toolSearch, Long version) {
+
+        /** Without a version: the update is applied to the agent as stored. */
+        public UpdateAgentRequest(String name, String description, String systemPrompt,
+                                  String welcomeMessage, String llmConfigName,
+                                  Integer maxIterations, List<String> responseReviewers,
+                                  AgentDefinition.ToolSearchConfig toolSearch) {
+            this(name, description, systemPrompt, welcomeMessage, llmConfigName, maxIterations,
+                    responseReviewers, toolSearch, null);
+        }
+    }
 
     @Operation(tags = "Agents", summary = "Update an agent",
             description = "Partial update — absent (null) fields keep their current value. "
                     + "Covers the same fields as the admin UI's edit form, through the same "
-                    + "AgentRegistryService path.")
+                    + "AgentRegistryService path. Send the agent's `version` as you read it to "
+                    + "have the update refused with 409 when the agent was saved since; without "
+                    + "it the update is applied to the agent as stored.")
     @PutMapping("/agents/{agentId}")
     public AgentDefinition updateAgent(@PathVariable String agentId,
                                        @RequestBody UpdateAgentRequest req) {
@@ -126,7 +142,7 @@ public class AgentApiController {
                 .withMaxIterations(req.maxIterations())
                 .withResponseReviewers(req.responseReviewers())
                 .withToolSearch(req.toolSearch());
-        return registryService.update(AgentId.of(agentId), patch);
+        return registryService.update(AgentId.of(agentId), patch, req.version());
     }
 
     @Operation(tags = "Agents", summary = "Delete an agent")

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/VersionConflictAdvice.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/VersionConflictAdvice.java
@@ -1,0 +1,27 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.common.StaleVersionException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+/**
+ * A save that carried a stale version — an agent, an LLM config or a vector-store
+ * template saved by someone else since the client read it — answers 409 Conflict,
+ * with the version now stored so the client can re-read and decide.
+ */
+@RestControllerAdvice(basePackages = "ai.mindconnect.agentrest")
+public class VersionConflictAdvice {
+
+    @ExceptionHandler(StaleVersionException.class)
+    public ResponseEntity<Map<String, Object>> conflict(StaleVersionException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of(
+                "error", e.getMessage(),
+                "code", e.code(),
+                "expectedVersion", e.expectedVersion(),
+                "storedVersion", e.storedVersion()));
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/auth/CurrentUsersTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/auth/CurrentUsersTest.java
@@ -51,7 +51,7 @@ class CurrentUsersTest {
     @Test
     void aSessionOpensOnlyForItsOwner() {
         var repo = new InMemoryAgentSessionRepository();
-        AgentSession alices = repo.save(AgentSession.start(AgentId.of("default-chat"), UserId.of("alice"),
+        AgentSession alices = repo.create(AgentSession.start(AgentId.of("default-chat"), UserId.of("alice"),
                 ConversationId.random()));
         var access = new SessionAccess(repo);
 

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SessionFilesApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SessionFilesApiControllerOwnershipTest.java
@@ -84,7 +84,7 @@ class SessionFilesApiControllerOwnershipTest {
     }
 
     private String session(String owner) {
-        AgentSession session = sessions.save(AgentSession.start(AgentId.of("default-chat"), UserId.of(owner),
+        AgentSession session = sessions.create(AgentSession.start(AgentId.of("default-chat"), UserId.of(owner),
                 ConversationId.random()));
         return session.id().value();
     }

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/VersionConflictAdviceTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/VersionConflictAdviceTest.java
@@ -1,0 +1,21 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.common.StaleVersionException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionConflictAdviceTest {
+
+    @Test
+    void aStaleVersionIsAConflictNamingTheStoredVersion() {
+        var response = new VersionConflictAdvice().conflict(
+                new StaleVersionException("AgentDefinition", "a1", 3, 5));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(409);
+        assertThat(response.getBody())
+                .containsEntry("code", "CONFLICT")
+                .containsEntry("expectedVersion", 3L)
+                .containsEntry("storedVersion", 5L);
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/WorkspaceApiControllerOwnershipTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/WorkspaceApiControllerOwnershipTest.java
@@ -86,6 +86,6 @@ class WorkspaceApiControllerOwnershipTest {
     }
 
     private AgentSession session(String owner) {
-        return sessions.save(AgentSession.start(AGENT, UserId.of(owner), ConversationId.random()));
+        return sessions.create(AgentSession.start(AGENT, UserId.of(owner), ConversationId.random()));
     }
 }

--- a/agents/vectorstore/mc-vector-store-tools/pom.xml
+++ b/agents/vectorstore/mc-vector-store-tools/pom.xml
@@ -24,6 +24,11 @@
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-file-repo</artifactId>
         </dependency>
+        <!-- Versions and StaleVersionException: templates are saved against the version they were read with. -->
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-common</artifactId>
+        </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
             <artifactId>mc-agent-tool-spi</artifactId>

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistry.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistry.java
@@ -55,8 +55,23 @@ public final class FileVectorStoreRegistry {
         return read(templatesDir, name, VectorStoreTemplate.class);
     }
 
-    public void saveTemplate(VectorStoreTemplate template) {
-        write(templatesDir, template.name(), template);
+    /**
+     * Saves the template: the version it carries is checked against the stored one
+     * and it is stored one higher, both under the file's lock ({@code null}: no check).
+     *
+     * @return the template as stored, with its new version
+     * @throws ai.mindconnect.common.StaleVersionException when it was saved by someone else meanwhile
+     */
+    public VectorStoreTemplate saveTemplate(VectorStoreTemplate template) {
+        Path file = fileFor(templatesDir, template.name());
+        return locked(file, () -> {
+            Long stored = read(templatesDir, template.name(), VectorStoreTemplate.class)
+                    .map(VectorStoreTemplate::version).orElse(null);
+            VectorStoreTemplate saved = template.withVersion(ai.mindconnect.common.Versions.next(
+                    stored, template.version(), "VectorStoreTemplate", template.name()));
+            store(file, saved);
+            return saved;
+        });
     }
 
     public void deleteTemplate(String name) {

--- a/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStoreTemplate.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/main/java/ai/mindconnect/vectorstore/tools/VectorStoreTemplate.java
@@ -15,6 +15,9 @@ import java.util.Map;
  * @param embeddingConfig   LlmConfig name for the embedding model
  * @param ingestionWorkflow workflow started by "Ingest file…" (e.g. {@code file-ingestion}); optional
  * @param metadata          free key-values (description, tags, chunking hints)
+ * @param version           the stored version this template was read with — a save with a
+ *                          version is refused once another save came in between;
+ *                          {@code null} saves without that check
  */
 public record VectorStoreTemplate(
         String name,
@@ -22,10 +25,23 @@ public record VectorStoreTemplate(
         Map<String, String> backendConfig,
         String embeddingConfig,
         String ingestionWorkflow,
-        Map<String, String> metadata
+        Map<String, String> metadata,
+        Long version
 ) {
     public VectorStoreTemplate {
         if (backendConfig == null) backendConfig = Map.of();
         if (metadata == null) metadata = Map.of();
+    }
+
+    /** Without a version: the template saves without a version check. */
+    public VectorStoreTemplate(String name, String backend, Map<String, String> backendConfig,
+                               String embeddingConfig, String ingestionWorkflow, Map<String, String> metadata) {
+        this(name, backend, backendConfig, embeddingConfig, ingestionWorkflow, metadata, null);
+    }
+
+    /** This template as read with, or to be saved against, {@code version} — nothing else changes. */
+    public VectorStoreTemplate withVersion(Long version) {
+        return new VectorStoreTemplate(name, backend, backendConfig, embeddingConfig, ingestionWorkflow,
+                metadata, version);
     }
 }

--- a/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistryTest.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/FileVectorStoreRegistryTest.java
@@ -52,12 +52,13 @@ class FileVectorStoreRegistryTest {
         VectorStoreTemplate template = new VectorStoreTemplate("Chat Uploads", "memory", Map.of(),
                 "embeddings", null, Map.of("description", "per chat"));
 
-        registry.saveTemplate(template);
+        VectorStoreTemplate saved = registry.saveTemplate(template);
         VectorStoreInstance instance = registry.registerInstance(
                 VectorStoreInstance.fromTemplate("docs", template, VectorStoreInstance.Scope.GLOBAL, null));
 
-        assertThat(registry.template("Chat Uploads")).contains(template);
-        assertThat(registry.templates()).containsExactly(template);
+        assertThat(saved.version()).isEqualTo(1L);
+        assertThat(registry.template("Chat Uploads")).contains(saved);
+        assertThat(registry.templates()).containsExactly(saved);
         assertThat(registry.instances(VectorStoreInstance.Scope.GLOBAL, null)).containsExactly(instance);
         registry.deleteInstance("docs");
         assertThat(registry.instance("docs")).isEmpty();

--- a/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/TemplateVersioningTest.java
+++ b/agents/vectorstore/mc-vector-store-tools/src/test/java/ai/mindconnect/vectorstore/tools/TemplateVersioningTest.java
@@ -1,0 +1,36 @@
+package ai.mindconnect.vectorstore.tools;
+
+import ai.mindconnect.common.StaleVersionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** A template saved from a form opened before another save is refused. */
+class TemplateVersioningTest {
+
+    @Test
+    void aSaveAgainstAStaleVersionIsRefused(@TempDir Path dir) {
+        FileVectorStoreRegistry registry = new FileVectorStoreRegistry(dir.resolve("vector-stores"));
+        VectorStoreTemplate template = new VectorStoreTemplate("knowledge", "memory", Map.of(),
+                "embeddings", null, Map.of());
+
+        VectorStoreTemplate first = registry.saveTemplate(template.withVersion(0L));
+        assertThat(first.version()).isEqualTo(1L);
+        VectorStoreTemplate second = registry.saveTemplate(first.withVersion(1L));
+        assertThat(second.version()).isEqualTo(2L);
+
+        assertThatThrownBy(() -> registry.saveTemplate(first))
+                .isInstanceOf(StaleVersionException.class);
+        assertThatThrownBy(() -> registry.saveTemplate(template.withVersion(0L)))
+                .as("a new template does not overwrite one of the same name")
+                .isInstanceOf(StaleVersionException.class);
+        assertThat(registry.template("knowledge")).map(VectorStoreTemplate::version).contains(2L);
+
+        assertThat(registry.saveTemplate(template).version()).as("no version: no check").isEqualTo(3L);
+    }
+}

--- a/common/mc-common/src/main/java/ai/mindconnect/common/StaleVersionException.java
+++ b/common/mc-common/src/main/java/ai/mindconnect/common/StaleVersionException.java
@@ -1,0 +1,30 @@
+package ai.mindconnect.common;
+
+/**
+ * A save carried a version that is no longer the stored one: someone else saved
+ * the entity in between. Nothing was written. The caller shows the current state
+ * and lets the user decide — it does not retry with the newer version, which
+ * would overwrite exactly the change the check just caught.
+ */
+public class StaleVersionException extends DomainException {
+
+    public static final String CODE = "CONFLICT";
+
+    private final long expectedVersion;
+    private final long storedVersion;
+
+    public StaleVersionException(String entity, String id, long expectedVersion, long storedVersion) {
+        super(CODE, entity + " " + id + " was changed meanwhile (edited version " + expectedVersion
+                + ", stored version " + storedVersion + ")");
+        this.expectedVersion = expectedVersion;
+        this.storedVersion = storedVersion;
+    }
+
+    public long expectedVersion() {
+        return expectedVersion;
+    }
+
+    public long storedVersion() {
+        return storedVersion;
+    }
+}

--- a/common/mc-common/src/main/java/ai/mindconnect/common/Versions.java
+++ b/common/mc-common/src/main/java/ai/mindconnect/common/Versions.java
@@ -1,0 +1,32 @@
+package ai.mindconnect.common;
+
+/**
+ * Optimistic locking for entities edited as a whole — in a form, through a REST
+ * {@code PUT}. The entity carries the version it was read with; a store saves it
+ * only if that is still the stored version, and stores it one higher.
+ *
+ * <p>A {@code null} version means "no check": the save overwrites whatever is
+ * stored, as every save did before versions existed. Seeds, imports and API
+ * clients that never read a version keep working that way.
+ */
+public final class Versions {
+
+    private Versions() {
+    }
+
+    /**
+     * The version to store.
+     *
+     * @param stored   the stored entity's version; {@code null} when there is none, or
+     *                 when it was written before versions existed — both count as 0
+     * @param expected the version the entity being saved was read with; {@code null}: no check
+     * @throws StaleVersionException when {@code expected} is not the stored version
+     */
+    public static long next(Long stored, Long expected, String entity, String id) {
+        long current = stored == null ? 0 : stored;
+        if (expected != null && expected != current) {
+            throw new StaleVersionException(entity, id, expected, current);
+        }
+        return current + 1;
+    }
+}

--- a/common/mc-common/src/main/java/ai/mindconnect/common/Versions.java
+++ b/common/mc-common/src/main/java/ai/mindconnect/common/Versions.java
@@ -9,7 +9,7 @@ package ai.mindconnect.common;
  * stored, as every save did before versions existed. Seeds, imports and API
  * clients that never read a version keep working that way.
  */
-public final class Versions {
+public class Versions {
 
     private Versions() {
     }

--- a/common/mc-common/src/test/java/ai/mindconnect/common/VersionsTest.java
+++ b/common/mc-common/src/test/java/ai/mindconnect/common/VersionsTest.java
@@ -1,0 +1,31 @@
+package ai.mindconnect.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VersionsTest {
+
+    @Test
+    void aSaveWithoutVersionIsNotChecked() {
+        assertThat(Versions.next(null, null, "Agent", "a")).isEqualTo(1);
+        assertThat(Versions.next(7L, null, "Agent", "a")).isEqualTo(8);
+    }
+
+    @Test
+    void theEditedVersionMustBeTheStoredOne() {
+        assertThat(Versions.next(3L, 3L, "Agent", "a")).isEqualTo(4);
+        assertThat(Versions.next(null, 0L, "Agent", "a")).as("nothing stored counts as 0").isEqualTo(1);
+
+        assertThatThrownBy(() -> Versions.next(4L, 3L, "Agent", "a"))
+                .isInstanceOf(StaleVersionException.class)
+                .hasMessageContaining("Agent a")
+                .satisfies(e -> {
+                    StaleVersionException stale = (StaleVersionException) e;
+                    assertThat(stale.code()).isEqualTo(StaleVersionException.CODE);
+                    assertThat(stale.expectedVersion()).isEqualTo(3);
+                    assertThat(stale.storedVersion()).isEqualTo(4);
+                });
+    }
+}

--- a/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/Documents.java
+++ b/common/mc-file-repo/src/main/java/ai/mindconnect/filerepo/Documents.java
@@ -179,6 +179,26 @@ public class Documents<K, V> {
     }
 
     /**
+     * Reads the document — empty when there is none — lets {@code change} decide
+     * what to store, and writes that, all under the document's write lock. For a
+     * save that depends on what is stored, whether or not anything is: a version
+     * check, say. Returning the very instance that was read writes nothing.
+     *
+     * @return what is stored afterwards
+     */
+    public V compute(K key, Function<Optional<V>, V> change) {
+        Path file = pathOf(key);
+        return locked(file, () -> {
+            Optional<V> current = read(file);
+            V next = Objects.requireNonNull(change.apply(current), "compute: the change returned null");
+            if (current.isEmpty() || next != current.get()) {
+                store(file, next);
+            }
+            return next;
+        });
+    }
+
+    /**
      * Stores {@code value} under {@code key}, replacing whatever is there. For
      * documents that are rebuilt whole rather than changed — a snapshot, a list
      * a tool replaces. For anything else, {@link #update} does not lose a

--- a/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/DocumentsComputeTest.java
+++ b/common/mc-file-repo/src/test/java/ai/mindconnect/filerepo/DocumentsComputeTest.java
@@ -1,0 +1,59 @@
+package ai.mindconnect.filerepo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** {@code compute}: decide on the stored document — or on its absence — and write, under one lock. */
+class DocumentsComputeTest {
+
+    record Counter(String id, int value) { }
+
+    @TempDir
+    Path dir;
+
+    private Documents<String, Counter> counters() {
+        return Documents.of(Counter.class)
+                .path((String id) -> "counters/" + id + ".json")
+                .lockTimeout(Duration.ofMinutes(1))
+                .build(FileRepo.open(dir.resolve("data"), "ns"), new ObjectMapper());
+    }
+
+    @Test
+    void computeCreatesChangesOrLeavesTheDocumentAlone() {
+        Documents<String, Counter> counters = counters();
+
+        assertThat(counters.compute("a", c -> c.map(x -> new Counter("a", x.value() + 1))
+                .orElse(new Counter("a", 1)))).isEqualTo(new Counter("a", 1));
+        assertThat(counters.compute("a", c -> new Counter("a", c.orElseThrow().value() + 1)))
+                .isEqualTo(new Counter("a", 2));
+        assertThat(counters.compute("a", c -> c.orElseThrow())).isEqualTo(new Counter("a", 2));
+        assertThat(counters.find("a")).contains(new Counter("a", 2));
+    }
+
+    @Test
+    void concurrentComputesStartingFromNothingAllLand() throws Exception {
+        Documents<String, Counter> counters = counters();
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 500; i++) {
+                futures.add(pool.submit(() -> counters.compute("shared",
+                        c -> new Counter("shared", c.map(Counter::value).orElse(0) + 1))));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(counters.find("shared")).contains(new Counter("shared", 500));
+    }
+}

--- a/common/mc-jdbc/src/main/java/ai/mindconnect/jdbc/DocumentTable.java
+++ b/common/mc-jdbc/src/main/java/ai/mindconnect/jdbc/DocumentTable.java
@@ -240,6 +240,51 @@ public final class DocumentTable<T> {
         });
     }
 
+    /**
+     * Reads the row — empty when there is none — lets {@code change} decide what to
+     * store, and writes that: an existing row {@code FOR UPDATE} in one transaction,
+     * a missing one by insert. When another writer inserts the row in between, the
+     * change runs again on that row. For a save that depends on what is stored,
+     * whether or not anything is — a version check, say.
+     *
+     * @return what is stored afterwards
+     */
+    public T compute(Object idValue, Function<Optional<T>, T> change) {
+        requireNoPartition("compute");
+        return compute(change, () -> update(idValue, current -> change.apply(Optional.of(current))), idValue);
+    }
+
+    /** {@link #compute(Object, Function)} for a table with a {@link Builder#partitionKey partition key}. */
+    public T compute(Object partitionValue, Object idValue, Function<Optional<T>, T> change) {
+        requirePartition("compute");
+        return compute(change, () -> update(partitionValue, idValue, current -> change.apply(Optional.of(current))),
+                partitionValue, idValue);
+    }
+
+    private T compute(Function<Optional<T>, T> change, java.util.function.Supplier<Optional<T>> updateExisting,
+                      Object... key) {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            Optional<T> updated = updateExisting.get();
+            if (updated.isPresent()) {
+                return updated.get();
+            }
+            T created = Objects.requireNonNull(change.apply(Optional.empty()), "compute: the change returned null");
+            Object[] createdKey = partition == null
+                    ? new Object[]{id.value().apply(created)}
+                    : new Object[]{partition.value().apply(created), id.value().apply(created)};
+            if (!Arrays.equals(createdKey, key)) {
+                throw new JdbcException("compute() must create the " + table + " row " + Arrays.toString(key)
+                        + ", not " + Arrays.toString(createdKey));
+            }
+            if (insert(created)) {
+                return created;
+            }
+            // Inserted by another writer meanwhile: apply the change to that row.
+        }
+        throw new JdbcException("compute() on " + table + " row " + Arrays.toString(key)
+                + " kept losing the race to insert it");
+    }
+
     private boolean sameKey(T a, T b) {
         return Objects.equals(id.value().apply(a), id.value().apply(b))
                 && (partition == null || Objects.equals(partition.value().apply(a), partition.value().apply(b)));

--- a/common/mc-jdbc/src/test/java/ai/mindconnect/jdbc/DocumentTableComputePostgresTest.java
+++ b/common/mc-jdbc/src/test/java/ai/mindconnect/jdbc/DocumentTableComputePostgresTest.java
@@ -1,0 +1,67 @@
+package ai.mindconnect.jdbc;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** {@code compute} against a real Postgres; skipped when none is reachable. */
+class DocumentTableComputePostgresTest {
+
+    record Counter(String namespace, String id, int value) { }
+
+    private DocumentTable<Counter> counters;
+
+    @BeforeEach
+    void setUp() {
+        Sql sql = Sql.of(TestDb.requirePostgres());
+        sql.execute("DROP TABLE IF EXISTS mc_jdbc_test_counter");
+        counters = DocumentTable.of(Counter.class)
+                .table("mc_jdbc_test_counter")
+                .partitionKey("namespace", "TEXT", Counter::namespace)
+                .id("id", "TEXT", Counter::id)
+                .build(sql);
+        counters.createSchema();
+    }
+
+    private static Counter next(Optional<Counter> current) {
+        return new Counter("ns", "c", current.map(Counter::value).orElse(0) + 1);
+    }
+
+    @Test
+    void computeInsertsAMissingRowAndUpdatesAnExistingOne() {
+        assertThat(counters.compute("ns", "c", DocumentTableComputePostgresTest::next))
+                .isEqualTo(new Counter("ns", "c", 1));
+        assertThat(counters.compute("ns", "c", DocumentTableComputePostgresTest::next))
+                .isEqualTo(new Counter("ns", "c", 2));
+        assertThat(counters.findById("ns", "c")).contains(new Counter("ns", "c", 2));
+    }
+
+    @Test
+    void concurrentComputesOnAMissingRowAllLand() throws Exception {
+        try (ExecutorService pool = Executors.newFixedThreadPool(8)) {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 50; i++) {
+                futures.add(pool.submit(() -> counters.compute("ns", "c", DocumentTableComputePostgresTest::next)));
+            }
+            for (Future<?> future : futures) future.get();
+        }
+
+        assertThat(counters.findById("ns", "c")).contains(new Counter("ns", "c", 50));
+    }
+
+    @Test
+    void computeMustCreateTheRowItWasAskedFor() {
+        assertThatThrownBy(() -> counters.compute("ns", "c", current -> new Counter("ns", "other", 1)))
+                .isInstanceOf(JdbcException.class);
+        assertThat(counters.findAll()).isEmpty();
+    }
+}

--- a/website/docs/agents/rest-api.md
+++ b/website/docs/agents/rest-api.md
@@ -60,6 +60,22 @@ Agents, LLM configs, knowledge-base vector stores and workflows are shared
 configuration, open to every authenticated caller; a chat's upload store
 (`session-…`) answers only to the chat's user.
 
+## Concurrent edits
+
+Agents, LLM configs and vector-store templates carry a `version` that every
+save raises. Send the version you read with a save to have it refused when
+someone else saved in between:
+
+- `PUT /api/agents/{id}` — `version` in the body, next to the fields you change
+- `POST /api/llm-configs`, `POST /api/vector-stores/templates` — the object as
+  you read it, `version` included
+
+A stale version answers `409 Conflict`, with `expectedVersion` and
+`storedVersion` in the body: read the object again and decide what to keep.
+Without a `version` a save overwrites whatever is stored, as it always did —
+what an import or a seed wants. A template saved with `"version": 0` is
+refused when one of that name exists already.
+
 ## OpenAI Responses API
 
 The admin UI app also serves OpenAI's Responses API, in OpenAI's own wire


### PR DESCRIPTION
Re-opens #74, whose content never reached `main`: it still pointed at its
stacked base `feature/locking-file-repo` when it was merged, so it landed in
a branch that was already merged. This branch is that work rebased onto
current `main`. It also carries the `main` build fix from #76 — merge that
one first and this commit disappears in the rebase.

## What does this PR do?

Agent definitions, LLM configs and vector-store templates are edited as a whole — in an admin form or through a REST save — so two editors who opened the same object overwrote each other: the second save carried the first editor's copy of every field. They now carry a `version` that every save raises, and a save that carries a stale version is refused.

- **Domain** — `AgentDefinition`, `LlmConfig` and `VectorStoreTemplate` gain `Long version`. The constructors without it stay and mean "no version".
- **Rule** (`Versions`, `StaleVersionException` in `mc-common`) — a save with a version is stored only while that is still the stored version (nothing stored counts as 0), and stores it one higher. A save **without** a version is not checked and overwrites as before: seeds, imports and existing API clients keep working.
- **Where the check runs** — where the write happens, so two saves cannot both pass it: under the document's lock in the file stores (`Documents.compute`, new), on the row read `FOR UPDATE` in Postgres (`DocumentTable.compute`, new — insert when missing, re-run on a racing insert), inside `ConcurrentHashMap.compute` in memory, under the template file's path lock in `FileVectorStoreRegistry`. The agent and LLM-config file stores now go through `Documents`.
- **Admin UI** — the agent, LLM-config and template forms carry the version they were opened with in a hidden field (`asEditable().hidden()`, which semantic-ui still submits). A stale save answers with a toast patch — "was changed by someone else in the meantime — your changes were not saved" — so the form and what was typed stay on screen (the client would show only a generic message for a non-2xx answer). A new template no longer replaces an existing one of the same name; renaming a template still saves it as a new one.
- **Agents** — `AgentRegistryService.update(id, patch, version)` for the form; `update(id, patch)` without a version re-applies the patch when another save came in between. Adding, editing and removing a tool go through `updateTools(id, change)` on the stored list, so a tool added meanwhile is kept.
- **REST** — a stale version answers `409 Conflict` with `expectedVersion` and `storedVersion` (`VersionConflictAdvice`). `PUT /api/agents/{id}` takes an optional `version`; `POST /api/llm-configs` and `POST /api/vector-stores/templates` check the `version` in the body. Documented in `website/docs/agents/rest-api.md`.
- **Migration and initial data** — the diffs ignore `version`, which counts saves, not content; a bundled seed carries none, so applying it overwrites as before.

## Affected area

agent runtime · common · docs

## Checklist

- [x] I targeted the `main` branch from a fork/branch (no direct push).
- [x] The change is focused (one topic).
- [x] I built and tested the affected module(s) locally
      (`mvn -f <area>/pom.xml clean install`).
- [x] I added/updated tests where it makes sense.
- [x] I updated docs/README if behaviour changed.
- [x] I have read and accept the [CLA](/CLA.md) and
      [Contributing guide](/CONTRIBUTING.md).

## Verification

- Every module that depends on the changed ones, after a full install: 714 tests, 0 failures, 8 skipped (live OpenAI tests without keys). Postgres tests ran against a local pgvector.
- New tests: `Versions`; `Documents.compute` (500 concurrent computes from nothing); `DocumentTable.compute` on Postgres (insert, update, 50 concurrent computes on a missing row); agent definitions on file, memory and Postgres and LLM configs on file and memory — a stale save refused, a save without a version not checked, of 20 concurrent saves from the same read exactly one lands; templates, including "new template with an existing name"; `AgentRegistryService` refusing a stale form and re-applying a tool change after a racing save; the 409 advice.
- Not verified by hand in a browser: the conflict toast in the three forms.

## Related issues

Replaces #74. Follows #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)