### PR TITLE
An attached file is a file on disk, and the tools say so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Fixed
+
+- **agents:** a file attached to a chat is findable on disk, not just by
+  search. The document tools said in their own description that an attached
+  file "has no path, use vector_search for it" — it has one since the chat
+  keeps its uploads in its own directory, and a model follows the tool's
+  description over the prompt, so it never opened the file. The prompt now
+  also names the path the tools take (`uploads/<name>` from the working
+  directory) beside the absolute one, `glob` says that it returns files and
+  never directories — `*` in a directory of sub-directories finds nothing —
+  and the bundled `coding-assistant` gets `file_list`, which it was missing.
+
 ## [0.8.0] - 2026-09-11
 
 ### Added

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/coding-assistant.json
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/agent-definitions/coding-assistant.json
@@ -38,6 +38,15 @@
       "needsApproval": false
     },
     {
+      "id": "00000003-0000-0000-0000-000000000910",
+      "agentDefinitionId": "00000002-0000-0000-0000-000000000013",
+      "name": "file_list",
+      "description": "Lists what a directory holds, sub-directories included — where glob only finds files.",
+      "enabled": true,
+      "deferred": false,
+      "needsApproval": false
+    },
+    {
       "id": "00000003-0000-0000-0000-000000000902",
       "agentDefinitionId": "00000002-0000-0000-0000-000000000013",
       "name": "file_read",

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRenderer.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRenderer.java
@@ -86,14 +86,15 @@ public final class SystemPromptRenderer {
             }
             out.append('\n');
         }
-        out.append("Their content is indexed for semantic search. To answer anything about them, "
-                + "call `vector_search` with your question (no `store` argument needed) and read the "
-                + "returned chunks.");
         if (anyOnDisk) {
-            out.append(" A file with a path is also a file on disk — `file_read`, `document_outline`, "
-                    + "`read_document`, `grep_document` and `bash` open it by that path, for the parts "
-                    + "a search does not surface.");
+            out.append("A file with a path is a file on disk: open it by that path — `file_read` for "
+                    + "text and code, `document_outline`, `document_sections`, `read_document` and "
+                    + "`grep_document` for PDF and Word — whenever the exact content, the structure or "
+                    + "a passage in context is what the question needs. ");
         }
+        out.append("Their content is also indexed for semantic search: `vector_search` with your "
+                + "question (no `store` argument needed) finds passages across all of them, which is "
+                + "the way into a long document and the only way to a file without a path.");
         if (searchable.stream().anyMatch(f -> !f.hasPath())) {
             out.append(" A file without a path is NOT on the filesystem: `file_read`, `document_outline`, "
                     + "`read_document`, `grep_document` and `bash` cannot open it, and its name is not a path.");

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRenderer.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRenderer.java
@@ -78,6 +78,10 @@ public final class SystemPromptRenderer {
             out.append("- ").append(file.name()).append(" (").append(AttachmentNotice.kind(file.name())).append(")");
             if (file.hasPath()) {
                 out.append(" — on disk at `").append(file.path()).append('`');
+                String inWorkingDir = relativeToWorkingDir(session, file.path());
+                if (inWorkingDir != null) {
+                    out.append(", i.e. `").append(inWorkingDir).append("` from the working directory");
+                }
                 anyOnDisk = true;
             }
             out.append('\n');
@@ -95,5 +99,22 @@ public final class SystemPromptRenderer {
                     + "`read_document`, `grep_document` and `bash` cannot open it, and its name is not a path.");
         }
         return out.toString();
+    }
+
+    /**
+     * The file's path as the tools take it here: relative to the session's
+     * working directory, which is what a model types after reading this
+     * section. Null when the session works elsewhere — then the absolute
+     * path is the only one that works.
+     */
+    private static String relativeToWorkingDir(AgentSession session, String path) {
+        if (path == null || !session.hasWorkingDir()) return null;
+        try {
+            java.nio.file.Path base = java.nio.file.Path.of(session.workingDir()).toAbsolutePath().normalize();
+            java.nio.file.Path file = java.nio.file.Path.of(path).toAbsolutePath().normalize();
+            return file.startsWith(base) && !file.equals(base) ? base.relativize(file).toString() : null;
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 }

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRendererWorkingDirTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRendererWorkingDirTest.java
@@ -65,4 +65,28 @@ class SystemPromptRendererWorkingDirTest {
                 session().withAttachedFiles(java.util.List.of(onDisk)));
         assertThat(onlyOnDisk).doesNotContain("NOT on the filesystem");
     }
+
+    @Test
+    void anUploadInTheChatsOwnDirectoryIsNamedTheWayTheToolsTakeIt() {
+        // The model types what the prompt shows, and `uploads/spec.docx` is
+        // what file_read, document_outline and grep_document want here.
+        var upload = new ai.mindconnect.agent.runtime.domain.AttachedFile("f1", "spec.docx", null, 10,
+                "/home/u/sessions/s1/uploads/spec.docx");
+
+        String inOwnDir = SystemPromptRenderer.attachedFilesSection(session()
+                .withWorkingDir("/home/u/sessions/s1")
+                .withAttachedFiles(java.util.List.of(upload)));
+        assertThat(inOwnDir)
+                .contains("on disk at `/home/u/sessions/s1/uploads/spec.docx`")
+                .contains("i.e. `uploads/spec.docx` from the working directory");
+
+        // A chat working in a project keeps the absolute path — the short one
+        // would point somewhere else.
+        String inProject = SystemPromptRenderer.attachedFilesSection(session()
+                .withWorkingDir("/home/u/project")
+                .withAttachedFiles(java.util.List.of(upload)));
+        assertThat(inProject)
+                .contains("on disk at `/home/u/sessions/s1/uploads/spec.docx`")
+                .doesNotContain("from the working directory");
+    }
 }

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRendererWorkingDirTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/service/prompt/SystemPromptRendererWorkingDirTest.java
@@ -58,7 +58,7 @@ class SystemPromptRendererWorkingDirTest {
         assertThat(both)
                 .contains("- spec.docx (Word document) — on disk at `/home/u/sessions/s1/uploads/spec.docx`")
                 .contains("- notes.md (Markdown)\n")
-                .contains("A file with a path is also a file on disk")
+                .contains("A file with a path is a file on disk: open it by that path")
                 .contains("A file without a path is NOT on the filesystem");
 
         String onlyOnDisk = SystemPromptRenderer.attachedFilesSection(

--- a/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/DocumentFileReadTool.java
+++ b/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/DocumentFileReadTool.java
@@ -37,8 +37,8 @@ public class DocumentFileReadTool implements Tool {
         return "Reads the contents of a file at the given path (relative to the base directory). " +
                "Supports plain text, PDF, Word, HTML, and other document formats via Apache Tika. " +
                "For large multi-page documents prefer document_outline + read_document for targeted access. " +
-               "Only for files on the filesystem — a file the user attached to this chat has no path; " +
-               "use vector_search for it.";
+               "A file the user attached to this chat is on the filesystem too when the prompt names " +
+               "a path for it — pass that path; without a path use vector_search for it.";
     }
 
     @Override

--- a/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/DocumentOutlineTool.java
+++ b/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/DocumentOutlineTool.java
@@ -45,7 +45,7 @@ public class DocumentOutlineTool implements Tool {
 
     @Override
     public String description() {
-        return "On the filesystem only — a file the user attached to this chat has no path, use vector_search for it. " +
+        return "Opens a file on the filesystem. A file the user attached to this chat is one too when the prompt names a path for it — pass that path; without a path it is not on the filesystem and vector_search is the way to it. " +
                "Returns the structural outline of a long document (PDF or Word .docx) — total " +
                "page count, approximate token count, and a tree of headings/bookmarks with their " +
                "page ranges. Use this FIRST when asked about a long document so you can decide " +

--- a/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/DocumentSectionsTool.java
+++ b/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/DocumentSectionsTool.java
@@ -46,7 +46,7 @@ public final class DocumentSectionsTool implements Tool {
 
     @Override
     public String description() {
-        return "On the filesystem only — a file the user attached to this chat has no path, use vector_search for it. " +
+        return "Opens a file on the filesystem. A file the user attached to this chat is one too when the prompt names a path for it — pass that path; without a path it is not on the filesystem and vector_search is the way to it. " +
                "Splits a document (PDF, Word .docx, text/markdown) into its sections — one per " +
                "heading, each with its exact content — and returns them as a JSON array: " +
                "{\"path\", \"sectionCount\", \"sections\": [{\"index\", \"level\", \"title\", \"content\"}]}. " +

--- a/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/GrepDocumentTool.java
+++ b/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/GrepDocumentTool.java
@@ -51,7 +51,7 @@ public class GrepDocumentTool implements Tool {
 
     @Override
     public String description() {
-        return "On the filesystem only — a file the user attached to this chat has no path, use vector_search for it. " +
+        return "Opens a file on the filesystem. A file the user attached to this chat is one too when the prompt names a path for it — pass that path; without a path it is not on the filesystem and vector_search is the way to it. " +
                "Searches inside a single long document (PDF or Word .docx) for a regex pattern. " +
                "Returns each match with `[page N]` and the surrounding lines, so you can locate " +
                "specific clauses or terms without reading the whole file.\n" +

--- a/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/ReadDocumentTool.java
+++ b/agents/core/mc-agent-tools-document/src/main/java/ai/mindconnect/agent/tools/document/ReadDocumentTool.java
@@ -45,7 +45,7 @@ public class ReadDocumentTool implements Tool {
 
     @Override
     public String description() {
-        return "On the filesystem only — a file the user attached to this chat has no path, use vector_search for it. " +
+        return "Opens a file on the filesystem. A file the user attached to this chat is one too when the prompt names a path for it — pass that path; without a path it is not on the filesystem and vector_search is the way to it. " +
                "Reads a specific page range from a long document (PDF or Word .docx). Returns " +
                "the text with `[page N]` markers so you can cite exact pages back to the user.\n" +
                "Always use `document_outline` FIRST to see how many pages exist and where the " +

--- a/agents/core/mc-agent-tools/src/main/java/ai/mindconnect/agent/tools/builtin/GlobTool.java
+++ b/agents/core/mc-agent-tools/src/main/java/ai/mindconnect/agent/tools/builtin/GlobTool.java
@@ -91,7 +91,10 @@ public class GlobTool implements Tool {
                 : "`pattern` is required; `path` is a sub-directory of the working directory " +
                   baseDir + " and defaults to the working directory itself.\n";
         return "Finds files by name pattern under a given directory. Returns paths newest first " +
-               "(sorted by modification time). Pure path matching — does NOT read file contents; " +
+               "(sorted by modification time). Files only — a directory never appears in the " +
+               "result, so `*` in a directory that holds only sub-directories (a chat's " +
+               "`uploads/`, say) finds nothing: use `**/*` to look inside them, or file_list " +
+               "to see what a directory holds. Pure path matching — does NOT read file contents; " +
                "use grep for that.\n" +
                where +
                "Pattern examples:\n" +

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/coding-assistant.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/agent-definitions/coding-assistant.json
@@ -38,6 +38,15 @@
       "needsApproval": false
     },
     {
+      "id": "00000003-0000-0000-0000-000000000910",
+      "agentDefinitionId": "00000002-0000-0000-0000-000000000013",
+      "name": "file_list",
+      "description": "Lists what a directory holds, sub-directories included — where glob only finds files.",
+      "enabled": true,
+      "deferred": false,
+      "needsApproval": false
+    },
+    {
       "id": "00000003-0000-0000-0000-000000000902",
       "agentDefinitionId": "00000002-0000-0000-0000-000000000013",
       "name": "file_read",


### PR DESCRIPTION
Measured on app.mindconnect.ai (0.8.0): uploading a file into a chat works — it lands in the chat's own `uploads/` directory, `file_list` and `file_read` reach it — but the model does not go there.

Three reasons, all fixed here:

- The five document tools said in their own description: *"a file the user attached to this chat has no path, use vector_search for it"*. The prompt says the opposite (and is right). A model follows the tool description: asked for `document_sections` on an upload, `default-chat` called `vector_search` instead.
- `glob '*'` in the working directory answers "No files matched" when the directory holds only `uploads/` — directories never appear in its result. The description now says so and points at `**/*` and `file_list`.
- The bundled `coding-assistant` has no `file_list` at all, so with it nothing lists a directory. It gets one.

The prompt now also names the path the tools take (`uploads/spec.docx` from the working directory) beside the absolute one — that is what a model types.

New test: `SystemPromptRendererWorkingDirTest.anUploadInTheChatsOwnDirectoryIsNamedTheWayTheToolsTakeIt` — short path in a chat working in its own directory, absolute only when it works elsewhere.

Note for deployments: the `coding-assistant` change is initial data. An installation whose stored agent differs keeps the stored one; apply it in the Migrations tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)