### PR TITLE
Registries: import LLM configs, agents, workflows and packages from a GitHub project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,11 @@ fresh empty one, so nothing has to be moved by hand at release time.
   runs on, the config behind it — says *Used by …* and starts unticked.
   Importing keeps what is already here unless overwrite is chosen, an overwrite
   keeps local ids so that sessions and aliases keep working, and an API key
-  that came with a registry file is dropped rather than used. Off for an
-  installation that wants no outbound calls
+  that came with a registry file is dropped rather than used. An application
+  ships registries as files under `initial-data/registries/`; the admin UI
+  comes with [mindconnect-ai/mc-registry](https://github.com/mindconnect-ai/mc-registry),
+  the default agents, LLM configs and workflows plus an example package. Off
+  for an installation that wants no outbound calls
   (`mindconnect.registry.enabled=false`); format and settings in the docs under
   *Registry*.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,28 @@ fresh empty one, so nothing has to be moved by hand at release time.
   agents, workflows and whole packages from a GitHub project. A registry is a
   repository, not a server: an index (`registry.json`) and the entity files it
   points at, added by its `owner/repo` (`owner/repo@v1.2.0` pins a tag, a
-  private one names the *environment variable* holding its token). Browse it,
-  filter by kind, import — a package installs the agent, its sub-agents, the
-  workflow they run and the LLM config they share, dependencies first and each
-  entity once, with a report that says line by line what was imported, updated,
-  skipped or failed. Importing keeps what is already here unless overwrite is
-  chosen, an overwrite keeps local ids so that sessions and aliases keep
-  working, and an API key that came with a registry file is dropped rather than
-  used. Off for an installation that wants no outbound calls
+  private one names the *environment variable* holding its token). Browse it
+  under *Agents*, *LLM configs*, *Workflows* and *Packages*, import — a package
+  installs the agent, its sub-agents, the workflow they run and the LLM config
+  they share, dependencies first and each entity once, with a report that says
+  line by line what was imported, updated, removed, skipped or failed. A
+  package's *Contents* tab lists everything it would install, marks what is
+  already here, and lets you untick entries to leave them out; **Remove** takes
+  a package out again, deleting the included entries and keeping the rest. An
+  entry that something outside the package still uses — the alias every agent
+  runs on, the config behind it — says *Used by …* and starts unticked.
+  Importing keeps what is already here unless overwrite is chosen, an overwrite
+  keeps local ids so that sessions and aliases keep working, and an API key
+  that came with a registry file is dropped rather than used. Off for an
+  installation that wants no outbound calls
   (`mindconnect.registry.enabled=false`); format and settings in the docs under
   *Registry*.
+
+### Changed
+
+- **agents:** the admin UI's collapsible headings — tool and agent groups,
+  migration rows, trace cards — read at body size in the theme's text colour
+  instead of the framework's small grey detail style.
 
 ## [0.8.1] - 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ fresh empty one, so nothing has to be moved by hand at release time.
 
 ## [Unreleased]
 
+### Added
+
+- **agents:** registries — a **Registry** screen that installs LLM configs,
+  agents, workflows and whole packages from a GitHub project. A registry is a
+  repository, not a server: an index (`registry.json`) and the entity files it
+  points at, added by its `owner/repo` (`owner/repo@v1.2.0` pins a tag, a
+  private one names the *environment variable* holding its token). Browse it,
+  filter by kind, import — a package installs the agent, its sub-agents, the
+  workflow they run and the LLM config they share, dependencies first and each
+  entity once, with a report that says line by line what was imported, updated,
+  skipped or failed. Importing keeps what is already here unless overwrite is
+  chosen, an overwrite keeps local ids so that sessions and aliases keep
+  working, and an API key that came with a registry file is dropped rather than
+  used. Off for an installation that wants no outbound calls
+  (`mindconnect.registry.enabled=false`); format and settings in the docs under
+  *Registry*.
+
 ## [0.8.1] - 2026-09-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,11 @@ The root `pom.xml` is an aggregator that builds, in order: the parent POMs, the 
     - `mc-agent-protocol` (+ `-openai`, `-mc-runtime`): protocol vocabulary and backend adapters
     - `mc-agent-tool-spi`: what a tool is — `Tool`, `ToolFactory`, `MultiToolProvider`, registry
     - `mc-agent-tools*`: built-in tool providers (filesystem/bash, code, document, web, web-browser, workflow)
+    - `mc-agent-registry-core` / `mc-agent-registry`: importing from a registry — a GitHub
+      project with an index of LLM configs, agents, workflows and packages — ports + import
+      service / GitHub client, file-backed source store, installers. An installer is
+      contributed by the module owning the entity (the workflow one sits in
+      `mc-agent-tools-workflow`)
     - `mc-credentials`: credential storage for tools & providers
   - `mcp/` — MCP servers as registered tools, split like the rest (ports in `-core`)
     - `mc-mcp-gateway-core` / `mc-mcp-gateway-local`: gateway ports and types / the in-process gateway
@@ -108,6 +113,7 @@ The root `pom.xml` is an aggregator that builds, in order: the parent POMs, the 
   - `server/` — deployable Spring Boot services
     - `mc-agent-api-rest` / `mc-agent-api-app`: REST API library / agent server (streaming via SSE)
     - `mc-agent-admin-ui-rest` / `mc-agent-admin-ui-app`: admin UI library / app (port 9090)
+    - `mc-agent-registry-admin-ui-rest`: the `/registry` screen, embedded by the admin UI
   - `client/mc-agent-cli`: terminal REPL client
 
 ## Architecture Notes

--- a/agents/README.md
+++ b/agents/README.md
@@ -51,6 +51,7 @@ the finished report:
 | `mc-message-repository` | Conversation & message storage |
 | `mc-credentials` | Credential storage for tools and providers |
 | `mc-agent-tools*` | Built-in tool providers (web, browser, document, todo, workflow) |
+| `mc-agent-registry-core` / `mc-agent-registry` | Import LLM configs, agents, workflows and whole packages from a registry — a GitHub project with an index |
 
 ### `mcp/` — Model Context Protocol servers as tools
 
@@ -69,6 +70,30 @@ server of its own without the tool side noticing.
 
 Concepts: `mc-sandbox/agents/doc/concepts/21-*`, `22-*`, `23-*`. Manual tests:
 `doc/manual-tests/mcp/`.
+
+### Registry — import from a GitHub project
+
+A registry is a repository, not a server: an index (`registry.json`) and the
+entity files it points at. Add one by its `owner/repo` under **Registry** in the
+admin UI, browse what it offers, import an entry — or a package that installs an
+agent, its sub-agents, their workflow and the LLM config they share, in order and
+each one once.
+
+| Module | Purpose |
+|--------|---------|
+| `mc-agent-registry-core` | What a registry is: domain, the ports (`RegistryClient`, `RegistrySourceRepository`, `RegistryInstaller`), the import service |
+| `mc-agent-registry` | The GitHub client (raw files over HTTPS, optional token), the file-backed store of registries, the LLM-config and agent installers |
+| `mc-agent-registry-admin-ui-rest` | The `/registry` screen |
+
+Installers are contributed by the module that owns the entity — the workflow one
+lives in `mc-agent-tools-workflow` — so an installation without a workflow engine
+lists workflows it cannot import and says so, instead of dragging the engine in.
+
+Nothing installs itself: reading a registry is safe, installing one is a decision
+a person makes per entry. Format and configuration:
+[website/docs/agents/registry.md](../website/docs/agents/registry.md), worked
+example: [`doc/registry-example/`](doc/registry-example/). Manual tests:
+`doc/manual-tests/registry/`.
 
 ### `adapter/` — alternative implementations of the core ports
 

--- a/agents/core/mc-agent-registry-core/pom.xml
+++ b/agents/core/mc-agent-registry-core/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-agent-registry-core</artifactId>
+    <name>mc-agent-registry-core</name>
+    <packaging>jar</packaging>
+    <description>
+        The registry's core: what a registry is (a Git repository with an
+        index of LLM configs, agents, workflows and packages), the ports to
+        read one (RegistryClient), to remember which ones this installation
+        knows (RegistrySourceRepository) and to install what was read
+        (RegistryInstaller), plus the import service that walks packages and
+        dependencies. No HTTP and no entity types — the adapters bring those.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-domain</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportMode.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportMode.java
@@ -1,0 +1,27 @@
+package ai.mindconnect.agent.registry.domain;
+
+/**
+ * What an import does when the installation already has something of that
+ * name.
+ *
+ * <p>The question cannot be answered centrally, because both answers are
+ * right: re-importing a registry agent to pick up its new prompt wants
+ * {@link #OVERWRITE}, and importing a package whose LLM alias you have
+ * carefully pointed at your own model wants {@link #SKIP_EXISTING}. So the
+ * person importing says, per import, and the report says what happened.
+ */
+public enum ImportMode {
+
+    /**
+     * Keep what is here. An existing name is reported as
+     * {@link ImportStatus#SKIPPED} and the rest of the package still installs
+     * — the default, because it cannot destroy anything.
+     */
+    SKIP_EXISTING,
+
+    /**
+     * Replace what is here, keeping the local entity's id and version so that
+     * everything pointing at it keeps working.
+     */
+    OVERWRITE
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportReport.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportReport.java
@@ -1,0 +1,52 @@
+package ai.mindconnect.agent.registry.domain;
+
+import java.util.List;
+
+/**
+ * What one import did, member by member.
+ *
+ * <p>An import of a package touches several stores and can half-succeed:
+ * three agents installed, one workflow skipped because a workflow of that id
+ * was already there, one LLM config failed because its JSON does not parse.
+ * Nothing is rolled back — an installed agent is useful even if its sibling
+ * failed, and a rollback across four independent stores would be a lie
+ * anyway. So the report is the honest record, and the screen shows every
+ * line.
+ *
+ * @param sourceId the registry this came from
+ * @param entryId  the entry that was asked for — a package's own id, when a
+ *                 package was imported
+ * @param items    what happened, in install order
+ */
+public record ImportReport(
+        String sourceId,
+        String entryId,
+        List<ImportedItem> items
+) {
+
+    public ImportReport {
+        items = items == null ? List.of() : List.copyOf(items);
+    }
+
+    /** Whether every member came through. */
+    public boolean ok() {
+        return items.stream().map(ImportedItem::status).allMatch(ImportStatus::ok);
+    }
+
+    /** How many members ended in that status. */
+    public long count(ImportStatus status) {
+        return items.stream().filter(item -> item.status() == status).count();
+    }
+
+    /** "2 imported, 1 skipped, 1 failed" — never empty. */
+    public String summary() {
+        StringBuilder text = new StringBuilder();
+        for (ImportStatus status : ImportStatus.values()) {
+            long count = count(status);
+            if (count == 0) continue;
+            if (!text.isEmpty()) text.append(", ");
+            text.append(count).append(' ').append(status.name().toLowerCase(java.util.Locale.ROOT));
+        }
+        return text.isEmpty() ? "nothing to import" : text.toString();
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportStatus.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportStatus.java
@@ -1,0 +1,22 @@
+package ai.mindconnect.agent.registry.domain;
+
+/** What became of one member of an import. */
+public enum ImportStatus {
+
+    /** Newly installed. */
+    IMPORTED,
+
+    /** Replaced an entity of the same name, under {@link ImportMode#OVERWRITE}. */
+    UPDATED,
+
+    /** Already there, and the mode said to keep it. */
+    SKIPPED,
+
+    /** Could not be installed — the detail says why. The rest of the import goes on. */
+    FAILED;
+
+    /** Whether this status means nothing is broken. */
+    public boolean ok() {
+        return this != FAILED;
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportStatus.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportStatus.java
@@ -1,6 +1,6 @@
 package ai.mindconnect.agent.registry.domain;
 
-/** What became of one member of an import. */
+/** What became of one member of an import, or of a package's removal. */
 public enum ImportStatus {
 
     /** Newly installed. */
@@ -9,7 +9,10 @@ public enum ImportStatus {
     /** Replaced an entity of the same name, under {@link ImportMode#OVERWRITE}. */
     UPDATED,
 
-    /** Already there, and the mode said to keep it. */
+    /** Deleted from this installation, by removing a package. */
+    REMOVED,
+
+    /** Left as it is: already there and the mode said to keep it, left out, or not there to remove. */
     SKIPPED,
 
     /** Could not be installed — the detail says why. The rest of the import goes on. */

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportedItem.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportedItem.java
@@ -31,6 +31,10 @@ public record ImportedItem(
         return new ImportedItem(entry.id(), entry.type(), name, ImportStatus.UPDATED, null);
     }
 
+    public static ImportedItem removed(RegistryEntry entry, String name) {
+        return new ImportedItem(entry.id(), entry.type(), name, ImportStatus.REMOVED, null);
+    }
+
     public static ImportedItem skipped(RegistryEntry entry, String name, String detail) {
         return new ImportedItem(entry.id(), entry.type(), name, ImportStatus.SKIPPED, detail);
     }

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportedItem.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/ImportedItem.java
@@ -1,0 +1,57 @@
+package ai.mindconnect.agent.registry.domain;
+
+import java.util.Locale;
+
+/**
+ * One line of an {@link ImportReport}: what was installed, under which name,
+ * and how it went.
+ *
+ * @param entryId the registry entry this came from
+ * @param type    what it was — {@code null} for a reference that named nothing,
+ *                where the kind is exactly what is not known
+ * @param name    the name it was installed under — an installer may have to
+ *                pick a different one than the entry advertised, and the
+ *                person needs to read the one that is now in their list
+ * @param status  how it went
+ * @param detail  why, when that is not obvious; {@code null} otherwise
+ */
+public record ImportedItem(
+        String entryId,
+        RegistryItemType type,
+        String name,
+        ImportStatus status,
+        String detail
+) {
+
+    public static ImportedItem imported(RegistryEntry entry, String name) {
+        return new ImportedItem(entry.id(), entry.type(), name, ImportStatus.IMPORTED, null);
+    }
+
+    public static ImportedItem updated(RegistryEntry entry, String name) {
+        return new ImportedItem(entry.id(), entry.type(), name, ImportStatus.UPDATED, null);
+    }
+
+    public static ImportedItem skipped(RegistryEntry entry, String name, String detail) {
+        return new ImportedItem(entry.id(), entry.type(), name, ImportStatus.SKIPPED, detail);
+    }
+
+    public static ImportedItem failed(RegistryEntry entry, String detail) {
+        return new ImportedItem(entry.id(), entry.type(), entry.name(), ImportStatus.FAILED, detail);
+    }
+
+    /**
+     * A reference in an index or a package manifest that named no entry — the
+     * kind is unknown, which is the point.
+     */
+    public static ImportedItem unresolved(String entryId, String detail) {
+        return new ImportedItem(entryId, null, entryId, ImportStatus.FAILED, detail);
+    }
+
+    /** "Agent 'web-researcher' — imported", plus the detail when there is one. */
+    @Override
+    public String toString() {
+        String kind = type == null ? "Entry" : type.label();
+        String line = kind + " '" + name + "' — " + status.name().toLowerCase(Locale.ROOT);
+        return detail == null ? line : line + " (" + detail + ")";
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryEntry.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryEntry.java
@@ -1,0 +1,106 @@
+package ai.mindconnect.agent.registry.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * One line of a registry index: something importable, and where its file sits
+ * in the repository.
+ *
+ * <p>The entry is the advertisement, not the thing. It carries what a person
+ * needs to decide — what this is, who wrote it, what it drags in — and a
+ * {@link #path} to the file that actually holds the entity. The file is
+ * fetched only when somebody imports.
+ *
+ * @param id          address of this entry within its registry, referenced by
+ *                    {@link #requires} and by a package's item list
+ * @param type        what it installs
+ * @param name        the entity's name, which is also the name it is installed
+ *                    under — the index says it so a screen can warn about a
+ *                    collision before fetching anything
+ * @param description one or two sentences for the list
+ * @param version     the entry author's version string, free-form
+ * @param path        path of the entity file inside the repository
+ * @param tags        free labels for filtering
+ * @param author      who wrote it
+ * @param homepage    where to read more
+ * @param requires    ids of entries in the same index that have to be installed
+ *                    first — the LLM alias an agent points at, the sub-agents
+ *                    it calls. Imported in order, before this entry
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RegistryEntry(
+        String id,
+        RegistryItemType type,
+        String name,
+        String description,
+        String version,
+        String path,
+        List<String> tags,
+        String author,
+        String homepage,
+        List<String> requires
+) {
+
+    public RegistryEntry {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("A registry entry needs an id");
+        }
+        if (type == null) {
+            throw new IllegalArgumentException("Registry entry '" + id + "' has no type");
+        }
+        if (path == null || path.isBlank()) {
+            throw new IllegalArgumentException("Registry entry '" + id + "' has no path");
+        }
+        id = id.strip();
+        path = path.strip();
+        if (path.startsWith("/")) path = path.substring(1);
+        if (name == null || name.isBlank()) name = id;
+        tags = tags == null ? List.of() : List.copyOf(tags);
+        requires = requires == null ? List.of() : List.copyOf(requires);
+    }
+
+    /** Does this entry's name, description or any tag contain {@code query}? Blank matches everything. */
+    public boolean matches(String query) {
+        if (query == null || query.isBlank()) return true;
+        String needle = query.strip().toLowerCase(Locale.ROOT);
+        return contains(id, needle) || contains(name, needle) || contains(description, needle)
+                || contains(author, needle)
+                || tags.stream().anyMatch(tag -> contains(tag, needle));
+    }
+
+    /** "Agent · v1.2.0 · by someone" — the subtitle a list draws under the name. */
+    @JsonIgnore
+    public String subtitle() {
+        StringBuilder text = new StringBuilder(type.label());
+        if (version != null && !version.isBlank()) text.append(" · ").append(version);
+        if (author != null && !author.isBlank()) text.append(" · by ").append(author);
+        return text.toString();
+    }
+
+    private static boolean contains(String value, String lowerCaseNeedle) {
+        return value != null && value.toLowerCase(Locale.ROOT).contains(lowerCaseNeedle);
+    }
+
+    /** Jackson: {@code requires} also accepts a single string, which is what people write. */
+    @JsonCreator
+    static RegistryEntry fromJson(
+            @JsonProperty("id")          String id,
+            @JsonProperty("type")        RegistryItemType type,
+            @JsonProperty("name")        String name,
+            @JsonProperty("description") String description,
+            @JsonProperty("version")     String version,
+            @JsonProperty("path")        String path,
+            @JsonProperty("tags")        List<String> tags,
+            @JsonProperty("author")      String author,
+            @JsonProperty("homepage")    String homepage,
+            @JsonProperty("requires")    List<String> requires) {
+        return new RegistryEntry(id, type, name, description, version, path, tags, author,
+                homepage, requires);
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryException.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryException.java
@@ -1,0 +1,21 @@
+package ai.mindconnect.agent.registry.domain;
+
+/**
+ * A registry could not be read or an import could not be started: an unknown
+ * source, an index that is not there or does not parse, a repository behind a
+ * token this installation does not have.
+ *
+ * <p>Not thrown for a single member that fails to install — that is a
+ * {@link ImportStatus#FAILED} line in the report, because the other members
+ * still installed.
+ */
+public class RegistryException extends RuntimeException {
+
+    public RegistryException(String message) {
+        super(message);
+    }
+
+    public RegistryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryIndex.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryIndex.java
@@ -1,0 +1,68 @@
+package ai.mindconnect.agent.registry.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * What a registry repository advertises: its {@code registry.json}.
+ *
+ * <p>One file, read in one request, listing everything the repository offers.
+ * A registry with a thousand entries would want paging; a registry is a Git
+ * repository somebody curates by hand, and those do not have a thousand
+ * entries.
+ *
+ * @param schemaVersion the index format — {@link #SCHEMA_VERSION} is what this
+ *                      code reads. A higher one is read anyway, on the
+ *                      assumption that the format grows by adding fields;
+ *                      unknown fields are ignored throughout
+ * @param name          what the registry calls itself
+ * @param description   what it is for
+ * @param entries       everything on offer
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RegistryIndex(
+        int schemaVersion,
+        String name,
+        String description,
+        List<RegistryEntry> entries
+) {
+
+    /** The index format this code was written against. */
+    public static final int SCHEMA_VERSION = 1;
+
+    public RegistryIndex {
+        entries = entries == null ? List.of() : List.copyOf(entries);
+        if (schemaVersion <= 0) schemaVersion = SCHEMA_VERSION;
+    }
+
+    public static RegistryIndex empty() {
+        return new RegistryIndex(SCHEMA_VERSION, null, null, List.of());
+    }
+
+    /** The entry of that id. */
+    public Optional<RegistryEntry> find(String entryId) {
+        if (entryId == null) return Optional.empty();
+        return entries.stream().filter(entry -> entry.id().equals(entryId)).findFirst();
+    }
+
+    /** The entries matching {@code query} and, when given, {@code type} — in index order. */
+    public List<RegistryEntry> search(String query, RegistryItemType type) {
+        return entries.stream()
+                .filter(entry -> type == null || entry.type() == type)
+                .filter(entry -> entry.matches(query))
+                .toList();
+    }
+
+    @JsonCreator
+    static RegistryIndex fromJson(
+            @JsonProperty("schemaVersion") int schemaVersion,
+            @JsonProperty("name")          String name,
+            @JsonProperty("description")   String description,
+            @JsonProperty("entries")       List<RegistryEntry> entries) {
+        return new RegistryIndex(schemaVersion, name, description, entries);
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryItemType.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryItemType.java
@@ -1,0 +1,63 @@
+package ai.mindconnect.agent.registry.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+/**
+ * What a registry entry installs. The wire name is the hyphenated lower-case
+ * form ({@code llm-config}), because a registry's index is written by hand and
+ * {@code LLM_CONFIG} in JSON reads like a leaked Java constant.
+ *
+ * <p>{@link #PACKAGE} is the odd one out: it installs nothing itself. Its file
+ * is a manifest of other entries — "an assistant, the two sub-agents it calls,
+ * their workflow and the LLM alias they all point at" — and the import service
+ * walks it.
+ */
+public enum RegistryItemType {
+
+    LLM_CONFIG("llm-config", "LLM config"),
+    AGENT("agent", "Agent"),
+    WORKFLOW("workflow", "Workflow"),
+    PACKAGE("package", "Package");
+
+    private final String wireName;
+    private final String label;
+
+    RegistryItemType(String wireName, String label) {
+        this.wireName = wireName;
+        this.label = label;
+    }
+
+    @JsonValue
+    public String wireName() {
+        return wireName;
+    }
+
+    /** For screens and reports. */
+    public String label() {
+        return label;
+    }
+
+    /**
+     * Reads a type from an index. Tolerant about spelling — {@code llm-config},
+     * {@code llm_config} and {@code LLM_CONFIG} all name the same thing, and an
+     * index author should not have to guess which.
+     *
+     * @throws IllegalArgumentException when the text names no known type
+     */
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static RegistryItemType fromWire(String text) {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("Registry entry has no type");
+        }
+        String normalised = text.strip().toLowerCase(Locale.ROOT).replace('_', '-');
+        for (RegistryItemType type : values()) {
+            if (type.wireName.equals(normalised)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown registry entry type '" + text + "'");
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryPackage.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistryPackage.java
@@ -1,0 +1,80 @@
+package ai.mindconnect.agent.registry.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The file behind a {@link RegistryItemType#PACKAGE} entry: everything that
+ * has to arrive together for a set-up to work.
+ *
+ * <p>A useful agent is rarely one file. It points at an LLM config by name,
+ * calls two sub-agents, and one of those runs a workflow — import the agent
+ * alone and it is installed and broken. A package names the whole set, and
+ * the import service installs it in the listed order.
+ *
+ * <p>Members come in two shapes, and a package may mix them:
+ * <ul>
+ *   <li>{@code includes} — ids of entries in the same registry index. Reuse:
+ *       the same agent can be a member of three packages and exist once.</li>
+ *   <li>{@code items} — full entries written into the package file itself, for
+ *       parts that are only ever this package's.</li>
+ * </ul>
+ *
+ * @param name        what the package is called
+ * @param description what it sets up
+ * @param version     the author's version string
+ * @param includes    ids of index entries that belong to this package, in
+ *                    install order
+ * @param items       entries declared inline, installed after the includes
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RegistryPackage(
+        String name,
+        String description,
+        String version,
+        List<String> includes,
+        List<RegistryEntry> items
+) {
+
+    public RegistryPackage {
+        includes = includes == null ? List.of() : List.copyOf(includes);
+        items = items == null ? List.of() : List.copyOf(items);
+    }
+
+    /** Whether this package would install nothing at all. */
+    public boolean isEmpty() {
+        return includes.isEmpty() && items.isEmpty();
+    }
+
+    /**
+     * The members, in install order, with each include resolved against
+     * {@code index}. An include naming an entry the index does not have is
+     * dropped here and reported by the caller — a package must not be able to
+     * abort an import halfway through because one of six members was renamed.
+     *
+     * @param index the index the package was listed in
+     * @param unresolved collects the include ids that named nothing
+     */
+    public List<RegistryEntry> members(RegistryIndex index, List<String> unresolved) {
+        List<RegistryEntry> members = new ArrayList<>();
+        for (String include : includes) {
+            index.find(include).ifPresentOrElse(members::add, () -> unresolved.add(include));
+        }
+        members.addAll(items);
+        return members;
+    }
+
+    @JsonCreator
+    static RegistryPackage fromJson(
+            @JsonProperty("name")        String name,
+            @JsonProperty("description") String description,
+            @JsonProperty("version")     String version,
+            @JsonProperty("includes")    List<String> includes,
+            @JsonProperty("items")       List<RegistryEntry> items) {
+        return new RegistryPackage(name, description, version, includes, items);
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistrySource.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistrySource.java
@@ -1,0 +1,174 @@
+package ai.mindconnect.agent.registry.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A registry this installation knows: a GitHub project holding an index and
+ * the entity files beside it.
+ *
+ * <p>There is no registry server. A registry is a repository — fork it, send a
+ * pull request, pin a tag — and everything a hosted catalogue would need
+ * (review, history, ownership) is what Git already does. Reading one is a
+ * plain HTTPS GET of raw files, so a private registry needs nothing but a
+ * token.
+ *
+ * @param id          stable local address of this source
+ * @param name        what to call it on screen; defaults to {@code owner/repo}
+ * @param owner       GitHub user or organisation
+ * @param repo        repository name
+ * @param ref         branch, tag or commit to read; {@code main} when omitted.
+ *                    Pin a tag for a registry you do not control — a branch is
+ *                    whatever its owner pushed last
+ * @param indexPath   path of the index inside the repository; {@code registry.json}
+ * @param tokenEnvVar name of the environment variable holding a token for a
+ *                    private repository, {@code null} for a public one. The
+ *                    name, never the token: a store that can be exported must
+ *                    not be able to leak one
+ * @param baseUrl     raw-content host, {@code null} for github.com. Set it for a
+ *                    GitHub Enterprise instance
+ * @param enabled     a disabled source stays configured but is not read
+ * @param version     the stored version this source was read with — optimistic
+ *                    locking, see {@code ai.mindconnect.common.Versions}
+ */
+public record RegistrySource(
+        RegistrySourceId id,
+        String name,
+        String owner,
+        String repo,
+        String ref,
+        String indexPath,
+        String tokenEnvVar,
+        String baseUrl,
+        boolean enabled,
+        Long version
+) {
+
+    /** What a source reads when it names no ref of its own. */
+    public static final String DEFAULT_REF = "main";
+
+    /** What a source reads when it names no index of its own. */
+    public static final String DEFAULT_INDEX_PATH = "registry.json";
+
+    /** Raw content of a repository on github.com. */
+    public static final String GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com";
+
+    /** {@code owner/repo}, optionally {@code @ref} and {@code :indexPath}. */
+    private static final Pattern SPEC = Pattern.compile(
+            "(?<owner>[^/@:\\s]+)/(?<repo>[^/@:\\s]+)(?:@(?<ref>[^:\\s]+))?(?::(?<path>\\S+))?");
+
+    public RegistrySource {
+        owner = required(owner, "owner");
+        repo = required(repo, "repo");
+        ref = blankTo(ref, DEFAULT_REF);
+        indexPath = stripLeadingSlash(blankTo(indexPath, DEFAULT_INDEX_PATH));
+        baseUrl = blankTo(baseUrl, GITHUB_RAW_BASE_URL);
+        tokenEnvVar = blankToNull(tokenEnvVar);
+        name = blankTo(name, owner + "/" + repo);
+    }
+
+    /**
+     * A source from the short form an operator types: {@code owner/repo},
+     * {@code owner/repo@v1.2.0}, {@code owner/repo@main:catalog/registry.json}.
+     * A full {@code https://github.com/owner/repo} URL is accepted too — it is
+     * what the browser's address bar offers, and refusing it would be a riddle.
+     *
+     * @throws IllegalArgumentException when the text names no repository
+     */
+    public static RegistrySource of(String spec) {
+        if (spec == null || spec.isBlank()) {
+            throw new IllegalArgumentException("A registry needs an owner/repo");
+        }
+        String text = spec.strip();
+        text = text.replaceFirst("^https?://(www\\.)?github\\.com/", "");
+        text = text.replaceFirst("\\.git$", "");
+        Matcher matcher = SPEC.matcher(text);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                    "'" + spec + "' is not a registry: expected owner/repo[@ref][:index-path]");
+        }
+        String owner = matcher.group("owner");
+        String repo = matcher.group("repo");
+        return new RegistrySource(idFor(owner, repo), owner + "/" + repo, owner, repo,
+                matcher.group("ref"), matcher.group("path"), null, null, true, null);
+    }
+
+    /**
+     * The id a source parsed from {@code owner/repo} gets: the two names, made
+     * into one that {@code EntityId} accepts. Readable, and the same every
+     * time, so adding the same registry twice collides instead of piling up.
+     */
+    private static RegistrySourceId idFor(String owner, String repo) {
+        String value = (owner + "-" + repo).toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9._-]", "-");
+        return RegistrySourceId.of(value);
+    }
+
+    /** {@code owner/repo@ref} — how a source names itself in a log or a report. */
+    @JsonIgnore
+    public String coordinates() {
+        return owner + "/" + repo + "@" + ref;
+    }
+
+    /**
+     * The repository's page on github.com, for a screen that wants to name
+     * where this came from — {@code null} for a source read from another host,
+     * whose web address does not follow from its raw-content one.
+     */
+    @JsonIgnore
+    public String repositoryUrl() {
+        return GITHUB_RAW_BASE_URL.equals(baseUrl)
+                ? "https://github.com/" + owner + "/" + repo
+                : null;
+    }
+
+    public RegistrySource withVersion(Long version) {
+        return new RegistrySource(id, name, owner, repo, ref, indexPath, tokenEnvVar, baseUrl,
+                enabled, version);
+    }
+
+    public RegistrySource withEnabled(boolean enabled) {
+        return new RegistrySource(id, name, owner, repo, ref, indexPath, tokenEnvVar, baseUrl,
+                enabled, version);
+    }
+
+    /** Jackson: trailing fields default, so sources written by older versions still load. */
+    @JsonCreator
+    static RegistrySource fromJson(
+            @JsonProperty("id")          String id,
+            @JsonProperty("name")        String name,
+            @JsonProperty("owner")       String owner,
+            @JsonProperty("repo")        String repo,
+            @JsonProperty("ref")         String ref,
+            @JsonProperty("indexPath")   String indexPath,
+            @JsonProperty("tokenEnvVar") String tokenEnvVar,
+            @JsonProperty("baseUrl")     String baseUrl,
+            @JsonProperty("enabled")     Boolean enabled,
+            @JsonProperty("version")     Long version) {
+        return new RegistrySource(RegistrySourceId.of(id), name, owner, repo, ref, indexPath,
+                tokenEnvVar, baseUrl, enabled == null || enabled, version);
+    }
+
+    private static String required(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("A registry source needs a " + field);
+        }
+        return value.strip();
+    }
+
+    private static String blankTo(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value.strip();
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.strip();
+    }
+
+    private static String stripLeadingSlash(String path) {
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistrySourceId.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/domain/RegistrySourceId.java
@@ -1,0 +1,31 @@
+package ai.mindconnect.agent.registry.domain;
+
+import ai.mindconnect.agent.EntityId;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Which registry — the same shape as every other id: a value and nothing
+ * else. The namespace sits with the store that holds the source; one process
+ * serves one.
+ */
+public record RegistrySourceId(@JsonValue String value) implements EntityId {
+
+    public RegistrySourceId {
+        EntityId.check(value);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static RegistrySourceId of(String value) {
+        return new RegistrySourceId(value);
+    }
+
+    public static RegistrySourceId random() {
+        return new RegistrySourceId(EntityId.randomValue());
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistryClient.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistryClient.java
@@ -1,0 +1,57 @@
+package ai.mindconnect.agent.registry.port.out;
+
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryPackage;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+
+/**
+ * Reads a registry repository. Two calls, because a registry is two things:
+ * an index, and the files it points at.
+ *
+ * <p>The port says nothing about GitHub. The default adapter fetches raw
+ * files over HTTPS, a test hands back strings from a map, and an installation
+ * that keeps its registry on a mounted volume can read from disk — the import
+ * service never learns the difference.
+ */
+public interface RegistryClient {
+
+    /**
+     * The source's index.
+     *
+     * @throws ai.mindconnect.agent.registry.domain.RegistryException when the
+     *         repository, the ref or the index file cannot be read, or the
+     *         index does not parse
+     */
+    RegistryIndex fetchIndex(RegistrySource source);
+
+    /**
+     * One file from the repository, as text.
+     *
+     * @param path repository-relative, as an entry carries it
+     * @throws ai.mindconnect.agent.registry.domain.RegistryException when the
+     *         file cannot be read
+     */
+    String fetchText(RegistrySource source, String path);
+
+    /**
+     * The package manifest at {@code path}.
+     *
+     * <p>Parsing lives here rather than in the import service for the same
+     * reason the index does: the core module knows the shape of a manifest,
+     * not the library that reads JSON.
+     *
+     * @throws ai.mindconnect.agent.registry.domain.RegistryException when the
+     *         file cannot be read or does not parse
+     */
+    RegistryPackage fetchPackage(RegistrySource source, String path);
+
+    /**
+     * Forgets whatever is cached for this source, so the next read goes to the
+     * repository. What the "refresh" button on a registry screen calls: a
+     * registry moves when its owner pushes, not on a schedule this
+     * installation knows.
+     */
+    default void refresh(RegistrySource source) {
+        // Adapters without a cache have nothing to forget.
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistryInstaller.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistryInstaller.java
@@ -1,0 +1,53 @@
+package ai.mindconnect.agent.registry.port.out;
+
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+
+/**
+ * Turns one fetched file into one stored entity. The seam that keeps the
+ * registry from knowing what an agent or a workflow is.
+ *
+ * <p>One installer per {@link RegistryItemType}, contributed by the module
+ * that owns the entity: the LLM-config installer sits with the gateway
+ * adapters, the workflow installer with the workflow tools, and an
+ * installation that has no workflow engine simply has no workflow installer —
+ * its registry then lists workflows it cannot import, and says so, rather
+ * than dragging the engine in as a dependency.
+ *
+ * <p>{@link RegistryItemType#PACKAGE} has no installer: a package is walked by
+ * the import service, not installed.
+ */
+public interface RegistryInstaller {
+
+    /** What this installer installs. */
+    RegistryItemType type();
+
+    /**
+     * Whether this installation already has an entity of that name — asked
+     * before fetching anything, so a screen can warn, and again at install
+     * time, so the mode can be applied.
+     */
+    boolean exists(String name);
+
+    /**
+     * Installs {@code content} as the entity {@code entry} advertises.
+     *
+     * <p>The installer decides what "already there" means for its entity and
+     * honours {@code mode}: {@link ImportMode#SKIP_EXISTING} returns a
+     * {@link ImportedItem#skipped skipped} line without writing,
+     * {@link ImportMode#OVERWRITE} replaces the stored entity while keeping
+     * its local id, so that agents, aliases and sessions pointing at it keep
+     * working.
+     *
+     * @param entry   the index line this came from
+     * @param content the file's text, exactly as the repository holds it
+     * @param mode    what to do about a name that is taken
+     * @return what happened — never null
+     * @throws Exception when the content cannot be read at all; the service
+     *         turns it into a {@link ai.mindconnect.agent.registry.domain.ImportStatus#FAILED}
+     *         line and carries on with the next member
+     */
+    ImportedItem install(RegistryEntry entry, String content, ImportMode mode) throws Exception;
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistryInstaller.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistryInstaller.java
@@ -50,4 +50,41 @@ public interface RegistryInstaller {
      *         line and carries on with the next member
      */
     ImportedItem install(RegistryEntry entry, String content, ImportMode mode) throws Exception;
+
+    /**
+     * Deletes the entity of the entry's name from this installation — how a
+     * package is removed again. Whatever else points at it (an agent naming a
+     * deleted LLM config, a workflow calling a deleted agent) is not this
+     * method's to know; the person chose what to remove on the package's
+     * Contents tab.
+     *
+     * <p>The default removes nothing and says so, for an installer written
+     * before removal existed.
+     *
+     * @return {@link ImportedItem#removed removed}, or
+     *         {@link ImportedItem#skipped skipped} when nothing of that name is here
+     * @throws Exception when the store refuses; the service turns it into a
+     *         {@code FAILED} line and carries on
+     */
+    default ImportedItem remove(RegistryEntry entry) throws Exception {
+        return ImportedItem.skipped(entry, entry.name(), "this installation cannot remove "
+                + entry.type().label().toLowerCase(java.util.Locale.ROOT) + "s");
+    }
+
+    /**
+     * The names of this installer's stored entities that point at the entity
+     * of that kind and name — the agents running on an LLM config, the
+     * workflows calling an agent. Asked before a package is removed, so that
+     * what something else still needs is not ticked for deletion.
+     *
+     * <p>The default knows of no references, for an installer written before
+     * removal existed; an entity it cannot see into is then not protected.
+     *
+     * @param type the kind of the entity referred to
+     * @param name its name
+     * @return the referring entities' names; empty when none
+     */
+    default java.util.List<String> referencesTo(RegistryItemType type, String name) {
+        return java.util.List.of();
+    }
 }

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistrySourceRepository.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/port/out/RegistrySourceRepository.java
@@ -1,0 +1,28 @@
+package ai.mindconnect.agent.registry.port.out;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The registries this installation knows. An adapter is bound to one
+ * namespace when it is built; a source's id is unique within it.
+ */
+public interface RegistrySourceRepository {
+
+    RegistrySource save(RegistrySource source);
+
+    Optional<RegistrySource> findById(RegistrySourceId id);
+
+    /** Every configured source, enabled or not. */
+    List<RegistrySource> findAll();
+
+    /** Only the sources that are actually read. */
+    default List<RegistrySource> findEnabled() {
+        return findAll().stream().filter(RegistrySource::enabled).toList();
+    }
+
+    void deleteById(RegistrySourceId id);
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/service/RegistryService.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/service/RegistryService.java
@@ -1,0 +1,259 @@
+package ai.mindconnect.agent.registry.service;
+
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportReport;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryException;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.domain.RegistryPackage;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+import ai.mindconnect.agent.registry.port.out.RegistryClient;
+import ai.mindconnect.agent.registry.port.out.RegistryInstaller;
+import ai.mindconnect.agent.registry.port.out.RegistrySourceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Browsing and importing registries — the one place that knows the order of
+ * things.
+ *
+ * <p>Importing an entry is rarely importing a file. An entry may
+ * {@code require} others, and a package is nothing but a list of members, each
+ * of which may require more. So an import is a walk: dependencies first, then
+ * the entry, every node visited once, cycles broken by the visited set rather
+ * than by a stack overflow. What each node's file means is the
+ * {@link RegistryInstaller}'s business; this class never parses an entity.
+ *
+ * <p>Nothing installs itself. A registry is a repository on the internet whose
+ * agents carry system prompts and whose packages pull in more of them —
+ * reading one is safe, and installing one is a decision a person makes, per
+ * entry, with the report in front of them.
+ */
+public class RegistryService {
+
+    private static final Logger log = LoggerFactory.getLogger(RegistryService.class);
+
+    /** Depth bound for the dependency walk — a guard, not a design limit. */
+    private static final int MAX_DEPTH = 32;
+
+    private final RegistrySourceRepository sources;
+    private final RegistryClient client;
+    private final Map<RegistryItemType, RegistryInstaller> installers =
+            new EnumMap<>(RegistryItemType.class);
+
+    public RegistryService(RegistrySourceRepository sources, RegistryClient client,
+                           List<RegistryInstaller> installers) {
+        this.sources = sources;
+        this.client = client;
+        for (RegistryInstaller installer : installers) {
+            RegistryInstaller previous = this.installers.put(installer.type(), installer);
+            if (previous != null) {
+                log.warn("Two installers for {} — keeping {}", installer.type().wireName(),
+                        installer.getClass().getSimpleName());
+            }
+        }
+        log.info("Registry service ready: {} source(s), installers for {}",
+                sources.findAll().size(), this.installers.keySet());
+    }
+
+    // ---------------------------------------------------------------- sources
+
+    /** Every configured registry, enabled or not. */
+    public List<RegistrySource> sources() {
+        return sources.findAll();
+    }
+
+    public Optional<RegistrySource> findSource(RegistrySourceId id) {
+        return sources.findById(id);
+    }
+
+    /** Adds a registry from the short form an operator types — see {@link RegistrySource#of}. */
+    public RegistrySource addSource(String spec) {
+        return sources.save(RegistrySource.of(spec));
+    }
+
+    public RegistrySource saveSource(RegistrySource source) {
+        return sources.save(source);
+    }
+
+    public void deleteSource(RegistrySourceId id) {
+        sources.deleteById(id);
+    }
+
+    // ---------------------------------------------------------------- reading
+
+    /**
+     * The source's index.
+     *
+     * @throws RegistryException when there is no such source, it is disabled,
+     *         or the repository cannot be read
+     */
+    public RegistryIndex index(RegistrySourceId sourceId) {
+        return client.fetchIndex(requireSource(sourceId));
+    }
+
+    /** The entries of that source matching {@code query} and, when given, {@code type}. */
+    public List<RegistryEntry> search(RegistrySourceId sourceId, String query, RegistryItemType type) {
+        return index(sourceId).search(query, type);
+    }
+
+    /** Drops what is cached for a source, so the next read goes to the repository. */
+    public void refresh(RegistrySourceId sourceId) {
+        client.refresh(requireSource(sourceId));
+    }
+
+    /**
+     * What this installation would do with the entry right now: whether an
+     * entity of that name is already here, and whether there is an installer
+     * for its type at all. For a screen that wants to warn before anybody
+     * presses Import.
+     */
+    public EntryStatus status(RegistryEntry entry) {
+        if (entry.type() == RegistryItemType.PACKAGE) {
+            return new EntryStatus(true, false);
+        }
+        RegistryInstaller installer = installers.get(entry.type());
+        return installer == null
+                ? new EntryStatus(false, false)
+                : new EntryStatus(true, installer.exists(entry.name()));
+    }
+
+    /**
+     * @param installable whether this installation can install this type at all
+     * @param present     whether something of that name is already here
+     */
+    public record EntryStatus(boolean installable, boolean present) {
+    }
+
+    /** The types this installation can install — a registry may offer more. */
+    public Set<RegistryItemType> installableTypes() {
+        return Set.copyOf(installers.keySet());
+    }
+
+    // -------------------------------------------------------------- importing
+
+    /**
+     * Imports one entry and everything it needs: its {@code requires} first,
+     * then the entry itself; a package instead walks its members, each with
+     * their own requires.
+     *
+     * <p>Never throws for a member that fails — the report carries a
+     * {@code FAILED} line and the walk goes on, because the members are
+     * independent entities in independent stores and stopping at the first
+     * failure would leave a half-installed set with no record of what landed.
+     *
+     * @throws RegistryException when there is no such source or entry, or the
+     *         index cannot be read — nothing was installed then
+     */
+    public ImportReport importEntry(RegistrySourceId sourceId, String entryId, ImportMode mode) {
+        RegistrySource source = requireSource(sourceId);
+        RegistryIndex index = client.fetchIndex(source);
+        RegistryEntry entry = index.find(entryId).orElseThrow(() -> new RegistryException(
+                "Registry '" + source.coordinates() + "' has no entry '" + entryId + "'"));
+
+        List<ImportedItem> items = new ArrayList<>();
+        install(source, index, entry, mode == null ? ImportMode.SKIP_EXISTING : mode,
+                new LinkedHashSet<>(), items, 0);
+        ImportReport report = new ImportReport(sourceId.value(), entryId, items);
+        log.info("Imported '{}' from {}: {}", entryId, source.coordinates(), report.summary());
+        return report;
+    }
+
+    /**
+     * One node of the walk: dependencies, then this entry. {@code visited}
+     * holds the entry ids already handled, so a diamond (two agents requiring
+     * the same LLM alias) installs it once and a cycle terminates.
+     */
+    private void install(RegistrySource source, RegistryIndex index, RegistryEntry entry,
+                         ImportMode mode, Set<String> visited, List<ImportedItem> items, int depth) {
+        if (!visited.add(entry.id())) {
+            return;
+        }
+        if (depth > MAX_DEPTH) {
+            items.add(ImportedItem.failed(entry,
+                    "dependency chain deeper than " + MAX_DEPTH + " — stopped here"));
+            return;
+        }
+        for (String required : entry.requires()) {
+            Optional<RegistryEntry> dependency = index.find(required);
+            if (dependency.isEmpty()) {
+                items.add(ImportedItem.unresolved(required,
+                        "required by '" + entry.id() + "' but not in this registry's index"));
+                continue;
+            }
+            install(source, index, dependency.get(), mode, visited, items, depth + 1);
+        }
+        if (entry.type() == RegistryItemType.PACKAGE) {
+            installPackage(source, index, entry, mode, visited, items, depth);
+            return;
+        }
+        items.add(installOne(source, entry, mode));
+    }
+
+    /** A package: read its manifest, then walk every member as an entry of its own. */
+    private void installPackage(RegistrySource source, RegistryIndex index, RegistryEntry entry,
+                                ImportMode mode, Set<String> visited, List<ImportedItem> items,
+                                int depth) {
+        RegistryPackage manifest;
+        try {
+            manifest = client.fetchPackage(source, entry.path());
+        } catch (RuntimeException e) {
+            items.add(ImportedItem.failed(entry, "package manifest unreadable: " + e.getMessage()));
+            return;
+        }
+        List<String> unresolved = new ArrayList<>();
+        List<RegistryEntry> members = manifest.members(index, unresolved);
+        for (String missing : unresolved) {
+            items.add(ImportedItem.unresolved(missing,
+                    "listed by package '" + entry.name() + "' but not in this registry's index"));
+        }
+        if (members.isEmpty() && unresolved.isEmpty()) {
+            items.add(ImportedItem.skipped(entry, entry.name(), "the package lists nothing"));
+            return;
+        }
+        for (RegistryEntry member : members) {
+            install(source, index, member, mode, visited, items, depth + 1);
+        }
+    }
+
+    /** One entity: fetch its file, hand it to the installer for its type. */
+    private ImportedItem installOne(RegistrySource source, RegistryEntry entry, ImportMode mode) {
+        RegistryInstaller installer = installers.get(entry.type());
+        if (installer == null) {
+            return ImportedItem.skipped(entry, entry.name(),
+                    "this installation cannot import "
+                            + entry.type().label().toLowerCase(Locale.ROOT) + "s");
+        }
+        try {
+            String content = client.fetchText(source, entry.path());
+            ImportedItem result = installer.install(entry, content, mode);
+            return result != null ? result
+                    : ImportedItem.failed(entry, "the installer reported nothing");
+        } catch (Exception e) {
+            log.warn("Importing '{}' from {} failed", entry.id(), source.coordinates(), e);
+            String message = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            return ImportedItem.failed(entry, message);
+        }
+    }
+
+    private RegistrySource requireSource(RegistrySourceId id) {
+        RegistrySource source = sources.findById(id).orElseThrow(() -> new RegistryException(
+                "No registry '" + (id == null ? "null" : id.value()) + "' is configured"));
+        if (!source.enabled()) {
+            throw new RegistryException("Registry '" + source.name() + "' is disabled");
+        }
+        return source;
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/service/RegistryService.java
+++ b/agents/core/mc-agent-registry-core/src/main/java/ai/mindconnect/agent/registry/service/RegistryService.java
@@ -2,6 +2,7 @@ package ai.mindconnect.agent.registry.service;
 
 import ai.mindconnect.agent.registry.domain.ImportMode;
 import ai.mindconnect.agent.registry.domain.ImportReport;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
 import ai.mindconnect.agent.registry.domain.ImportedItem;
 import ai.mindconnect.agent.registry.domain.RegistryEntry;
 import ai.mindconnect.agent.registry.domain.RegistryException;
@@ -18,6 +19,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -115,6 +118,131 @@ public class RegistryService {
     }
 
     /**
+     * What importing a package would install: every entity the import walks
+     * to — its members and whatever they require, in install order, each once —
+     * and the references that named nothing. The same walk as
+     * {@link #importEntry}, without installing, so a screen can show what is
+     * already here before anybody chooses what to leave out.
+     *
+     * @throws RegistryException when there is no such source, the entry is not
+     *         a package, or the index or a manifest cannot be read
+     */
+    public PackageContents packageContents(RegistrySourceId sourceId, RegistryEntry entry) {
+        if (entry.type() != RegistryItemType.PACKAGE) {
+            throw new RegistryException("'" + entry.id() + "' is a "
+                    + entry.type().label().toLowerCase(Locale.ROOT) + ", not a package");
+        }
+        RegistrySource source = requireSource(sourceId);
+        RegistryIndex index = client.fetchIndex(source);
+        List<RegistryEntry> members = new ArrayList<>();
+        List<String> unresolved = new ArrayList<>();
+        walk(source, index, entry, Set.of(), new LinkedHashSet<>(), 0, new Visitor() {
+            @Override
+            public void entity(RegistryEntry member) {
+                members.add(member);
+            }
+
+            @Override
+            public void excluded(RegistryEntry member) {
+                // Nothing is left out of a preview.
+            }
+
+            @Override
+            public void report(ImportedItem item) {
+                if (item.status() != ImportStatus.FAILED) {
+                    return;
+                }
+                if (item.type() == null) {
+                    unresolved.add(item.entryId());
+                } else {
+                    throw new RegistryException(item.detail());
+                }
+            }
+        });
+        return new PackageContents(members, unresolved, usedOutside(members));
+    }
+
+    /**
+     * For each member that is already here, what still needs it if the package
+     * goes — "Agent 'default-chat'" for the LLM config it runs on.
+     *
+     * <p>A user inside the package does not count by itself: removing both
+     * halves leaves nothing dangling. It counts once it is itself used from
+     * outside, because then it stays — the alias every agent runs on keeps the
+     * config it delegates to. That is followed until nothing changes.
+     */
+    private Map<String, List<String>> usedOutside(List<RegistryEntry> members) {
+        Map<String, RegistryEntry> memberByKey = new LinkedHashMap<>();
+        members.forEach(member -> memberByKey.put(key(member.type(), member.name()), member));
+
+        // Who refers to each member that is here, split by whether the user is in the package.
+        Map<String, List<String>> outside = new LinkedHashMap<>();
+        Map<String, List<RegistryEntry>> insideUsers = new LinkedHashMap<>();
+        for (RegistryEntry member : members) {
+            RegistryInstaller own = installers.get(member.type());
+            if (own == null || !own.exists(member.name())) {
+                continue;
+            }
+            for (RegistryInstaller installer : installers.values()) {
+                for (String user : installer.referencesTo(member.type(), member.name())) {
+                    RegistryEntry insider = memberByKey.get(key(installer.type(), user));
+                    if (insider == null) {
+                        outside.computeIfAbsent(member.id(), id -> new ArrayList<>())
+                                .add(installer.type().label() + " '" + user + "'");
+                    } else if (!insider.id().equals(member.id())) {
+                        insideUsers.computeIfAbsent(member.id(), id -> new ArrayList<>()).add(insider);
+                    }
+                }
+            }
+        }
+
+        Map<String, List<String>> usedBy = new LinkedHashMap<>(outside);
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            for (Map.Entry<String, List<RegistryEntry>> users : insideUsers.entrySet()) {
+                for (RegistryEntry insider : users.getValue()) {
+                    String label = insider.type().label() + " '" + insider.name() + "'";
+                    List<String> labels = usedBy.get(users.getKey());
+                    if (usedBy.containsKey(insider.id()) && (labels == null || !labels.contains(label))) {
+                        usedBy.computeIfAbsent(users.getKey(), id -> new ArrayList<>()).add(label);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        return usedBy;
+    }
+
+    private static String key(RegistryItemType type, String name) {
+        return type.wireName() + ":" + name;
+    }
+
+    /**
+     * @param members    the entities a package import installs, in order
+     * @param unresolved referenced ids the index has no entry for
+     * @param usedBy     per member entry id, what outside the package uses the
+     *                   entity of that name here; members nothing else uses are absent
+     */
+    public record PackageContents(List<RegistryEntry> members, List<String> unresolved,
+                                  Map<String, List<String>> usedBy) {
+        public PackageContents {
+            members = List.copyOf(members);
+            unresolved = List.copyOf(unresolved);
+            usedBy = usedBy == null ? Map.of() : Map.copyOf(usedBy);
+        }
+
+        public PackageContents(List<RegistryEntry> members, List<String> unresolved) {
+            this(members, unresolved, Map.of());
+        }
+
+        /** What outside the package uses that member; empty when nothing does. */
+        public List<String> usedBy(String entryId) {
+            return usedBy.getOrDefault(entryId, List.of());
+        }
+    }
+
+    /**
      * What this installation would do with the entry right now: whether an
      * entity of that name is already here, and whether there is an installer
      * for its type at all. For a screen that wants to warn before anybody
@@ -158,17 +286,135 @@ public class RegistryService {
      *         index cannot be read — nothing was installed then
      */
     public ImportReport importEntry(RegistrySourceId sourceId, String entryId, ImportMode mode) {
+        return importEntry(sourceId, entryId, mode, Set.of());
+    }
+
+    /**
+     * Imports the entry as {@link #importEntry(RegistrySourceId, String, ImportMode)}
+     * does, leaving out the entries named in {@code excluded}. A left-out entry
+     * is not installed at all — not as a package member, and not as what
+     * another entry requires — and the report says so; what only it required is
+     * not walked to either.
+     *
+     * @param excluded entry ids not to install; the entry itself cannot be one
+     */
+    public ImportReport importEntry(RegistrySourceId sourceId, String entryId, ImportMode mode,
+                                    Set<String> excluded) {
         RegistrySource source = requireSource(sourceId);
         RegistryIndex index = client.fetchIndex(source);
         RegistryEntry entry = index.find(entryId).orElseThrow(() -> new RegistryException(
                 "Registry '" + source.coordinates() + "' has no entry '" + entryId + "'"));
+        ImportMode effectiveMode = mode == null ? ImportMode.SKIP_EXISTING : mode;
+        Set<String> leftOut = new HashSet<>(excluded == null ? Set.of() : excluded);
+        leftOut.remove(entryId);
 
         List<ImportedItem> items = new ArrayList<>();
-        install(source, index, entry, mode == null ? ImportMode.SKIP_EXISTING : mode,
-                new LinkedHashSet<>(), items, 0);
+        walk(source, index, entry, leftOut, new LinkedHashSet<>(), 0, new Visitor() {
+            @Override
+            public void entity(RegistryEntry member) {
+                items.add(installOne(source, member, effectiveMode));
+            }
+
+            @Override
+            public void excluded(RegistryEntry member) {
+                items.add(ImportedItem.skipped(member, member.name(), "left out of this import"));
+            }
+
+            @Override
+            public void report(ImportedItem item) {
+                items.add(item);
+            }
+        });
         ImportReport report = new ImportReport(sourceId.value(), entryId, items);
         log.info("Imported '{}' from {}: {}", entryId, source.coordinates(), report.summary());
         return report;
+    }
+
+    // --------------------------------------------------------------- removing
+
+    /**
+     * Removes a package from this installation: deletes what its import would
+     * install — the set its Contents tab shows — except the entries in
+     * {@code kept}. Deletion runs in reverse install order, so a workflow goes
+     * before the agents it calls and an agent before the LLM config it runs on.
+     * An entry that is not here is skipped; one a store refuses is a
+     * {@code FAILED} line, and the rest goes on.
+     *
+     * <p>Nothing checks what else uses a deleted entity. An agent outside the
+     * package that names a deleted LLM config stops working — that is what the
+     * checkboxes are for.
+     *
+     * @param kept entry ids to leave in place
+     * @throws RegistryException when there is no such source or entry, the entry
+     *         is not a package, or the index cannot be read — nothing was removed then
+     */
+    public ImportReport removeEntry(RegistrySourceId sourceId, String entryId, Set<String> kept) {
+        RegistrySource source = requireSource(sourceId);
+        RegistryIndex index = client.fetchIndex(source);
+        RegistryEntry entry = index.find(entryId).orElseThrow(() -> new RegistryException(
+                "Registry '" + source.coordinates() + "' has no entry '" + entryId + "'"));
+        if (entry.type() != RegistryItemType.PACKAGE) {
+            throw new RegistryException("Only a package can be removed; '" + entryId + "' is a "
+                    + entry.type().label().toLowerCase(Locale.ROOT));
+        }
+        Set<String> leftOut = new HashSet<>(kept == null ? Set.of() : kept);
+        leftOut.remove(entryId);
+
+        List<RegistryEntry> toRemove = new ArrayList<>();
+        List<ImportedItem> keptLines = new ArrayList<>();
+        List<ImportedItem> problems = new ArrayList<>();
+        walk(source, index, entry, leftOut, new LinkedHashSet<>(), 0, new Visitor() {
+            @Override
+            public void entity(RegistryEntry member) {
+                toRemove.add(member);
+            }
+
+            @Override
+            public void excluded(RegistryEntry member) {
+                keptLines.add(ImportedItem.skipped(member, member.name(), "kept — left out of the removal"));
+            }
+
+            @Override
+            public void report(ImportedItem item) {
+                // A reference that names nothing has nothing here to delete.
+                if (item.status() == ImportStatus.FAILED && item.type() != null) {
+                    problems.add(item);
+                }
+            }
+        });
+
+        List<ImportedItem> items = new ArrayList<>(problems);
+        for (RegistryEntry member : toRemove.reversed()) {
+            items.add(removeOne(source, member));
+        }
+        items.addAll(keptLines);
+        ImportReport report = new ImportReport(sourceId.value(), entryId, items);
+        log.info("Removed '{}' of {}: {}", entryId, source.coordinates(), report.summary());
+        return report;
+    }
+
+    private ImportedItem removeOne(RegistrySource source, RegistryEntry entry) {
+        RegistryInstaller installer = installers.get(entry.type());
+        if (installer == null) {
+            return ImportedItem.skipped(entry, entry.name(), "this installation has no "
+                    + entry.type().label().toLowerCase(Locale.ROOT) + "s");
+        }
+        try {
+            ImportedItem result = installer.remove(entry);
+            return result != null ? result : ImportedItem.failed(entry, "the installer reported nothing");
+        } catch (Exception e) {
+            log.warn("Removing '{}' of {} failed", entry.id(), source.coordinates(), e);
+            return ImportedItem.failed(entry, e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+        }
+    }
+
+    /** What the walk finds: an entity, one left out, or a line for the report. */
+    private interface Visitor {
+        void entity(RegistryEntry entry);
+
+        void excluded(RegistryEntry entry);
+
+        void report(ImportedItem item);
     }
 
     /**
@@ -176,55 +422,58 @@ public class RegistryService {
      * holds the entry ids already handled, so a diamond (two agents requiring
      * the same LLM alias) installs it once and a cycle terminates.
      */
-    private void install(RegistrySource source, RegistryIndex index, RegistryEntry entry,
-                         ImportMode mode, Set<String> visited, List<ImportedItem> items, int depth) {
+    private void walk(RegistrySource source, RegistryIndex index, RegistryEntry entry,
+                      Set<String> excluded, Set<String> visited, int depth, Visitor visitor) {
         if (!visited.add(entry.id())) {
             return;
         }
+        if (excluded.contains(entry.id())) {
+            visitor.excluded(entry);
+            return;
+        }
         if (depth > MAX_DEPTH) {
-            items.add(ImportedItem.failed(entry,
+            visitor.report(ImportedItem.failed(entry,
                     "dependency chain deeper than " + MAX_DEPTH + " — stopped here"));
             return;
         }
         for (String required : entry.requires()) {
             Optional<RegistryEntry> dependency = index.find(required);
             if (dependency.isEmpty()) {
-                items.add(ImportedItem.unresolved(required,
+                visitor.report(ImportedItem.unresolved(required,
                         "required by '" + entry.id() + "' but not in this registry's index"));
                 continue;
             }
-            install(source, index, dependency.get(), mode, visited, items, depth + 1);
+            walk(source, index, dependency.get(), excluded, visited, depth + 1, visitor);
         }
         if (entry.type() == RegistryItemType.PACKAGE) {
-            installPackage(source, index, entry, mode, visited, items, depth);
+            walkPackage(source, index, entry, excluded, visited, depth, visitor);
             return;
         }
-        items.add(installOne(source, entry, mode));
+        visitor.entity(entry);
     }
 
     /** A package: read its manifest, then walk every member as an entry of its own. */
-    private void installPackage(RegistrySource source, RegistryIndex index, RegistryEntry entry,
-                                ImportMode mode, Set<String> visited, List<ImportedItem> items,
-                                int depth) {
+    private void walkPackage(RegistrySource source, RegistryIndex index, RegistryEntry entry,
+                             Set<String> excluded, Set<String> visited, int depth, Visitor visitor) {
         RegistryPackage manifest;
         try {
             manifest = client.fetchPackage(source, entry.path());
         } catch (RuntimeException e) {
-            items.add(ImportedItem.failed(entry, "package manifest unreadable: " + e.getMessage()));
+            visitor.report(ImportedItem.failed(entry, "package manifest unreadable: " + e.getMessage()));
             return;
         }
         List<String> unresolved = new ArrayList<>();
         List<RegistryEntry> members = manifest.members(index, unresolved);
         for (String missing : unresolved) {
-            items.add(ImportedItem.unresolved(missing,
+            visitor.report(ImportedItem.unresolved(missing,
                     "listed by package '" + entry.name() + "' but not in this registry's index"));
         }
         if (members.isEmpty() && unresolved.isEmpty()) {
-            items.add(ImportedItem.skipped(entry, entry.name(), "the package lists nothing"));
+            visitor.report(ImportedItem.skipped(entry, entry.name(), "the package lists nothing"));
             return;
         }
         for (RegistryEntry member : members) {
-            install(source, index, member, mode, visited, items, depth + 1);
+            walk(source, index, member, excluded, visited, depth + 1, visitor);
         }
     }
 

--- a/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistryIndexTest.java
+++ b/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistryIndexTest.java
@@ -1,0 +1,69 @@
+package ai.mindconnect.agent.registry;
+
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RegistryIndexTest {
+
+    private static RegistryEntry entry(String id, RegistryItemType type, String name, String... tags) {
+        return new RegistryEntry(id, type, name, "Does " + name, "1.0.0",
+                type.wireName() + "s/" + id + ".json", List.of(tags), "someone", null, List.of());
+    }
+
+    private final RegistryIndex index = new RegistryIndex(1, "Test registry", null, List.of(
+            entry("web-researcher", RegistryItemType.AGENT, "web-researcher", "research"),
+            entry("default-llm", RegistryItemType.LLM_CONFIG, "default"),
+            entry("summarize", RegistryItemType.WORKFLOW, "summarize", "text")));
+
+    @Test
+    void finds_an_entry_by_id() {
+        assertThat(index.find("summarize")).isPresent();
+        assertThat(index.find("nope")).isEmpty();
+        assertThat(index.find(null)).isEmpty();
+    }
+
+    @Test
+    void a_blank_query_matches_everything_in_index_order() {
+        assertThat(index.search(null, null)).hasSize(3);
+        assertThat(index.search("  ", null)).extracting(RegistryEntry::id)
+                .containsExactly("web-researcher", "default-llm", "summarize");
+    }
+
+    @Test
+    void searches_name_description_and_tags_ignoring_case() {
+        assertThat(index.search("RESEARCH", null)).extracting(RegistryEntry::id)
+                .containsExactly("web-researcher");
+        assertThat(index.search("does summarize", null)).extracting(RegistryEntry::id)
+                .containsExactly("summarize");
+    }
+
+    @Test
+    void filters_by_kind() {
+        assertThat(index.search(null, RegistryItemType.AGENT)).extracting(RegistryEntry::id)
+                .containsExactly("web-researcher");
+        assertThat(index.search("x", RegistryItemType.AGENT)).isEmpty();
+    }
+
+    @Test
+    void an_entry_without_a_path_is_no_entry() {
+        assertThatThrownBy(() -> new RegistryEntry("a", RegistryItemType.AGENT, "a", null, null,
+                null, null, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void a_type_reads_in_whatever_spelling_the_index_author_used() {
+        assertThat(RegistryItemType.fromWire("llm-config")).isEqualTo(RegistryItemType.LLM_CONFIG);
+        assertThat(RegistryItemType.fromWire("LLM_CONFIG")).isEqualTo(RegistryItemType.LLM_CONFIG);
+        assertThat(RegistryItemType.fromWire(" Agent ")).isEqualTo(RegistryItemType.AGENT);
+        assertThatThrownBy(() -> RegistryItemType.fromWire("prompt"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistryServiceTest.java
+++ b/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistryServiceTest.java
@@ -24,9 +24,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 /**
  * The import walk: dependencies before the entry, a package as its member
@@ -39,14 +41,16 @@ class RegistryServiceTest {
 
     private final Map<String, RegistryEntry> entries = new LinkedHashMap<>();
     private final Map<String, RegistryPackage> packages = new HashMap<>();
+    /** Every removal across all installers, in the order it happened. */
+    private final List<String> removalLog = new ArrayList<>();
     private RecordingInstaller agents;
     private RecordingInstaller configs;
     private RegistryService service;
 
     @BeforeEach
     void setUp() {
-        agents = new RecordingInstaller(RegistryItemType.AGENT);
-        configs = new RecordingInstaller(RegistryItemType.LLM_CONFIG);
+        agents = new RecordingInstaller(RegistryItemType.AGENT, removalLog);
+        configs = new RecordingInstaller(RegistryItemType.LLM_CONFIG, removalLog);
         service = new RegistryService(new FixedSources(), new FakeClient(),
                 List.of(agents, configs));
     }
@@ -186,6 +190,135 @@ class RegistryServiceTest {
                 .hasMessageContaining("disabled");
     }
 
+    @Test
+    void a_packages_contents_are_everything_its_import_would_install_in_order() {
+        entry("default-llm", RegistryItemType.LLM_CONFIG);
+        entry("researcher", RegistryItemType.AGENT, "default-llm");
+        entry("kit", RegistryItemType.PACKAGE);
+        RegistryEntry inline = new RegistryEntry("helper", RegistryItemType.AGENT, "helper", null,
+                null, "agents/helper.json", List.of(), null, null, List.of("default-llm"));
+        packages.put("packages/kit.json", new RegistryPackage("Kit", null, null,
+                List.of("researcher", "gone"), List.of(inline)));
+
+        RegistryService.PackageContents contents = service.packageContents(SOURCE.id(), entries.get("kit"));
+
+        // What a member requires is installed too, so it is shown — once, before it is needed.
+        assertThat(contents.members()).extracting(RegistryEntry::id)
+                .containsExactly("default-llm", "researcher", "helper");
+        assertThat(contents.unresolved()).containsExactly("gone");
+        assertThat(configs.installed).isEmpty();
+    }
+
+    @Test
+    void a_left_out_entry_is_installed_neither_as_a_member_nor_as_a_requirement() {
+        entry("default-llm", RegistryItemType.LLM_CONFIG);
+        entry("researcher", RegistryItemType.AGENT, "default-llm");
+        entry("writer", RegistryItemType.AGENT);
+        entry("kit", RegistryItemType.PACKAGE);
+        packages.put("packages/kit.json", new RegistryPackage("Kit", null, null,
+                List.of("default-llm", "researcher", "writer"), List.of()));
+
+        ImportReport report = service.importEntry(SOURCE.id(), "kit", ImportMode.SKIP_EXISTING,
+                Set.of("default-llm", "writer"));
+
+        assertThat(agents.installed).containsExactly("researcher");
+        assertThat(configs.installed).isEmpty();
+        assertThat(report.items()).extracting(ImportedItem::entryId, ImportedItem::status)
+                .containsExactly(
+                        tuple("default-llm", ImportStatus.SKIPPED),
+                        tuple("researcher", ImportStatus.IMPORTED),
+                        tuple("writer", ImportStatus.SKIPPED));
+    }
+
+    @Test
+    void removing_a_package_deletes_the_included_entries_that_are_here_dependents_first() {
+        entry("default-llm", RegistryItemType.LLM_CONFIG);
+        entry("researcher", RegistryItemType.AGENT, "default-llm");
+        entry("writer", RegistryItemType.AGENT, "default-llm");
+        entry("reviewer", RegistryItemType.AGENT);
+        entry("kit", RegistryItemType.PACKAGE);
+        packages.put("packages/kit.json", new RegistryPackage("Kit", null, null,
+                List.of("researcher", "writer", "reviewer"), List.of()));
+        configs.present.add("default-llm");
+        agents.present.addAll(List.of("researcher", "writer"));
+
+        ImportReport report = service.removeEntry(SOURCE.id(), "kit", Set.of("writer"));
+
+        // The agents go before the config they run on; writer stays; reviewer was never here.
+        assertThat(removalLog).containsExactly("researcher", "default-llm");
+        assertThat(agents.present).containsExactly("writer");
+        assertThat(report.items()).extracting(ImportedItem::entryId, ImportedItem::status)
+                .containsExactly(
+                        tuple("reviewer", ImportStatus.SKIPPED),
+                        tuple("researcher", ImportStatus.REMOVED),
+                        tuple("default-llm", ImportStatus.REMOVED),
+                        tuple("writer", ImportStatus.SKIPPED));
+    }
+
+    @Test
+    void a_member_here_says_what_outside_the_package_uses_it() {
+        entry("default-llm", RegistryItemType.LLM_CONFIG);
+        entry("researcher", RegistryItemType.AGENT, "default-llm");
+        entry("writer", RegistryItemType.AGENT, "default-llm");
+        entry("kit", RegistryItemType.PACKAGE);
+        packages.put("packages/kit.json", new RegistryPackage("Kit", null, null,
+                List.of("researcher", "writer"), List.of()));
+        configs.present.add("default-llm");
+        agents.present.add("researcher");
+        agents.references.put("llm-config:default-llm", List.of("researcher", "default-chat"));
+        agents.references.put("agent:writer", List.of("planner"));
+
+        RegistryService.PackageContents contents = service.packageContents(SOURCE.id(), entries.get("kit"));
+
+        // researcher is in the package, so only default-chat counts; writer is not
+        // here, so what would call it is nothing to protect.
+        assertThat(contents.usedBy("default-llm")).containsExactly("Agent 'default-chat'");
+        assertThat(contents.usedBy("researcher")).isEmpty();
+        assertThat(contents.usedBy("writer")).isEmpty();
+    }
+
+    @Test
+    void what_a_member_used_from_outside_needs_counts_as_used_too() {
+        entry("openai", RegistryItemType.LLM_CONFIG);
+        entry("alias", RegistryItemType.LLM_CONFIG, "openai");
+        entry("helper", RegistryItemType.AGENT, "alias");
+        entry("kit", RegistryItemType.PACKAGE);
+        packages.put("packages/kit.json", new RegistryPackage("Kit", null, null,
+                List.of("helper"), List.of()));
+        configs.present.addAll(List.of("openai", "alias"));
+        agents.present.add("helper");
+        configs.references.put("llm-config:openai", List.of("alias"));
+        agents.references.put("llm-config:alias", List.of("helper", "default-chat"));
+
+        RegistryService.PackageContents contents = service.packageContents(SOURCE.id(), entries.get("kit"));
+
+        // The alias stays for default-chat, so the config it delegates to must stay as well;
+        // helper is used by nothing outside and may go.
+        assertThat(contents.usedBy("alias")).containsExactly("Agent 'default-chat'");
+        assertThat(contents.usedBy("openai")).containsExactly("LLM config 'alias'");
+        assertThat(contents.usedBy("helper")).isEmpty();
+    }
+
+    @Test
+    void only_a_package_can_be_removed() {
+        entry("researcher", RegistryItemType.AGENT);
+        agents.present.add("researcher");
+
+        assertThatThrownBy(() -> service.removeEntry(SOURCE.id(), "researcher", Set.of()))
+                .isInstanceOf(RegistryException.class)
+                .hasMessageContaining("Only a package");
+        assertThat(agents.present).containsExactly("researcher");
+    }
+
+    @Test
+    void only_a_package_has_contents() {
+        entry("researcher", RegistryItemType.AGENT);
+
+        assertThatThrownBy(() -> service.packageContents(SOURCE.id(), entries.get("researcher")))
+                .isInstanceOf(RegistryException.class)
+                .hasMessageContaining("not a package");
+    }
+
     // ---------------------------------------------------------------- helpers
 
     private ImportReport importEntry(String entryId) {
@@ -257,9 +390,28 @@ class RegistryServiceTest {
         final List<String> installed = new ArrayList<>();
         final List<String> present = new ArrayList<>();
         String failOn;
+        private final List<String> removalLog;
 
-        RecordingInstaller(RegistryItemType type) {
+        RecordingInstaller(RegistryItemType type, List<String> removalLog) {
             this.type = type;
+            this.removalLog = removalLog;
+        }
+
+        /** "llm-config:default-llm" → the names of this installer's entities that use it. */
+        final Map<String, List<String>> references = new HashMap<>();
+
+        @Override
+        public List<String> referencesTo(RegistryItemType type, String name) {
+            return references.getOrDefault(type.wireName() + ":" + name, List.of());
+        }
+
+        @Override
+        public ImportedItem remove(RegistryEntry entry) {
+            if (!present.remove(entry.name())) {
+                return ImportedItem.skipped(entry, entry.name(), "not here");
+            }
+            removalLog.add(entry.name());
+            return ImportedItem.removed(entry, entry.name());
         }
 
         @Override

--- a/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistryServiceTest.java
+++ b/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistryServiceTest.java
@@ -1,0 +1,289 @@
+package ai.mindconnect.agent.registry;
+
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportReport;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryException;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.domain.RegistryPackage;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+import ai.mindconnect.agent.registry.port.out.RegistryClient;
+import ai.mindconnect.agent.registry.port.out.RegistryInstaller;
+import ai.mindconnect.agent.registry.port.out.RegistrySourceRepository;
+import ai.mindconnect.agent.registry.service.RegistryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The import walk: dependencies before the entry, a package as its member
+ * list, every entry once, and a failing member that does not take the rest
+ * of the import with it.
+ */
+class RegistryServiceTest {
+
+    private static final RegistrySource SOURCE = RegistrySource.of("acme/registry");
+
+    private final Map<String, RegistryEntry> entries = new LinkedHashMap<>();
+    private final Map<String, RegistryPackage> packages = new HashMap<>();
+    private RecordingInstaller agents;
+    private RecordingInstaller configs;
+    private RegistryService service;
+
+    @BeforeEach
+    void setUp() {
+        agents = new RecordingInstaller(RegistryItemType.AGENT);
+        configs = new RecordingInstaller(RegistryItemType.LLM_CONFIG);
+        service = new RegistryService(new FixedSources(), new FakeClient(),
+                List.of(agents, configs));
+    }
+
+    // ------------------------------------------------------------------ cases
+
+    @Test
+    void installs_what_an_entry_requires_before_the_entry() {
+        entry("default-llm", RegistryItemType.LLM_CONFIG);
+        entry("researcher", RegistryItemType.AGENT, "default-llm");
+
+        ImportReport report = importEntry("researcher");
+
+        assertThat(report.items()).extracting(ImportedItem::entryId)
+                .containsExactly("default-llm", "researcher");
+        assertThat(report.ok()).isTrue();
+        assertThat(report.summary()).isEqualTo("2 imported");
+    }
+
+    @Test
+    void a_package_installs_its_members_in_order() {
+        entry("default-llm", RegistryItemType.LLM_CONFIG);
+        entry("researcher", RegistryItemType.AGENT);
+        entry("kit", RegistryItemType.PACKAGE);
+        packages.put("packages/kit.json", new RegistryPackage("Research kit", null, "1.0",
+                List.of("default-llm", "researcher"), List.of()));
+
+        ImportReport report = importEntry("kit");
+
+        assertThat(report.items()).extracting(ImportedItem::entryId)
+                .containsExactly("default-llm", "researcher");
+        assertThat(configs.installed).containsExactly("default-llm");
+        assertThat(agents.installed).containsExactly("researcher");
+    }
+
+    @Test
+    void an_entry_reached_twice_is_installed_once() {
+        entry("default-llm", RegistryItemType.LLM_CONFIG);
+        entry("one", RegistryItemType.AGENT, "default-llm");
+        entry("two", RegistryItemType.AGENT, "default-llm");
+        entry("kit", RegistryItemType.PACKAGE);
+        packages.put("packages/kit.json", new RegistryPackage("Kit", null, null,
+                List.of("one", "two"), List.of()));
+
+        ImportReport report = importEntry("kit");
+
+        assertThat(configs.installed).containsExactly("default-llm");
+        assertThat(report.items()).extracting(ImportedItem::entryId)
+                .containsExactly("default-llm", "one", "two");
+    }
+
+    @Test
+    void a_cycle_terminates_instead_of_recursing() {
+        entry("a", RegistryItemType.AGENT, "b");
+        entry("b", RegistryItemType.AGENT, "a");
+
+        ImportReport report = importEntry("a");
+
+        assertThat(agents.installed).containsExactly("b", "a");
+        assertThat(report.ok()).isTrue();
+    }
+
+    @Test
+    void a_required_entry_the_index_does_not_have_fails_only_itself() {
+        entry("researcher", RegistryItemType.AGENT, "missing-llm");
+
+        ImportReport report = importEntry("researcher");
+
+        assertThat(report.count(ImportStatus.FAILED)).isEqualTo(1);
+        assertThat(agents.installed).containsExactly("researcher");
+        ImportedItem unresolved = report.items().get(0);
+        assertThat(unresolved.detail()).contains("not in this registry's index");
+        // Its kind is exactly what nobody knows — the index has no line for it.
+        assertThat(unresolved.type()).isNull();
+        assertThat(unresolved).hasToString("Entry 'missing-llm' — failed ("
+                + unresolved.detail() + ")");
+    }
+
+    @Test
+    void a_member_whose_installer_throws_does_not_stop_the_others() {
+        entry("bad", RegistryItemType.AGENT);
+        entry("good", RegistryItemType.AGENT);
+        entry("kit", RegistryItemType.PACKAGE);
+        packages.put("packages/kit.json", new RegistryPackage("Kit", null, null,
+                List.of("bad", "good"), List.of()));
+        agents.failOn = "bad";
+
+        ImportReport report = importEntry("kit");
+
+        assertThat(report.ok()).isFalse();
+        assertThat(report.count(ImportStatus.FAILED)).isEqualTo(1);
+        assertThat(agents.installed).containsExactly("good");
+        assertThat(report.summary()).isEqualTo("1 imported, 1 failed");
+    }
+
+    @Test
+    void a_kind_without_an_installer_is_skipped_with_the_reason() {
+        entry("summarize", RegistryItemType.WORKFLOW);
+
+        ImportReport report = importEntry("summarize");
+
+        assertThat(report.count(ImportStatus.SKIPPED)).isEqualTo(1);
+        assertThat(report.items().get(0).detail()).contains("cannot import");
+        assertThat(service.status(entries.get("summarize")).installable()).isFalse();
+    }
+
+    @Test
+    void skip_existing_keeps_what_is_here_and_overwrite_replaces_it() {
+        entry("researcher", RegistryItemType.AGENT);
+        agents.present.add("researcher");
+
+        assertThat(importEntry("researcher").count(ImportStatus.SKIPPED)).isEqualTo(1);
+        assertThat(agents.installed).isEmpty();
+
+        ImportReport overwritten = service.importEntry(SOURCE.id(), "researcher", ImportMode.OVERWRITE);
+        assertThat(overwritten.count(ImportStatus.UPDATED)).isEqualTo(1);
+        assertThat(agents.installed).containsExactly("researcher");
+    }
+
+    @Test
+    void an_unknown_entry_or_source_is_an_error_rather_than_an_empty_report() {
+        assertThatThrownBy(() -> importEntry("nope"))
+                .isInstanceOf(RegistryException.class)
+                .hasMessageContaining("no entry 'nope'");
+        assertThatThrownBy(() -> service.importEntry(RegistrySourceId.of("other"), "x", null))
+                .isInstanceOf(RegistryException.class)
+                .hasMessageContaining("No registry");
+    }
+
+    @Test
+    void a_disabled_registry_is_not_read() {
+        RegistryService disabled = new RegistryService(
+                new FixedSources(SOURCE.withEnabled(false)), new FakeClient(), List.of());
+
+        assertThatThrownBy(() -> disabled.index(SOURCE.id()))
+                .isInstanceOf(RegistryException.class)
+                .hasMessageContaining("disabled");
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private ImportReport importEntry(String entryId) {
+        return service.importEntry(SOURCE.id(), entryId, ImportMode.SKIP_EXISTING);
+    }
+
+    private void entry(String id, RegistryItemType type, String... requires) {
+        String path = (type == RegistryItemType.PACKAGE ? "packages/" : type.wireName() + "s/")
+                + id + ".json";
+        entries.put(id, new RegistryEntry(id, type, id, null, null, path, List.of(), null, null,
+                List.of(requires)));
+    }
+
+    /** One configured source, and no other. */
+    private static final class FixedSources implements RegistrySourceRepository {
+        private final RegistrySource source;
+
+        FixedSources() {
+            this(SOURCE);
+        }
+
+        FixedSources(RegistrySource source) {
+            this.source = source;
+        }
+
+        @Override
+        public RegistrySource save(RegistrySource source) {
+            return source;
+        }
+
+        @Override
+        public Optional<RegistrySource> findById(RegistrySourceId id) {
+            return source.id().equals(id) ? Optional.of(source) : Optional.empty();
+        }
+
+        @Override
+        public List<RegistrySource> findAll() {
+            return List.of(source);
+        }
+
+        @Override
+        public void deleteById(RegistrySourceId id) {
+        }
+    }
+
+    /** The index and the files, straight out of the test's maps. */
+    private final class FakeClient implements RegistryClient {
+        @Override
+        public RegistryIndex fetchIndex(RegistrySource source) {
+            return new RegistryIndex(1, "Fake", null, new ArrayList<>(entries.values()));
+        }
+
+        @Override
+        public RegistryPackage fetchPackage(RegistrySource source, String path) {
+            RegistryPackage found = packages.get(path);
+            if (found == null) throw new RegistryException("no package at " + path);
+            return found;
+        }
+
+        @Override
+        public String fetchText(RegistrySource source, String path) {
+            return "{\"path\":\"" + path + "\"}";
+        }
+    }
+
+    /** An installer that only remembers what it was asked to do. */
+    private static final class RecordingInstaller implements RegistryInstaller {
+        private final RegistryItemType type;
+        final List<String> installed = new ArrayList<>();
+        final List<String> present = new ArrayList<>();
+        String failOn;
+
+        RecordingInstaller(RegistryItemType type) {
+            this.type = type;
+        }
+
+        @Override
+        public RegistryItemType type() {
+            return type;
+        }
+
+        @Override
+        public boolean exists(String name) {
+            return present.contains(name);
+        }
+
+        @Override
+        public ImportedItem install(RegistryEntry entry, String content, ImportMode mode) {
+            if (entry.id().equals(failOn)) {
+                throw new IllegalStateException("this one is broken");
+            }
+            if (present.contains(entry.name()) && mode == ImportMode.SKIP_EXISTING) {
+                return ImportedItem.skipped(entry, entry.name(), "already here");
+            }
+            boolean update = present.contains(entry.name());
+            installed.add(entry.name());
+            return update ? ImportedItem.updated(entry, entry.name())
+                    : ImportedItem.imported(entry, entry.name());
+        }
+    }
+}

--- a/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistrySourceTest.java
+++ b/agents/core/mc-agent-registry-core/src/test/java/ai/mindconnect/agent/registry/RegistrySourceTest.java
@@ -1,0 +1,75 @@
+package ai.mindconnect.agent.registry;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RegistrySourceTest {
+
+    @Test
+    void reads_the_short_form_and_fills_in_the_defaults() {
+        RegistrySource source = RegistrySource.of("mindconnect-ai/registry");
+
+        assertThat(source.owner()).isEqualTo("mindconnect-ai");
+        assertThat(source.repo()).isEqualTo("registry");
+        assertThat(source.ref()).isEqualTo(RegistrySource.DEFAULT_REF);
+        assertThat(source.indexPath()).isEqualTo(RegistrySource.DEFAULT_INDEX_PATH);
+        assertThat(source.baseUrl()).isEqualTo(RegistrySource.GITHUB_RAW_BASE_URL);
+        assertThat(source.enabled()).isTrue();
+        assertThat(source.id().value()).isEqualTo("mindconnect-ai-registry");
+    }
+
+    @Test
+    void reads_a_pinned_tag_and_a_custom_index_path() {
+        RegistrySource source = RegistrySource.of("acme/agents@v1.2.0:catalog/index.json");
+
+        assertThat(source.ref()).isEqualTo("v1.2.0");
+        assertThat(source.indexPath()).isEqualTo("catalog/index.json");
+        assertThat(source.coordinates()).isEqualTo("acme/agents@v1.2.0");
+    }
+
+    @Test
+    void reads_the_url_from_the_browsers_address_bar() {
+        assertThat(RegistrySource.of("https://github.com/acme/agents.git").repo()).isEqualTo("agents");
+        assertThat(RegistrySource.of("https://github.com/acme/agents").owner()).isEqualTo("acme");
+    }
+
+    @Test
+    void refuses_text_that_names_no_repository() {
+        assertThatThrownBy(() -> RegistrySource.of("agents"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> RegistrySource.of(" "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void the_same_repository_always_gets_the_same_id_so_adding_it_twice_collides() {
+        assertThat(RegistrySource.of("Acme/Agents").id())
+                .isEqualTo(RegistrySource.of("acme/agents").id());
+    }
+
+    @Test
+    void a_github_source_names_its_page_and_another_host_names_none() {
+        assertThat(RegistrySource.of("acme/agents").repositoryUrl())
+                .isEqualTo("https://github.com/acme/agents");
+
+        RegistrySource enterprise = new RegistrySource(RegistrySource.of("acme/agents").id(), null,
+                "acme", "agents", null, null, null, "https://raw.github.acme.internal", true, null);
+
+        // Its web address does not follow from its raw-content one, and a link
+        // to github.com/acme/agents would point at somebody else's repository.
+        assertThat(enterprise.repositoryUrl()).isNull();
+    }
+
+    @Test
+    void a_blank_token_variable_is_no_token_variable() {
+        RegistrySource source = new RegistrySource(
+                RegistrySource.of("acme/agents").id(), null, "acme", "agents", null, null,
+                "  ", null, true, null);
+
+        assertThat(source.tokenEnvVar()).isNull();
+        assertThat(source.name()).isEqualTo("acme/agents");
+    }
+}

--- a/agents/core/mc-agent-registry/pom.xml
+++ b/agents/core/mc-agent-registry/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-initial-data</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
             <artifactId>mc-llm-gateway-core</artifactId>
         </dependency>
         <dependency>

--- a/agents/core/mc-agent-registry/pom.xml
+++ b/agents/core/mc-agent-registry/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-agent-registry</artifactId>
+    <name>mc-agent-registry</name>
+    <packaging>jar</packaging>
+    <description>
+        The registry's adapters: the GitHub client that reads raw files from a
+        repository, the file-backed store of configured registries, and the
+        installers for the two entities this module can see — LLM configs and
+        agents. Workflows are installed by mc-agent-tools-workflow, which is
+        the module that has a workflow store.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-registry-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-domain</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-file-repo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-llm-gateway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-runtime-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/file/FileRegistrySourceRepository.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/file/FileRegistrySourceRepository.java
@@ -1,0 +1,71 @@
+package ai.mindconnect.agent.registry.adapter.file;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+import ai.mindconnect.agent.registry.port.out.RegistrySourceRepository;
+import ai.mindconnect.common.Versions;
+import ai.mindconnect.filerepo.Documents;
+import ai.mindconnect.filerepo.FileRepo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Stores configured registries under
+ * {@code {base}/{namespace}/system/registries/{id}.json} — beside the agents
+ * and LLM configs they install.
+ *
+ * <p>A file each, so an installation can ship a registry the way it ships a
+ * seed agent: drop the JSON in and it is there on the next start.
+ */
+public class FileRegistrySourceRepository implements RegistrySourceRepository {
+
+    private static final String DIR = "system/registries";
+
+    private final Documents<RegistrySourceId, RegistrySource> sources;
+    private final Path directory;
+
+    public FileRegistrySourceRepository(Path storageDir, Namespace namespace) {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        FileRepo repo = FileRepo.open(storageDir, namespace.value());
+        this.directory = repo.resolve(DIR);
+        this.sources = Documents.of(RegistrySource.class)
+                .path((RegistrySourceId id) -> DIR + "/" + id.value() + ".json")
+                .build(repo, objectMapper);
+    }
+
+    /** Where the files are — what an initial-data installer seeds into. */
+    public Path directory() {
+        return directory;
+    }
+
+    @Override
+    public RegistrySource save(RegistrySource source) {
+        return sources.compute(source.id(), current -> source.withVersion(Versions.next(
+                current.map(RegistrySource::version).orElse(null), source.version(),
+                "RegistrySource", source.id().value())));
+    }
+
+    @Override
+    public Optional<RegistrySource> findById(RegistrySourceId id) {
+        return sources.find(id).filter(source -> source.id().equals(id));
+    }
+
+    @Override
+    public List<RegistrySource> findAll() {
+        return sources.findAll(DIR).stream()
+                .sorted(Comparator.comparing(RegistrySource::name, String.CASE_INSENSITIVE_ORDER))
+                .toList();
+    }
+
+    @Override
+    public void deleteById(RegistrySourceId id) {
+        sources.delete(id);
+    }
+}

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/github/GitHubRegistryClient.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/github/GitHubRegistryClient.java
@@ -1,0 +1,228 @@
+package ai.mindconnect.agent.registry.adapter.github;
+
+import ai.mindconnect.agent.registry.domain.RegistryException;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryPackage;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.port.out.RegistryClient;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Reads a registry as what it is: raw files in a GitHub repository.
+ *
+ * <p>{@code https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}} —
+ * no API, no rate limit worth worrying about for a public repository, and
+ * nothing to run on the registry's side. A private repository is the same URL
+ * with a token, which the source names by environment variable so that the
+ * store holding the source can never hold the secret.
+ *
+ * <p>Answers are cached for a TTL, because a screen that lists a registry and
+ * then shows one of its entries would otherwise fetch the index twice for one
+ * pair of clicks. The cache is dropped by {@link #refresh}, which is what the
+ * screen's refresh button calls — a registry changes when its owner pushes,
+ * and nothing here can know when that was.
+ */
+public class GitHubRegistryClient implements RegistryClient {
+
+    private static final Logger log = LoggerFactory.getLogger(GitHubRegistryClient.class);
+
+    /**
+     * Cap on a single fetched file. A registry entry is a JSON document
+     * somebody wrote by hand; anything past this is not one, and reading it
+     * into memory because a URL pointed at it is how a browse turns into an
+     * outage.
+     */
+    private static final int MAX_BYTES = 4 * 1024 * 1024;
+
+    private final HttpClient http;
+    private final ObjectMapper objectMapper;
+    private final Duration ttl;
+    private final Duration timeout;
+    /** Where a token named by a source is looked up — the process environment, or a test's map. */
+    private final Function<String, String> env;
+
+    private final Map<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    public GitHubRegistryClient() {
+        this(Duration.ofMinutes(10), Duration.ofSeconds(20));
+    }
+
+    public GitHubRegistryClient(Duration ttl, Duration timeout) {
+        this(ttl, timeout, System::getenv);
+    }
+
+    public GitHubRegistryClient(Duration ttl, Duration timeout, Function<String, String> env) {
+        this.ttl = ttl == null ? Duration.ZERO : ttl;
+        this.timeout = timeout == null ? Duration.ofSeconds(20) : timeout;
+        this.env = env == null ? name -> null : env;
+        this.objectMapper = new ObjectMapper()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(this.timeout)
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+    }
+
+    @Override
+    public RegistryIndex fetchIndex(RegistrySource source) {
+        return parse(source, source.indexPath(), RegistryIndex.class, "index");
+    }
+
+    @Override
+    public RegistryPackage fetchPackage(RegistrySource source, String path) {
+        return parse(source, path, RegistryPackage.class, "package manifest");
+    }
+
+    @Override
+    public String fetchText(RegistrySource source, String path) {
+        String url = rawUrl(source, path);
+        CacheEntry cached = cache.get(url);
+        if (cached != null && cached.isFresh(ttl)) {
+            return cached.body();
+        }
+        String body = get(source, url);
+        cache.put(url, new CacheEntry(body, Instant.now()));
+        return body;
+    }
+
+    @Override
+    public void refresh(RegistrySource source) {
+        String prefix = rawUrl(source, "");
+        cache.keySet().removeIf(url -> url.startsWith(prefix));
+        log.debug("Dropped the cached files of {}", source.coordinates());
+    }
+
+    private <T> T parse(RegistrySource source, String path, Class<T> type, String what) {
+        String body = fetchText(source, path);
+        try {
+            T parsed = objectMapper.readValue(body, type);
+            if (parsed == null) {
+                throw new RegistryException("The " + what + " of " + source.coordinates() + " is empty");
+            }
+            return parsed;
+        } catch (RegistryException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RegistryException("The " + what + " of " + source.coordinates()
+                    + " (" + path + ") could not be read: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * The raw URL of one repository file. Every path segment is encoded, and a
+     * path that tries to climb out of the repository is refused here: entries
+     * come from a file somebody else wrote, and {@code ../../} in one of them
+     * must not turn into a request to another repository.
+     */
+    String rawUrl(RegistrySource source, String path) {
+        String relative = path == null ? "" : path.strip();
+        if (relative.startsWith("/")) relative = relative.substring(1);
+        if (relative.contains("..") || relative.contains("://")) {
+            throw new RegistryException("'" + path + "' is not a path inside a registry repository");
+        }
+        StringBuilder url = new StringBuilder(trimSlash(source.baseUrl()))
+                .append('/').append(encode(source.owner()))
+                .append('/').append(encode(source.repo()))
+                .append('/').append(encode(source.ref()))
+                .append('/');
+        if (!relative.isEmpty()) {
+            String[] segments = relative.split("/");
+            for (int i = 0; i < segments.length; i++) {
+                if (i > 0) url.append('/');
+                url.append(encode(segments[i]));
+            }
+        }
+        return url.toString();
+    }
+
+    private String get(RegistrySource source, String url) {
+        HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(timeout)
+                .header("Accept", "text/plain, application/json, */*")
+                .header("User-Agent", "mindconnect-registry")
+                .GET();
+        String token = token(source);
+        if (token != null) {
+            request.header("Authorization", "Bearer " + token);
+        }
+        HttpResponse<byte[]> response;
+        try {
+            response = http.send(request.build(), HttpResponse.BodyHandlers.ofByteArray());
+        } catch (IOException e) {
+            throw new RegistryException("Registry " + source.coordinates() + " is unreachable: "
+                    + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RegistryException("Reading registry " + source.coordinates() + " was interrupted", e);
+        }
+        if (response.statusCode() == 404) {
+            throw new RegistryException("Registry " + source.coordinates() + " has no " + fileOf(url)
+                    + (token == null && source.tokenEnvVar() == null
+                            ? " (a private repository needs a token)" : ""));
+        }
+        if (response.statusCode() == 401 || response.statusCode() == 403) {
+            throw new RegistryException("Registry " + source.coordinates() + " refused the request ("
+                    + response.statusCode() + ")"
+                    + (token == null ? " — it may need a token" : " — check the token in "
+                            + source.tokenEnvVar()));
+        }
+        if (response.statusCode() / 100 != 2) {
+            throw new RegistryException("Registry " + source.coordinates() + " answered "
+                    + response.statusCode() + " for " + fileOf(url));
+        }
+        byte[] body = response.body();
+        if (body.length > MAX_BYTES) {
+            throw new RegistryException(fileOf(url) + " of registry " + source.coordinates()
+                    + " is larger than " + (MAX_BYTES / (1024 * 1024)) + " MB — refusing to read it");
+        }
+        return new String(body, StandardCharsets.UTF_8);
+    }
+
+    /** The token a source names, from the environment — {@code null} for a public repository. */
+    private String token(RegistrySource source) {
+        if (source.tokenEnvVar() == null) return null;
+        String value = env.apply(source.tokenEnvVar());
+        if (value == null || value.isBlank()) {
+            log.warn("Registry {} names the token variable {}, which is not set",
+                    source.coordinates(), source.tokenEnvVar());
+            return null;
+        }
+        return value.strip();
+    }
+
+    private static String fileOf(String url) {
+        int slash = url.lastIndexOf('/');
+        return slash < 0 ? url : url.substring(slash + 1);
+    }
+
+    private static String trimSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    /** Path segments are encoded, but a space becomes {@code %20}, not {@code +}. */
+    private static String encode(String segment) {
+        return URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private record CacheEntry(String body, Instant fetchedAt) {
+        boolean isFresh(Duration ttl) {
+            return !ttl.isZero() && fetchedAt.plus(ttl).isAfter(Instant.now());
+        }
+    }
+}

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/initialdata/InitialRegistrySources.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/initialdata/InitialRegistrySources.java
@@ -1,0 +1,62 @@
+package ai.mindconnect.agent.registry.adapter.initialdata;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+import ai.mindconnect.agent.registry.port.out.RegistrySourceRepository;
+import ai.mindconnect.initialdata.ImportInitialDataInstaller;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.List;
+
+/**
+ * Seeds the registries an application ships with, the way it ships its seed
+ * agents and MCP servers: one JSON file per registry under
+ * {@code initial-data/registries/}, installed on start when no registry of that
+ * id is configured yet.
+ *
+ * <p>The file is a stored registry — {@code owner} and {@code repo}, and
+ * optionally {@code name}, {@code ref}, {@code indexPath}, {@code tokenEnvVar},
+ * {@code baseUrl}, {@code enabled}. Its id is the file name, so
+ * {@code mindconnect-ai-mc-registry.json} seeds the registry the screen would
+ * create for {@code mindconnect-ai/mc-registry}; an {@code id} in the file is
+ * ignored rather than trusted to agree with it.
+ *
+ * <p>A registry that is already configured is left as it is — an operator who
+ * pinned a tag or disabled it keeps that. One that was deleted comes back on
+ * the next start, as a deleted seed agent does.
+ */
+public class InitialRegistrySources {
+
+    /** Where applications put their registries. */
+    public static final String LOCATION = "classpath*:initial-data/registries/*.json";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private InitialRegistrySources() {
+    }
+
+    /**
+     * Installs every registry file at {@code locationPattern} whose id is not
+     * configured yet.
+     *
+     * @return the ids that were newly installed
+     */
+    public static List<String> install(RegistrySourceRepository repository, String locationPattern) {
+        return new ImportInitialDataInstaller(
+                id -> repository.findById(RegistrySourceId.of(id)).isPresent(),
+                (id, resource) -> {
+                    JsonNode tree = MAPPER.readTree(resource.getInputStream());
+                    if (!(tree instanceof ObjectNode object)) {
+                        throw new IllegalArgumentException("A registry file has to be a JSON object");
+                    }
+                    object.put("id", id);
+                    object.remove("version");
+                    repository.save(MAPPER.treeToValue(object, RegistrySource.class));
+                })
+                .install(locationPattern);
+    }
+}

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/AgentDefinitionInstaller.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/AgentDefinitionInstaller.java
@@ -1,0 +1,99 @@
+package ai.mindconnect.agent.registry.adapter.installer;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.port.out.RegistryInstaller;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.agent.runtime.domain.AgentDefinitionStatus;
+import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Installs an {@code agent} entry.
+ *
+ * <p>Like the LLM config, the agent is re-addressed on the way in: a new agent
+ * gets a fresh {@link AgentId}, a re-import keeps the local id and version so
+ * that sessions, sub-agent rosters and tool bindings still point at the same
+ * agent. Timestamps are this installation's — {@code createdAt} is when the
+ * agent arrived here, not when its author wrote it.
+ *
+ * <p>What is <em>not</em> checked is what the agent refers to. An imported
+ * agent may name an LLM config or a sub-agent this installation does not have;
+ * that is what an entry's {@code requires} and a package are for, and an agent
+ * whose model is missing says so plainly on its own screen. Refusing the
+ * import would only make the two halves of a package impossible to install in
+ * any order.
+ */
+public class AgentDefinitionInstaller implements RegistryInstaller {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentDefinitionInstaller.class);
+
+    private final AgentDefinitionRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public AgentDefinitionInstaller(AgentDefinitionRepository repository) {
+        this.repository = repository;
+        this.objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    @Override
+    public RegistryItemType type() {
+        return RegistryItemType.AGENT;
+    }
+
+    @Override
+    public boolean exists(String name) {
+        return name != null && repository.findByName(name).isPresent();
+    }
+
+    @Override
+    public ImportedItem install(RegistryEntry entry, String content, ImportMode mode) throws Exception {
+        AgentDefinition incoming = objectMapper.readValue(content, AgentDefinition.class);
+        String name = incoming.name() != null && !incoming.name().isBlank()
+                ? incoming.name() : entry.name();
+        Optional<AgentDefinition> existing = repository.findByName(name);
+
+        if (existing.isPresent() && mode == ImportMode.SKIP_EXISTING) {
+            return ImportedItem.skipped(entry, name, "an agent of this name is already here");
+        }
+
+        Instant now = Instant.now();
+        AgentDefinition toSave = new AgentDefinition(
+                existing.map(AgentDefinition::id).orElseGet(AgentId::random),
+                name,
+                incoming.description(),
+                incoming.group(),
+                incoming.icon(),
+                incoming.systemPrompt(),
+                incoming.welcomeMessage(),
+                incoming.llmConfigName(),
+                incoming.maxIterations() > 0 ? incoming.maxIterations() : 10,
+                incoming.effectiveMemoryConfig(),
+                incoming.status() != null ? incoming.status() : AgentDefinitionStatus.ACTIVE,
+                incoming.tools(),
+                incoming.responseReviewers(),
+                incoming.callableAgents(),
+                incoming.toolSearch(),
+                existing.map(AgentDefinition::createdAt).orElse(now),
+                now,
+                existing.map(AgentDefinition::version).orElse(null));
+        repository.save(toSave);
+        log.info("Imported agent '{}' from registry entry '{}'", name, entry.id());
+
+        return new ImportedItem(entry.id(), type(), name,
+                existing.isPresent() ? ImportStatus.UPDATED : ImportStatus.IMPORTED, null);
+    }
+}

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/AgentDefinitionInstaller.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/AgentDefinitionInstaller.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -57,6 +58,37 @@ public class AgentDefinitionInstaller implements RegistryInstaller {
     @Override
     public boolean exists(String name) {
         return name != null && repository.findByName(name).isPresent();
+    }
+
+    /** Agents running on that LLM config, or calling or reviewing with that agent. */
+    @Override
+    public List<String> referencesTo(RegistryItemType type, String name) {
+        if (name == null || (type != RegistryItemType.LLM_CONFIG && type != RegistryItemType.AGENT)) {
+            return List.of();
+        }
+        return repository.findAll().stream()
+                .filter(agent -> type == RegistryItemType.LLM_CONFIG
+                        ? name.equals(agent.llmConfigName())
+                        : !name.equals(agent.name())
+                                && (contains(agent.callableAgents(), name)
+                                        || contains(agent.responseReviewers(), name)))
+                .map(AgentDefinition::name)
+                .toList();
+    }
+
+    private static boolean contains(List<String> names, String name) {
+        return names != null && names.contains(name);
+    }
+
+    @Override
+    public ImportedItem remove(RegistryEntry entry) {
+        Optional<AgentDefinition> existing = repository.findByName(entry.name());
+        if (existing.isEmpty()) {
+            return ImportedItem.skipped(entry, entry.name(), "no agent of this name is here");
+        }
+        repository.deleteById(existing.get().id());
+        log.info("Removed agent '{}' (registry entry '{}')", entry.name(), entry.id());
+        return ImportedItem.removed(entry, entry.name());
     }
 
     @Override

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/LlmConfigInstaller.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/LlmConfigInstaller.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -56,6 +57,29 @@ public class LlmConfigInstaller implements RegistryInstaller {
     @Override
     public boolean exists(String name) {
         return name != null && repository.findByName(name).isPresent();
+    }
+
+    /** Aliases that delegate to that LLM config. */
+    @Override
+    public List<String> referencesTo(RegistryItemType type, String name) {
+        if (type != RegistryItemType.LLM_CONFIG || name == null) {
+            return List.of();
+        }
+        return repository.findAll().stream()
+                .filter(config -> config.isAlias() && name.equals(config.delegatesTo()))
+                .map(LlmConfig::name)
+                .toList();
+    }
+
+    @Override
+    public ImportedItem remove(RegistryEntry entry) {
+        Optional<LlmConfig> existing = repository.findByName(entry.name());
+        if (existing.isEmpty()) {
+            return ImportedItem.skipped(entry, entry.name(), "no LLM config of this name is here");
+        }
+        repository.deleteById(existing.get().id());
+        log.info("Removed LLM config '{}' (registry entry '{}')", entry.name(), entry.id());
+        return ImportedItem.removed(entry, entry.name());
     }
 
     @Override

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/LlmConfigInstaller.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/installer/LlmConfigInstaller.java
@@ -1,0 +1,127 @@
+package ai.mindconnect.agent.registry.adapter.installer;
+
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.port.out.RegistryInstaller;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigId;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * Installs an {@code llm-config} entry.
+ *
+ * <p>Two things are taken away from the imported file, both for the same
+ * reason — a registry is somebody else's repository:
+ *
+ * <ul>
+ *   <li><b>The id.</b> A new config gets a fresh one; re-importing over an
+ *       existing config keeps the local id and version, so the agents pointing
+ *       at it keep working and the optimistic lock still holds.</li>
+ *   <li><b>A literal API key.</b> A registry config is meant to carry
+ *       {@code ${OPENAI_API_KEY}}, which resolves against this installation's
+ *       environment at call time. A key that is not a placeholder is somebody
+ *       else's credential — it is dropped, and the report says so, rather than
+ *       this installation quietly billing a stranger.</li>
+ * </ul>
+ */
+public class LlmConfigInstaller implements RegistryInstaller {
+
+    private static final Logger log = LoggerFactory.getLogger(LlmConfigInstaller.class);
+
+    private final LlmConfigRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public LlmConfigInstaller(LlmConfigRepository repository) {
+        this.repository = repository;
+        this.objectMapper = new ObjectMapper()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    @Override
+    public RegistryItemType type() {
+        return RegistryItemType.LLM_CONFIG;
+    }
+
+    @Override
+    public boolean exists(String name) {
+        return name != null && repository.findByName(name).isPresent();
+    }
+
+    @Override
+    public ImportedItem install(RegistryEntry entry, String content, ImportMode mode) throws Exception {
+        LlmConfig incoming = read(content);
+        String name = incoming.name() != null && !incoming.name().isBlank()
+                ? incoming.name() : entry.name();
+        Optional<LlmConfig> existing = repository.findByName(name);
+
+        if (existing.isPresent() && mode == ImportMode.SKIP_EXISTING) {
+            return ImportedItem.skipped(entry, name, "an LLM config of this name is already here");
+        }
+
+        boolean keyDropped = isLiteralSecret(incoming.apiKey());
+        LlmConfig toSave = rewrite(incoming, name,
+                existing.map(LlmConfig::id).orElseGet(LlmConfigId::random),
+                existing.map(LlmConfig::version).orElse(null),
+                keyDropped ? null : incoming.apiKey());
+        repository.save(toSave);
+        log.info("Imported LLM config '{}' from registry entry '{}'", name, entry.id());
+
+        String detail = keyDropped
+                ? "the file's API key was dropped — set one here, or use a ${ENV_VAR} placeholder"
+                : null;
+        return new ImportedItem(entry.id(), type(), name,
+                existing.isPresent() ? ImportStatus.UPDATED : ImportStatus.IMPORTED, detail);
+    }
+
+    /**
+     * The file as an {@link LlmConfig}.
+     *
+     * <p>A registry file carries no id — an id addresses an entity in one
+     * installation's store, and the config's own reader insists on a valid one.
+     * So a placeholder goes in before parsing; {@link #install} then puts the
+     * local id in its place.
+     */
+    private LlmConfig read(String content) throws Exception {
+        JsonNode tree = objectMapper.readTree(content);
+        if (!(tree instanceof ObjectNode object)) {
+            throw new IllegalArgumentException("An LLM config file has to be a JSON object");
+        }
+        JsonNode id = object.get("id");
+        if (id == null || id.isNull() || id.asText().isBlank()) {
+            object.put("id", LlmConfigId.random().value());
+        }
+        return objectMapper.treeToValue(object, LlmConfig.class);
+    }
+
+    /** The incoming config under the local id, name, version and key. */
+    private static LlmConfig rewrite(LlmConfig incoming, String name, LlmConfigId id,
+                                     Long version, String apiKey) {
+        return new LlmConfig(id, name, incoming.provider(), incoming.model(), incoming.baseUrl(),
+                apiKey, incoming.defaultTemperature(), incoming.maxOutputTokens(),
+                incoming.additionalParams(), incoming.contextWindowTokens(), incoming.isAlias(),
+                incoming.delegatesTo(), incoming.retry(), incoming.rateLimit(), incoming.type(),
+                incoming.capabilities(), version);
+    }
+
+    /**
+     * Whether this key is a value rather than a reference. {@code ${OPENAI_API_KEY}}
+     * and {@code ${KEY:fallback}} are references this installation resolves for
+     * itself; anything else that is not blank came with the file.
+     */
+    static boolean isLiteralSecret(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) return false;
+        String value = apiKey.strip();
+        return !(value.startsWith("${") && value.endsWith("}"));
+    }
+}

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/memory/InMemoryRegistrySourceRepository.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/adapter/memory/InMemoryRegistrySourceRepository.java
@@ -1,0 +1,40 @@
+package ai.mindconnect.agent.registry.adapter.memory;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+import ai.mindconnect.agent.registry.port.out.RegistrySourceRepository;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** The registries of a process that keeps nothing — tests, and an embedded runtime. */
+public class InMemoryRegistrySourceRepository implements RegistrySourceRepository {
+
+    private final Map<RegistrySourceId, RegistrySource> sources = new ConcurrentHashMap<>();
+
+    @Override
+    public RegistrySource save(RegistrySource source) {
+        sources.put(source.id(), source);
+        return source;
+    }
+
+    @Override
+    public Optional<RegistrySource> findById(RegistrySourceId id) {
+        return Optional.ofNullable(sources.get(id));
+    }
+
+    @Override
+    public List<RegistrySource> findAll() {
+        return sources.values().stream()
+                .sorted(Comparator.comparing(RegistrySource::name, String.CASE_INSENSITIVE_ORDER))
+                .toList();
+    }
+
+    @Override
+    public void deleteById(RegistrySourceId id) {
+        sources.remove(id);
+    }
+}

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/spring/RegistryAutoConfiguration.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/spring/RegistryAutoConfiguration.java
@@ -39,8 +39,15 @@ import java.time.Duration;
  * <p>{@code mindconnect.registry.default-source} seeds one registry on first
  * start ({@code owner/repo[@ref][:index-path]}) — how a distribution points a
  * fresh installation at its own catalogue without shipping a file.
+ *
+ * <p>Ordered after the persistence starters: the installers are conditional on
+ * the repositories those register, and a {@code @ConditionalOnBean} evaluated
+ * before them finds nothing — the screen then offers every entry and can
+ * import none.
  */
-@AutoConfiguration
+@AutoConfiguration(afterName = {
+        "ai.mindconnect.agent.starter.file.FilePersistenceAutoConfiguration",
+        "ai.mindconnect.agent.starter.postgres.PostgresPersistenceConfig"})
 @ConditionalOnProperty(prefix = "mindconnect.registry", name = "enabled",
         havingValue = "true", matchIfMissing = true)
 public class RegistryAutoConfiguration {

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/spring/RegistryAutoConfiguration.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/spring/RegistryAutoConfiguration.java
@@ -3,6 +3,7 @@ package ai.mindconnect.agent.registry.spring;
 import ai.mindconnect.agent.Namespace;
 import ai.mindconnect.agent.registry.adapter.file.FileRegistrySourceRepository;
 import ai.mindconnect.agent.registry.adapter.github.GitHubRegistryClient;
+import ai.mindconnect.agent.registry.adapter.initialdata.InitialRegistrySources;
 import ai.mindconnect.agent.registry.adapter.installer.AgentDefinitionInstaller;
 import ai.mindconnect.agent.registry.adapter.installer.LlmConfigInstaller;
 import ai.mindconnect.agent.registry.domain.RegistrySource;
@@ -36,9 +37,12 @@ import java.time.Duration;
  * whole thing away for an installation that wants no outbound calls even as a
  * possibility.
  *
- * <p>{@code mindconnect.registry.default-source} seeds one registry on first
- * start ({@code owner/repo[@ref][:index-path]}) — how a distribution points a
- * fresh installation at its own catalogue without shipping a file.
+ * <p>The registries an application ships with are files under
+ * {@code initial-data/registries/} on its classpath, installed on start when
+ * not configured yet — see {@link InitialRegistrySources}.
+ * {@code mindconnect.registry.default-source} seeds one more on first start
+ * ({@code owner/repo[@ref][:index-path]}) — how a deployment points a fresh
+ * installation at its own catalogue without shipping a file.
  *
  * <p>Ordered after the persistence starters: the installers are conditional on
  * the repositories those register, and a {@code @ConditionalOnBean} evaluated
@@ -62,6 +66,7 @@ public class RegistryAutoConfiguration {
             ObjectProvider<Namespace> namespace) {
         FileRegistrySourceRepository repository = new FileRegistrySourceRepository(
                 Path.of(dataBaseDir), namespace.getIfAvailable(() -> Namespace.DEFAULT));
+        InitialRegistrySources.install(repository, InitialRegistrySources.LOCATION);
         seed(repository, defaultSource);
         return repository;
     }

--- a/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/spring/RegistryAutoConfiguration.java
+++ b/agents/core/mc-agent-registry/src/main/java/ai/mindconnect/agent/registry/spring/RegistryAutoConfiguration.java
@@ -1,0 +1,118 @@
+package ai.mindconnect.agent.registry.spring;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.registry.adapter.file.FileRegistrySourceRepository;
+import ai.mindconnect.agent.registry.adapter.github.GitHubRegistryClient;
+import ai.mindconnect.agent.registry.adapter.installer.AgentDefinitionInstaller;
+import ai.mindconnect.agent.registry.adapter.installer.LlmConfigInstaller;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.port.out.RegistryClient;
+import ai.mindconnect.agent.registry.port.out.RegistryInstaller;
+import ai.mindconnect.agent.registry.port.out.RegistrySourceRepository;
+import ai.mindconnect.agent.registry.service.RegistryService;
+import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+/**
+ * Wires the registry into a host application: the store of configured
+ * registries, the GitHub client, the installers for the entities this module
+ * can see, and the service over them.
+ *
+ * <p>Off by nothing and on by default — reading a registry happens only when
+ * somebody opens the screen, and an installation with no sources configured
+ * reads nothing at all. {@code mindconnect.registry.enabled=false} takes the
+ * whole thing away for an installation that wants no outbound calls even as a
+ * possibility.
+ *
+ * <p>{@code mindconnect.registry.default-source} seeds one registry on first
+ * start ({@code owner/repo[@ref][:index-path]}) — how a distribution points a
+ * fresh installation at its own catalogue without shipping a file.
+ */
+@AutoConfiguration
+@ConditionalOnProperty(prefix = "mindconnect.registry", name = "enabled",
+        havingValue = "true", matchIfMissing = true)
+public class RegistryAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(RegistryAutoConfiguration.class);
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RegistrySourceRepository registrySourceRepository(
+            @Value("${mindconnect.data.base-dir:./data}") String dataBaseDir,
+            @Value("${mindconnect.registry.default-source:}") String defaultSource,
+            ObjectProvider<Namespace> namespace) {
+        FileRegistrySourceRepository repository = new FileRegistrySourceRepository(
+                Path.of(dataBaseDir), namespace.getIfAvailable(() -> Namespace.DEFAULT));
+        seed(repository, defaultSource);
+        return repository;
+    }
+
+    /**
+     * Adds the configured default registry unless it is already there. Only
+     * ever adds: an operator who deleted it meant to, and a start that puts it
+     * back would be a bug report.
+     */
+    private void seed(RegistrySourceRepository repository, String defaultSource) {
+        if (defaultSource == null || defaultSource.isBlank()) {
+            return;
+        }
+        try {
+            RegistrySource source = RegistrySource.of(defaultSource);
+            if (repository.findById(source.id()).isEmpty() && repository.findAll().isEmpty()) {
+                repository.save(source);
+                log.info("Seeded the default registry {}", source.coordinates());
+            }
+        } catch (RuntimeException e) {
+            log.warn("mindconnect.registry.default-source '{}' is not a registry: {}",
+                    defaultSource, e.getMessage());
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RegistryClient registryClient(
+            @Value("${mindconnect.registry.cache-ttl:PT10M}") Duration cacheTtl,
+            @Value("${mindconnect.registry.timeout:PT20S}") Duration timeout) {
+        return new GitHubRegistryClient(cacheTtl, timeout);
+    }
+
+    @Bean
+    @ConditionalOnBean(LlmConfigRepository.class)
+    @ConditionalOnMissingBean
+    public LlmConfigInstaller llmConfigRegistryInstaller(LlmConfigRepository repository) {
+        return new LlmConfigInstaller(repository);
+    }
+
+    @Bean
+    @ConditionalOnBean(AgentDefinitionRepository.class)
+    @ConditionalOnMissingBean
+    public AgentDefinitionInstaller agentDefinitionRegistryInstaller(AgentDefinitionRepository repository) {
+        return new AgentDefinitionInstaller(repository);
+    }
+
+    /**
+     * The service over whatever installers the host assembled — the two here,
+     * plus any another module contributed (the workflow installer lives with
+     * the workflow tools). A host with no installers at all still gets the
+     * service: browsing a registry is useful before anything can be installed,
+     * and every entry then reports why it cannot be.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public RegistryService registryService(RegistrySourceRepository sources, RegistryClient client,
+                                           ObjectProvider<RegistryInstaller> installers) {
+        return new RegistryService(sources, client, installers.orderedStream().toList());
+    }
+}

--- a/agents/core/mc-agent-registry/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agents/core/mc-agent-registry/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ai.mindconnect.agent.registry.spring.RegistryAutoConfiguration

--- a/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/AgentDefinitionInstallerTest.java
+++ b/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/AgentDefinitionInstallerTest.java
@@ -86,6 +86,26 @@ class AgentDefinitionInstallerTest {
                 .isEqualTo("my prompt");
     }
 
+    @Test
+    void references_are_the_agents_running_on_a_config_or_calling_an_agent() {
+        repository.save(AgentDefinition.create("web-researcher", "", "p", null, "default"));
+        repository.save(AgentDefinition.create("lead", "", "p", null, "other")
+                .withCallableAgents(List.of("web-researcher")));
+
+        assertThat(installer.referencesTo(RegistryItemType.LLM_CONFIG, "default")).containsExactly("web-researcher");
+        assertThat(installer.referencesTo(RegistryItemType.AGENT, "web-researcher")).containsExactly("lead");
+        assertThat(installer.referencesTo(RegistryItemType.WORKFLOW, "web-researcher")).isEmpty();
+    }
+
+    @Test
+    void remove_deletes_the_agent_of_the_entrys_name_and_skips_when_there_is_none() {
+        repository.save(AgentDefinition.create("web-researcher", "mine", "my prompt", null, "default"));
+
+        assertThat(installer.remove(ENTRY).status()).isEqualTo(ImportStatus.REMOVED);
+        assertThat(repository.findByName("web-researcher")).isEmpty();
+        assertThat(installer.remove(ENTRY).status()).isEqualTo(ImportStatus.SKIPPED);
+    }
+
     private static final class FakeRepository implements AgentDefinitionRepository {
         private final List<AgentDefinition> agents = new ArrayList<>();
 

--- a/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/AgentDefinitionInstallerTest.java
+++ b/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/AgentDefinitionInstallerTest.java
@@ -1,0 +1,119 @@
+package ai.mindconnect.agent.registry.adapter;
+
+import ai.mindconnect.agent.AgentId;
+import ai.mindconnect.agent.registry.adapter.installer.AgentDefinitionInstaller;
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.runtime.domain.AgentDefinition;
+import ai.mindconnect.agent.runtime.domain.AgentDefinitionStatus;
+import ai.mindconnect.agent.runtime.port.out.AgentDefinitionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgentDefinitionInstallerTest {
+
+    private static final String JSON = """
+            {
+              "name": "web-researcher",
+              "description": "Researches on the web",
+              "group": "sub-agents",
+              "icon": "telescope",
+              "systemPrompt": "You research.",
+              "llmConfigName": "default",
+              "maxIterations": 20,
+              "tools": []
+            }
+            """;
+
+    private static final RegistryEntry ENTRY = new RegistryEntry("web-researcher",
+            RegistryItemType.AGENT, "web-researcher", null, "1.0", "agents/web-researcher.json",
+            List.of(), null, null, List.of());
+
+    private FakeRepository repository;
+    private AgentDefinitionInstaller installer;
+
+    @BeforeEach
+    void setUp() {
+        repository = new FakeRepository();
+        installer = new AgentDefinitionInstaller(repository);
+    }
+
+    @Test
+    void installs_the_agent_with_its_prompt_and_an_active_status() throws Exception {
+        ImportedItem item = installer.install(ENTRY, JSON, ImportMode.SKIP_EXISTING);
+
+        assertThat(item.status()).isEqualTo(ImportStatus.IMPORTED);
+        AgentDefinition saved = repository.findByName("web-researcher").orElseThrow();
+        assertThat(saved.systemPrompt()).isEqualTo("You research.");
+        assertThat(saved.group()).isEqualTo("sub-agents");
+        assertThat(saved.maxIterations()).isEqualTo(20);
+        assertThat(saved.status()).isEqualTo(AgentDefinitionStatus.ACTIVE);
+        assertThat(saved.createdAt()).isNotNull();
+    }
+
+    @Test
+    void an_overwrite_keeps_the_local_id_and_the_date_it_first_arrived() throws Exception {
+        AgentDefinition existing = AgentDefinition.create("web-researcher", "old", "old prompt",
+                null, "default");
+        repository.save(existing);
+
+        ImportedItem item = installer.install(ENTRY, JSON, ImportMode.OVERWRITE);
+
+        assertThat(item.status()).isEqualTo(ImportStatus.UPDATED);
+        AgentDefinition saved = repository.findByName("web-researcher").orElseThrow();
+        assertThat(saved.id()).isEqualTo(existing.id());
+        assertThat(saved.createdAt()).isEqualTo(existing.createdAt());
+        assertThat(saved.systemPrompt()).isEqualTo("You research.");
+    }
+
+    @Test
+    void keeps_what_is_here_under_the_default_mode() throws Exception {
+        repository.save(AgentDefinition.create("web-researcher", "mine", "my prompt", null, "default"));
+
+        ImportedItem item = installer.install(ENTRY, JSON, ImportMode.SKIP_EXISTING);
+
+        assertThat(item.status()).isEqualTo(ImportStatus.SKIPPED);
+        assertThat(repository.findByName("web-researcher").orElseThrow().systemPrompt())
+                .isEqualTo("my prompt");
+    }
+
+    private static final class FakeRepository implements AgentDefinitionRepository {
+        private final List<AgentDefinition> agents = new ArrayList<>();
+
+        @Override
+        public AgentDefinition save(AgentDefinition definition) {
+            agents.removeIf(a -> a.id().equals(definition.id()));
+            agents.add(definition);
+            return definition;
+        }
+
+        @Override
+        public Optional<AgentDefinition> findById(AgentId id) {
+            return agents.stream().filter(a -> a.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public List<AgentDefinition> findAll() {
+            return List.copyOf(agents);
+        }
+
+        @Override
+        public Optional<AgentDefinition> findByName(String name) {
+            return agents.stream().filter(a -> name.equalsIgnoreCase(a.name())).findFirst();
+        }
+
+        @Override
+        public void deleteById(AgentId id) {
+            agents.removeIf(a -> a.id().equals(id));
+        }
+    }
+}

--- a/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/FileRegistrySourceRepositoryTest.java
+++ b/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/FileRegistrySourceRepositoryTest.java
@@ -1,0 +1,57 @@
+package ai.mindconnect.agent.registry.adapter;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.registry.adapter.file.FileRegistrySourceRepository;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileRegistrySourceRepositoryTest {
+
+    @Test
+    void a_saved_registry_reads_back_with_everything_it_was_given(@TempDir Path dir) {
+        FileRegistrySourceRepository repository =
+                new FileRegistrySourceRepository(dir, Namespace.DEFAULT);
+        RegistrySource source = new RegistrySource(RegistrySource.of("acme/agents").id(),
+                "Acme agents", "acme", "agents", "v2", "catalog/index.json", "ACME_TOKEN",
+                null, true, null);
+
+        repository.save(source);
+
+        RegistrySource read = repository.findById(source.id()).orElseThrow();
+        assertThat(read.owner()).isEqualTo("acme");
+        assertThat(read.ref()).isEqualTo("v2");
+        assertThat(read.indexPath()).isEqualTo("catalog/index.json");
+        assertThat(read.tokenEnvVar()).isEqualTo("ACME_TOKEN");
+        assertThat(read.version()).isNotNull();
+        assertThat(repository.findAll()).hasSize(1);
+        assertThat(repository.findEnabled()).hasSize(1);
+    }
+
+    @Test
+    void a_disabled_registry_stays_configured_but_out_of_the_enabled_list(@TempDir Path dir) {
+        FileRegistrySourceRepository repository =
+                new FileRegistrySourceRepository(dir, Namespace.DEFAULT);
+        RegistrySource saved = repository.save(RegistrySource.of("acme/agents"));
+
+        repository.save(saved.withEnabled(false));
+
+        assertThat(repository.findAll()).hasSize(1);
+        assertThat(repository.findEnabled()).isEmpty();
+    }
+
+    @Test
+    void deleting_one_leaves_the_store_empty(@TempDir Path dir) {
+        FileRegistrySourceRepository repository =
+                new FileRegistrySourceRepository(dir, Namespace.DEFAULT);
+        RegistrySource saved = repository.save(RegistrySource.of("acme/agents"));
+
+        repository.deleteById(saved.id());
+
+        assertThat(repository.findAll()).isEmpty();
+    }
+}

--- a/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/InitialRegistrySourcesTest.java
+++ b/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/InitialRegistrySourcesTest.java
@@ -1,0 +1,46 @@
+package ai.mindconnect.agent.registry.adapter;
+
+import ai.mindconnect.agent.Namespace;
+import ai.mindconnect.agent.registry.adapter.file.FileRegistrySourceRepository;
+import ai.mindconnect.agent.registry.adapter.initialdata.InitialRegistrySources;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * An application ships its registries as files under
+ * {@code initial-data/registries/}; a start installs the ones not configured yet.
+ */
+class InitialRegistrySourcesTest {
+
+    private static final String LOCATION = "classpath*:initial-data-test/registries/*.json";
+    private static final RegistrySourceId ID = RegistrySourceId.of("acme-agents");
+
+    @Test
+    void a_shipped_registry_is_installed_under_its_file_name(@TempDir Path dir) {
+        FileRegistrySourceRepository repository = new FileRegistrySourceRepository(dir, Namespace.DEFAULT);
+
+        assertThat(InitialRegistrySources.install(repository, LOCATION)).containsExactly("acme-agents");
+
+        RegistrySource source = repository.findById(ID).orElseThrow();
+        assertThat(source.coordinates()).isEqualTo("acme/agents@v1.0.0");
+        assertThat(source.enabled()).isTrue();
+        assertThat(repository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void a_registry_already_configured_keeps_what_the_operator_made_of_it(@TempDir Path dir) {
+        FileRegistrySourceRepository repository = new FileRegistrySourceRepository(dir, Namespace.DEFAULT);
+        InitialRegistrySources.install(repository, LOCATION);
+        repository.save(repository.findById(ID).orElseThrow().withEnabled(false));
+
+        assertThat(InitialRegistrySources.install(repository, LOCATION)).isEmpty();
+
+        assertThat(repository.findById(ID).orElseThrow().enabled()).isFalse();
+    }
+}

--- a/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/LlmConfigInstallerTest.java
+++ b/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/LlmConfigInstallerTest.java
@@ -1,0 +1,129 @@
+package ai.mindconnect.agent.registry.adapter;
+
+import ai.mindconnect.agent.registry.adapter.installer.LlmConfigInstaller;
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.llm.domain.LlmConfig;
+import ai.mindconnect.llm.domain.LlmConfigId;
+import ai.mindconnect.llm.port.out.LlmConfigRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmConfigInstallerTest {
+
+    private static final String JSON = """
+            {
+              "name": "default",
+              "provider": "ANTHROPIC",
+              "model": "claude-sonnet-5",
+              "baseUrl": "https://api.anthropic.com",
+              "apiKey": "%s",
+              "maxOutputTokens": 8192
+            }
+            """;
+
+    private static final RegistryEntry ENTRY = new RegistryEntry("default-llm",
+            RegistryItemType.LLM_CONFIG, "default", null, "1.0", "llm-configs/default.json",
+            List.of(), null, null, List.of());
+
+    private FakeRepository repository;
+    private LlmConfigInstaller installer;
+
+    @BeforeEach
+    void setUp() {
+        repository = new FakeRepository();
+        installer = new LlmConfigInstaller(repository);
+    }
+
+    @Test
+    void installs_the_config_under_a_fresh_id() throws Exception {
+        ImportedItem item = installer.install(ENTRY, JSON.formatted("${ANTHROPIC_API_KEY}"),
+                ImportMode.SKIP_EXISTING);
+
+        assertThat(item.status()).isEqualTo(ImportStatus.IMPORTED);
+        LlmConfig saved = repository.findByName("default").orElseThrow();
+        assertThat(saved.model()).isEqualTo("claude-sonnet-5");
+        assertThat(saved.apiKey()).isEqualTo("${ANTHROPIC_API_KEY}");
+        assertThat(saved.id()).isNotNull();
+    }
+
+    @Test
+    void drops_an_api_key_that_came_with_the_file_and_says_so() throws Exception {
+        ImportedItem item = installer.install(ENTRY, JSON.formatted("sk-ant-somebody-elses-key"),
+                ImportMode.SKIP_EXISTING);
+
+        assertThat(repository.findByName("default").orElseThrow().apiKey()).isNull();
+        assertThat(item.detail()).contains("API key was dropped");
+    }
+
+    @Test
+    void keeps_what_is_here_unless_the_mode_says_otherwise() throws Exception {
+        repository.save(LlmConfig.claude("default", "claude-opus-5", "my-key"));
+
+        ImportedItem skipped = installer.install(ENTRY, JSON.formatted("${KEY}"),
+                ImportMode.SKIP_EXISTING);
+
+        assertThat(skipped.status()).isEqualTo(ImportStatus.SKIPPED);
+        assertThat(repository.findByName("default").orElseThrow().model()).isEqualTo("claude-opus-5");
+    }
+
+    @Test
+    void an_overwrite_keeps_the_local_id_so_that_aliases_keep_pointing_at_it() throws Exception {
+        LlmConfig existing = LlmConfig.claude("default", "claude-opus-5", "my-key");
+        repository.save(existing);
+
+        ImportedItem item = installer.install(ENTRY, JSON.formatted("${KEY}"), ImportMode.OVERWRITE);
+
+        assertThat(item.status()).isEqualTo(ImportStatus.UPDATED);
+        LlmConfig saved = repository.findByName("default").orElseThrow();
+        assertThat(saved.id()).isEqualTo(existing.id());
+        assertThat(saved.model()).isEqualTo("claude-sonnet-5");
+    }
+
+    @Test
+    void exists_asks_the_store_by_name() {
+        assertThat(installer.exists("default")).isFalse();
+        repository.save(LlmConfig.claude("default", "claude-opus-5", "k"));
+        assertThat(installer.exists("default")).isTrue();
+    }
+
+    /** A store that is a list — enough for what the installer does with one. */
+    private static final class FakeRepository implements LlmConfigRepository {
+        private final List<LlmConfig> configs = new ArrayList<>();
+
+        @Override
+        public void save(LlmConfig config) {
+            configs.removeIf(c -> c.id().equals(config.id()));
+            configs.add(config);
+        }
+
+        @Override
+        public Optional<LlmConfig> findById(LlmConfigId id) {
+            return configs.stream().filter(c -> c.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public Optional<LlmConfig> findByName(String name) {
+            return configs.stream().filter(c -> name.equals(c.name())).findFirst();
+        }
+
+        @Override
+        public List<LlmConfig> findAll() {
+            return List.copyOf(configs);
+        }
+
+        @Override
+        public void deleteById(LlmConfigId id) {
+            configs.removeIf(c -> c.id().equals(id));
+        }
+    }
+}

--- a/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/LlmConfigInstallerTest.java
+++ b/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/LlmConfigInstallerTest.java
@@ -96,6 +96,26 @@ class LlmConfigInstallerTest {
         assertThat(installer.exists("default")).isTrue();
     }
 
+    @Test
+    void references_are_the_aliases_delegating_to_a_config() throws Exception {
+        repository.save(LlmConfig.claude("default", "claude-opus-5", "k"));
+        installer.install(new RegistryEntry("alias", RegistryItemType.LLM_CONFIG, "agent-default", null, null,
+                        "llm-configs/agent-default.json", List.of(), null, null, List.of()),
+                "{\"name\":\"agent-default\",\"isAlias\":true,\"delegatesTo\":\"default\"}", ImportMode.OVERWRITE);
+
+        assertThat(installer.referencesTo(RegistryItemType.LLM_CONFIG, "default")).containsExactly("agent-default");
+        assertThat(installer.referencesTo(RegistryItemType.AGENT, "default")).isEmpty();
+    }
+
+    @Test
+    void remove_deletes_the_config_of_the_entrys_name_and_skips_when_there_is_none() throws Exception {
+        repository.save(LlmConfig.claude("default", "claude-opus-5", "k"));
+
+        assertThat(installer.remove(ENTRY).status()).isEqualTo(ImportStatus.REMOVED);
+        assertThat(repository.findByName("default")).isEmpty();
+        assertThat(installer.remove(ENTRY).status()).isEqualTo(ImportStatus.SKIPPED);
+    }
+
     /** A store that is a list — enough for what the installer does with one. */
     private static final class FakeRepository implements LlmConfigRepository {
         private final List<LlmConfig> configs = new ArrayList<>();

--- a/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/github/GitHubRegistryClientTest.java
+++ b/agents/core/mc-agent-registry/src/test/java/ai/mindconnect/agent/registry/adapter/github/GitHubRegistryClientTest.java
@@ -1,0 +1,59 @@
+package ai.mindconnect.agent.registry.adapter.github;
+
+import ai.mindconnect.agent.registry.domain.RegistryException;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * URL building, which is the whole of the client that can be tested without a
+ * network — and the one part that must not be sloppy: the paths come out of
+ * somebody else's index file.
+ */
+class GitHubRegistryClientTest {
+
+    private final GitHubRegistryClient client =
+            new GitHubRegistryClient(Duration.ZERO, Duration.ofSeconds(1), name -> null);
+
+    private final RegistrySource source = RegistrySource.of("acme/registry@v1.0.0");
+
+    @Test
+    void builds_the_raw_url_of_a_repository_file() {
+        assertThat(client.rawUrl(source, "agents/web-researcher.json"))
+                .isEqualTo("https://raw.githubusercontent.com/acme/registry/v1.0.0/"
+                        + "agents/web-researcher.json");
+    }
+
+    @Test
+    void a_leading_slash_is_not_a_second_repository_root() {
+        assertThat(client.rawUrl(source, "/registry.json"))
+                .isEqualTo(client.rawUrl(source, "registry.json"));
+    }
+
+    @Test
+    void refuses_a_path_that_climbs_out_of_the_repository() {
+        assertThatThrownBy(() -> client.rawUrl(source, "../../etc/passwd"))
+                .isInstanceOf(RegistryException.class);
+        assertThatThrownBy(() -> client.rawUrl(source, "https://evil.example.com/x.json"))
+                .isInstanceOf(RegistryException.class);
+    }
+
+    @Test
+    void encodes_each_segment_but_keeps_the_separators() {
+        assertThat(client.rawUrl(source, "agents/my agent.json"))
+                .endsWith("/agents/my%20agent.json");
+    }
+
+    @Test
+    void an_enterprise_host_replaces_the_raw_base_url() {
+        RegistrySource enterprise = new RegistrySource(source.id(), null, "acme", "registry",
+                "main", null, null, "https://raw.github.acme.internal/", true, null);
+
+        assertThat(client.rawUrl(enterprise, "registry.json"))
+                .isEqualTo("https://raw.github.acme.internal/acme/registry/main/registry.json");
+    }
+}

--- a/agents/core/mc-agent-registry/src/test/resources/initial-data-test/registries/acme-agents.json
+++ b/agents/core/mc-agent-registry/src/test/resources/initial-data-test/registries/acme-agents.json
@@ -1,0 +1,6 @@
+{
+  "id": "not-the-file-name",
+  "owner": "acme",
+  "repo": "agents",
+  "ref": "v1.0.0"
+}

--- a/agents/core/mc-agent-tools-workflow/pom.xml
+++ b/agents/core/mc-agent-tools-workflow/pom.xml
@@ -28,6 +28,16 @@
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-registry-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-workflow-jackson</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
             <artifactId>mc-workflow-persistence</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryAutoConfiguration.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryAutoConfiguration.java
@@ -1,0 +1,25 @@
+package ai.mindconnect.agent.tools.workflow.registry;
+
+import ai.mindconnect.workflow.persistence.port.WorkflowDataRepository;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Contributes the workflow installer when this host has both a workflow store
+ * to write into and the registry on the classpath. Either missing and there is
+ * nothing to wire — the registry is optional, and so is the workflow engine.
+ */
+@AutoConfiguration
+@ConditionalOnClass(name = "ai.mindconnect.agent.registry.port.out.RegistryInstaller")
+public class WorkflowRegistryAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(WorkflowDataRepository.class)
+    @ConditionalOnMissingBean
+    public WorkflowRegistryInstaller workflowRegistryInstaller(WorkflowDataRepository repository) {
+        return new WorkflowRegistryInstaller(repository);
+    }
+}

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryAutoConfiguration.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryAutoConfiguration.java
@@ -11,8 +11,13 @@ import org.springframework.context.annotation.Bean;
  * Contributes the workflow installer when this host has both a workflow store
  * to write into and the registry on the classpath. Either missing and there is
  * nothing to wire — the registry is optional, and so is the workflow engine.
+ *
+ * <p>Ordered after the auto-configurations that register a workflow store, so
+ * that {@code @ConditionalOnBean} sees it.
  */
-@AutoConfiguration
+@AutoConfiguration(afterName = {
+        "ai.mindconnect.workflow.admin.WorkflowAdminAutoConfiguration",
+        "ai.mindconnect.workflow.persistence.pg.WorkflowPostgresAutoConfiguration"})
 @ConditionalOnClass(name = "ai.mindconnect.agent.registry.port.out.RegistryInstaller")
 public class WorkflowRegistryAutoConfiguration {
 

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstaller.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstaller.java
@@ -10,10 +10,15 @@ import ai.mindconnect.workflow.domain.WorkflowData;
 import ai.mindconnect.workflow.jackson.JacksonWorkflowSerializer;
 import ai.mindconnect.workflow.jackson.WorkflowObjectMapperFactory;
 import ai.mindconnect.workflow.persistence.port.WorkflowDataRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Installs a {@code workflow} entry into the host's workflow store — the same
@@ -33,6 +38,8 @@ import java.util.Locale;
 public class WorkflowRegistryInstaller implements RegistryInstaller {
 
     private static final Logger log = LoggerFactory.getLogger(WorkflowRegistryInstaller.class);
+    /** Reads a serialised workflow as a plain tree, to search it for references. */
+    private static final ObjectMapper TREE_READER = new ObjectMapper();
 
     private final WorkflowDataRepository repository;
     private final JacksonWorkflowSerializer serializer;
@@ -55,6 +62,66 @@ public class WorkflowRegistryInstaller implements RegistryInstaller {
     @Override
     public boolean exists(String name) {
         return name != null && repository.exists(idOf(name));
+    }
+
+    /**
+     * Workflows whose steps call that agent, run an inline agent on that LLM
+     * config, or call that workflow. Read from each workflow's serialised form,
+     * so a reference nested in a loop or a branch is found the same way.
+     */
+    @Override
+    public List<String> referencesTo(RegistryItemType type, String name) {
+        if (name == null || type == RegistryItemType.PACKAGE) {
+            return List.of();
+        }
+        List<String> referring = new ArrayList<>();
+        for (String id : repository.listIds()) {
+            if (type == RegistryItemType.WORKFLOW && id.equals(idOf(name))) {
+                continue;
+            }
+            try {
+                Optional<WorkflowData> workflow = repository.findById(id);
+                if (workflow.isPresent()
+                        && refersTo(TREE_READER.readTree(serializer.write(workflow.get())), type, name)) {
+                    referring.add(id);
+                }
+            } catch (Exception unreadable) {
+                log.debug("Workflow '{}' not searched for references: {}", id, unreadable.getMessage());
+            }
+        }
+        return referring;
+    }
+
+    private static boolean refersTo(JsonNode node, RegistryItemType type, String name) {
+        if (node.isObject()) {
+            String stepClass = node.path("@class").asText("");
+            boolean hit = switch (type) {
+                case AGENT -> stepClass.endsWith(".AgentCallData") && name.equals(node.path("agent").asText(null));
+                case LLM_CONFIG -> name.equals(node.path("llmConfigName").asText(null));
+                case WORKFLOW -> stepClass.endsWith(".CallWorkflowData")
+                        && name.equals(node.path("workflow").asText(null));
+                case PACKAGE -> false;
+            };
+            if (hit) {
+                return true;
+            }
+        }
+        for (JsonNode child : node) {
+            if (refersTo(child, type, name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public ImportedItem remove(RegistryEntry entry) {
+        String id = idOf(entry.name());
+        if (!repository.delete(id)) {
+            return ImportedItem.skipped(entry, id, "no workflow with this id is here");
+        }
+        log.info("Removed workflow '{}' (registry entry '{}')", id, entry.id());
+        return ImportedItem.removed(entry, id);
     }
 
     @Override

--- a/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstaller.java
+++ b/agents/core/mc-agent-tools-workflow/src/main/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstaller.java
@@ -1,0 +1,87 @@
+package ai.mindconnect.agent.tools.workflow.registry;
+
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.port.out.RegistryInstaller;
+import ai.mindconnect.workflow.domain.WorkflowData;
+import ai.mindconnect.workflow.jackson.JacksonWorkflowSerializer;
+import ai.mindconnect.workflow.jackson.WorkflowObjectMapperFactory;
+import ai.mindconnect.workflow.persistence.port.WorkflowDataRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+
+/**
+ * Installs a {@code workflow} entry into the host's workflow store — the same
+ * store the workflow admin writes to and the workflow tools read, so an
+ * imported workflow is editable, runnable and callable by agents on the next
+ * lookup, without a restart.
+ *
+ * <p>This installer lives here rather than with the other two because this is
+ * the module that has a workflow store at all. An installation without a
+ * workflow engine has no installer for the kind, and its registry screen says
+ * so on the entry instead of failing at import time.
+ *
+ * <p>A workflow is addressed by its id, which is its file name — there is no
+ * separate name field to fall back on — so the entry's name becomes the id,
+ * sanitised the way the store sanitises it anyway.
+ */
+public class WorkflowRegistryInstaller implements RegistryInstaller {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkflowRegistryInstaller.class);
+
+    private final WorkflowDataRepository repository;
+    private final JacksonWorkflowSerializer serializer;
+
+    public WorkflowRegistryInstaller(WorkflowDataRepository repository) {
+        this(repository, new JacksonWorkflowSerializer(WorkflowObjectMapperFactory.create()));
+    }
+
+    public WorkflowRegistryInstaller(WorkflowDataRepository repository,
+                                     JacksonWorkflowSerializer serializer) {
+        this.repository = repository;
+        this.serializer = serializer;
+    }
+
+    @Override
+    public RegistryItemType type() {
+        return RegistryItemType.WORKFLOW;
+    }
+
+    @Override
+    public boolean exists(String name) {
+        return name != null && repository.exists(idOf(name));
+    }
+
+    @Override
+    public ImportedItem install(RegistryEntry entry, String content, ImportMode mode) {
+        WorkflowData workflow = serializer.read(content);
+        String id = idOf(entry.name());
+        boolean present = repository.exists(id);
+
+        if (present && mode == ImportMode.SKIP_EXISTING) {
+            return ImportedItem.skipped(entry, id, "a workflow with this id is already here");
+        }
+        repository.save(id, workflow);
+        log.info("Imported workflow '{}' from registry entry '{}'", id, entry.id());
+        return new ImportedItem(entry.id(), type(), id,
+                present ? ImportStatus.UPDATED : ImportStatus.IMPORTED, null);
+    }
+
+    /**
+     * The entry's name as a workflow id: lower case, and everything that is
+     * not a letter, a digit, {@code -} or {@code _} becomes a hyphen. The
+     * store sanitises ids on the way to disk regardless; doing it here too
+     * means {@link #exists} asks about the same id the import will write.
+     */
+    static String idOf(String name) {
+        String id = name == null ? "" : name.strip().toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9._-]+", "-")
+                .replaceAll("(^-+)|(-+$)", "");
+        return id.isEmpty() ? "workflow" : id;
+    }
+}

--- a/agents/core/mc-agent-tools-workflow/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agents/core/mc-agent-tools-workflow/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 ai.mindconnect.agent.tools.workflow.McAgentWorkflowStepsAutoConfiguration
+ai.mindconnect.agent.tools.workflow.registry.WorkflowRegistryAutoConfiguration

--- a/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstallerTest.java
+++ b/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstallerTest.java
@@ -70,6 +70,48 @@ class WorkflowRegistryInstallerTest {
     }
 
     @Test
+    void references_are_found_in_steps_nested_anywhere_in_a_workflow() {
+        installer.install(entry("digest"), """
+                {
+                  "@class" : "ai.mindconnect.workflow.domain.WorkflowData",
+                  "name" : "digest",
+                  "steps" : [ {
+                    "@class" : "ai.mindconnect.workflow.domain.ForEachData",
+                    "name" : "each",
+                    "loopOver" : "items",
+                    "runVar" : "item",
+                    "steps" : [ {
+                      "@class" : "ai.mindconnect.agent.tools.workflow.step.AgentCallData",
+                      "name" : "summarize",
+                      "agent" : "Summarizer",
+                      "message" : "${item}"
+                    }, {
+                      "@class" : "ai.mindconnect.agent.tools.workflow.step.AgentCallData",
+                      "name" : "inline",
+                      "agentSpec" : { "name" : "writer", "llmConfigName" : "agent-default" },
+                      "message" : "${item}"
+                    } ]
+                  } ],
+                  "subWorkflows" : [ ]
+                }
+                """, ImportMode.SKIP_EXISTING);
+        installer.install(entry("summarize"), JSON, ImportMode.SKIP_EXISTING);
+
+        assertThat(installer.referencesTo(RegistryItemType.AGENT, "Summarizer")).containsExactly("digest");
+        assertThat(installer.referencesTo(RegistryItemType.LLM_CONFIG, "agent-default")).containsExactly("digest");
+        assertThat(installer.referencesTo(RegistryItemType.AGENT, "Poet")).isEmpty();
+    }
+
+    @Test
+    void remove_deletes_the_workflow_under_the_id_the_import_wrote() {
+        installer.install(entry("Summarize Text"), JSON, ImportMode.SKIP_EXISTING);
+
+        assertThat(installer.remove(entry("Summarize Text")).status()).isEqualTo(ImportStatus.REMOVED);
+        assertThat(repository.findById("summarize-text")).isEmpty();
+        assertThat(installer.remove(entry("Summarize Text")).status()).isEqualTo(ImportStatus.SKIPPED);
+    }
+
+    @Test
     void a_name_that_sanitises_to_nothing_still_gets_an_id() {
         assertThat(WorkflowRegistryInstaller.idOf("///")).isEqualTo("workflow");
         assertThat(WorkflowRegistryInstaller.idOf(null)).isEqualTo("workflow");

--- a/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstallerTest.java
+++ b/agents/core/mc-agent-tools-workflow/src/test/java/ai/mindconnect/agent/tools/workflow/registry/WorkflowRegistryInstallerTest.java
@@ -1,0 +1,78 @@
+package ai.mindconnect.agent.tools.workflow.registry;
+
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportStatus;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.workflow.domain.WorkflowData;
+import ai.mindconnect.workflow.persistence.memory.InMemoryWorkflowDataRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkflowRegistryInstallerTest {
+
+    /** A workflow as the store writes it — the type id is part of the format. */
+    private static final String JSON = """
+            {
+              "@class" : "ai.mindconnect.workflow.domain.WorkflowData",
+              "name" : "summarize",
+              "steps" : [ ],
+              "subWorkflows" : [ ]
+            }
+            """;
+
+    private static RegistryEntry entry(String name) {
+        return new RegistryEntry("summarize", RegistryItemType.WORKFLOW, name, null, "1.0",
+                "workflows/summarize.json", List.of(), null, null, List.of());
+    }
+
+    private InMemoryWorkflowDataRepository repository;
+    private WorkflowRegistryInstaller installer;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryWorkflowDataRepository();
+        installer = new WorkflowRegistryInstaller(repository);
+    }
+
+    @Test
+    void installs_the_workflow_under_the_entrys_name_as_its_id() {
+        ImportedItem item = installer.install(entry("summarize"), JSON, ImportMode.SKIP_EXISTING);
+
+        assertThat(item.status()).isEqualTo(ImportStatus.IMPORTED);
+        assertThat(item.name()).isEqualTo("summarize");
+        assertThat(repository.findById("summarize")).isPresent();
+    }
+
+    @Test
+    void keeps_what_is_here_unless_the_mode_says_otherwise() {
+        repository.save("summarize", new WorkflowData());
+
+        assertThat(installer.install(entry("summarize"), JSON, ImportMode.SKIP_EXISTING).status())
+                .isEqualTo(ImportStatus.SKIPPED);
+        assertThat(installer.install(entry("summarize"), JSON, ImportMode.OVERWRITE).status())
+                .isEqualTo(ImportStatus.UPDATED);
+    }
+
+    @Test
+    void exists_asks_about_the_same_id_the_import_would_write() {
+        assertThat(installer.exists("Summarize Text")).isFalse();
+
+        installer.install(entry("Summarize Text"), JSON, ImportMode.SKIP_EXISTING);
+
+        assertThat(installer.exists("Summarize Text")).isTrue();
+        assertThat(repository.findById("summarize-text")).isPresent();
+    }
+
+    @Test
+    void a_name_that_sanitises_to_nothing_still_gets_an_id() {
+        assertThat(WorkflowRegistryInstaller.idOf("///")).isEqualTo("workflow");
+        assertThat(WorkflowRegistryInstaller.idOf(null)).isEqualTo("workflow");
+        assertThat(WorkflowRegistryInstaller.idOf("My Workflow!")).isEqualTo("my-workflow");
+    }
+}

--- a/agents/doc/manual-tests/registry/import-a-package.md
+++ b/agents/doc/manual-tests/registry/import-a-package.md
@@ -1,0 +1,77 @@
+---
+id: registry-import-a-package
+area: registry
+requires: [server-9091, internet]
+duration: ~8 min
+last-verified: never
+---
+
+# A package installs every entity it names, once, in order
+
+**Goal:** Adding a registry, browsing it and importing a package leaves the
+agent, the workflow and the LLM config they share in the local stores — and a
+second import changes nothing unless overwrite is asked for.
+
+## Preconditions
+
+- Admin UI running at http://localhost:9091 (otherwise: SKIPPED)
+- Outbound HTTPS to raw.githubusercontent.com (otherwise: SKIPPED)
+- A public GitHub repository holding the contents of
+  `agents/doc/registry-example/` at its root — push that directory as-is. Its
+  `owner/repo` is `<REGISTRY>` below.
+
+## Setup
+
+1. Make sure no agent named `changelog-writer`, no LLM config named
+   `example-default` and no workflow `greeting` exists yet — delete them if a
+   previous run left them behind.
+
+## Steps
+
+1. http://localhost:9091/registry → **Add registry**. Type `<REGISTRY>` into
+   **Repository**, leave everything else empty, **Save**.
+   **Expected:** Back on the list, one row, named `<REGISTRY>`, subtitle
+   `<REGISTRY>@main`.
+2. Click the row.
+   **Expected:** Four entries — an LLM config, an agent, a workflow and a
+   package — each with its kind and version in the subtitle. Nothing says
+   "already here".
+3. Type `release` into the search field.
+   **Expected:** Only **Release kit** remains. Clear it again.
+4. Set the kind filter to **Agent**.
+   **Expected:** Only `changelog-writer`. Set it back to **Everything**.
+5. Click **Release kit**, then **Import**.
+   **Expected:** The entry screen comes back with a report under it:
+   `3 imported`, one line each for the LLM config, the agent and the workflow,
+   in that order — the config before the agent that requires it.
+6. http://localhost:9091/admin/agents and http://localhost:9091/admin/llm-configs
+   and http://localhost:9091/workflow-admin.
+   **Expected:** `changelog-writer` is in the agent list with the prompt from
+   the file, `example-default` is in the LLM configs with its API key showing
+   the `${ANTHROPIC_API_KEY}` placeholder rather than a key, and `greeting` is
+   in the workflow list.
+7. Open the agent `changelog-writer` and change its description to `mine`. Save.
+   Back to the registry, **Release kit**, **Import** again.
+   **Expected:** `3 skipped` — every line says something of that name is already
+   here. The agent's description is still `mine`.
+8. Same screen, **Import and overwrite**, confirm.
+   **Expected:** `3 updated`. The agent's description is back to the registry's,
+   and its id in the URL is **unchanged** from step 7 — an overwrite keeps the
+   local id.
+9. Back on the entry list, one entry at a time: the rows now read
+   "already here".
+
+## Cleanup
+
+- Delete the agent `changelog-writer`, the LLM config `example-default` and the
+  workflow `greeting`.
+- Remove the registry from http://localhost:9091/registry.
+
+## Notes
+
+- The import fetches over the network; the index and the files are cached for
+  ten minutes. **Refresh** on the registry screen drops that cache — use it
+  after pushing a change to the registry repository mid-test.
+- A private registry needs **Token variable** set to the *name* of an
+  environment variable holding a GitHub token, and that variable set in the
+  server's environment.

--- a/agents/doc/manual-tests/registry/unreachable-registry.md
+++ b/agents/doc/manual-tests/registry/unreachable-registry.md
@@ -1,0 +1,49 @@
+---
+id: registry-unreachable
+area: registry
+requires: [server-9091]
+duration: ~4 min
+last-verified: never
+---
+
+# A registry that cannot be read says why, and costs nothing else
+
+**Goal:** A wrong repository, a wrong ref or a missing token produces a readable
+screen with a way out — and leaves the other registries, and everything already
+imported, alone.
+
+## Preconditions
+
+- Admin UI running at http://localhost:9091 (otherwise: SKIPPED)
+
+## Steps
+
+1. http://localhost:9091/registry → **Add registry**, **Repository**
+   `mindconnect-ai/this-does-not-exist`, **Save**, then open the row.
+   **Expected:** A screen headed with the registry's name saying it cannot read
+   `mindconnect-ai/this-does-not-exist@main`, naming the missing file and
+   mentioning that a private repository needs a token. Three buttons: **Try
+   again**, **Edit registry**, **All registries**. No stack trace.
+2. Click **Edit registry**, set **Branch, tag or commit** to `no-such-ref`,
+   **Save**, open the row again.
+   **Expected:** The same screen, now naming `@no-such-ref`.
+3. Type `owner` (no slash) into a new registry's **Repository** field and save.
+   **Expected:** The form comes back with everything typed still in it and a
+   message that this is not a registry — expected `owner/repo[@ref][:index-path]`.
+4. Add a registry pointing at a repository that exists but has no index, e.g.
+   `mindconnect-ai/mindconnect`, and open it.
+   **Expected:** Cannot read … `registry.json`. The other registries in the list
+   are unaffected.
+5. Go to http://localhost:9091/admin/agents.
+   **Expected:** Unchanged — a registry that cannot be read imports nothing and
+   breaks nothing.
+
+## Cleanup
+
+- Remove every registry added above.
+
+## Notes
+
+- Step 1's message differs by one clause depending on whether the repository is
+  private or absent: GitHub answers 404 for both, on purpose, and the screen
+  says so rather than guessing.

--- a/agents/doc/registry-example/README.md
+++ b/agents/doc/registry-example/README.md
@@ -1,0 +1,25 @@
+# Example registry
+
+A registry is a GitHub project: an index (`registry.json`) and the entity files
+it points at. This directory is a working one, small enough to read in a minute.
+
+```
+registry.json                     the index — everything on offer
+llm-configs/example-default.json  an LLM config, keyed from ${ANTHROPIC_API_KEY}
+agents/changelog-writer.json      an agent, requiring the config above
+workflows/greeting.json           a workflow, exactly as the store writes it
+packages/release-kit.json         a package: all three, installed together
+```
+
+## Trying it
+
+1. Push this directory to the root of a repository of your own.
+2. In the admin UI, open **Registry → Add registry** and type `owner/repo`.
+3. Open it, and import `Release kit`.
+
+Three entities arrive: the LLM config first (the agent requires it), then the
+agent and the workflow. Nothing runs; the changelog writer is in your agent list
+and the workflow in the workflow admin.
+
+The format is documented at
+[website/docs/agents/registry.md](../../../website/docs/agents/registry.md).

--- a/agents/doc/registry-example/agents/changelog-writer.json
+++ b/agents/doc/registry-example/agents/changelog-writer.json
@@ -1,0 +1,15 @@
+{
+  "name": "changelog-writer",
+  "description": "Turns a list of commits into a changelog entry a reader can decide on.",
+  "group": "assistants",
+  "icon": "pencil",
+  "systemPrompt": "You write changelog entries.\n\nThe reader is deciding whether to upgrade. Write for them: what changed for someone using the software, in one line per change, in plain English. Leave out refactorings, test changes and build plumbing — the releases page already has the commit log.\n\nGiven a list of commits, answer with the lines only, no preamble.",
+  "welcomeMessage": "Paste a list of commits and I will write the changelog entry.",
+  "llmConfigName": "example-default",
+  "maxIterations": 5,
+  "memoryConfig": {
+    "kind": "none"
+  },
+  "status": "ACTIVE",
+  "tools": []
+}

--- a/agents/doc/registry-example/llm-configs/example-default.json
+++ b/agents/doc/registry-example/llm-configs/example-default.json
@@ -1,0 +1,11 @@
+{
+  "name": "example-default",
+  "provider": "ANTHROPIC",
+  "model": "claude-sonnet-5",
+  "baseUrl": "https://api.anthropic.com",
+  "apiKey": "${ANTHROPIC_API_KEY}",
+  "defaultTemperature": 0.7,
+  "maxOutputTokens": 8192,
+  "contextWindowTokens": 200000,
+  "capabilities": ["TOOL_CALLING", "VISION", "DOCUMENTS"]
+}

--- a/agents/doc/registry-example/packages/release-kit.json
+++ b/agents/doc/registry-example/packages/release-kit.json
@@ -1,0 +1,7 @@
+{
+  "name": "Release kit",
+  "description": "The changelog writer, the workflow it runs, and the model they share.",
+  "version": "1.0.0",
+  "includes": ["example-llm", "changelog-writer", "greeting"],
+  "items": []
+}

--- a/agents/doc/registry-example/registry.json
+++ b/agents/doc/registry-example/registry.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "name": "Example registry",
+  "description": "A worked example of the registry layout — copy this directory into a GitHub repository of your own and add it under Registry in the admin UI.",
+  "entries": [
+    {
+      "id": "example-llm",
+      "type": "llm-config",
+      "name": "example-default",
+      "description": "Claude Sonnet, keyed from the installation's own environment",
+      "version": "1.0.0",
+      "path": "llm-configs/example-default.json",
+      "tags": ["anthropic"],
+      "author": "mindconnect"
+    },
+    {
+      "id": "changelog-writer",
+      "type": "agent",
+      "name": "changelog-writer",
+      "description": "Turns a list of commits into a changelog entry a reader can decide on",
+      "version": "1.0.0",
+      "path": "agents/changelog-writer.json",
+      "tags": ["writing", "release"],
+      "author": "mindconnect",
+      "requires": ["example-llm"]
+    },
+    {
+      "id": "greeting",
+      "type": "workflow",
+      "name": "greeting",
+      "description": "A one-step workflow, here to show the file layout",
+      "version": "1.0.0",
+      "path": "workflows/greeting.json",
+      "author": "mindconnect"
+    },
+    {
+      "id": "release-kit",
+      "type": "package",
+      "name": "Release kit",
+      "description": "The changelog writer, the workflow it runs, and the model they share",
+      "version": "1.0.0",
+      "path": "packages/release-kit.json",
+      "author": "mindconnect"
+    }
+  ]
+}

--- a/agents/doc/registry-example/workflows/greeting.json
+++ b/agents/doc/registry-example/workflows/greeting.json
@@ -1,0 +1,17 @@
+{
+  "@class" : "ai.mindconnect.workflow.domain.WorkflowData",
+  "name" : "greeting",
+  "resultFrom" : "greeting",
+  "steps" : [ {
+    "@class" : "ai.mindconnect.workflow.domain.AssignVariablesData",
+    "name" : "greet",
+    "assignResultToVar" : "greeting",
+    "variableAssignments" : [ {
+      "varName" : "greeting",
+      "expressionOrVarName" : "Hello ${name}!"
+    } ],
+    "type" : "assignvariables"
+  } ],
+  "params" : [ "name" ],
+  "subWorkflows" : [ ]
+}

--- a/agents/mc-agents-parent/pom.xml
+++ b/agents/mc-agents-parent/pom.xml
@@ -213,6 +213,21 @@
             </dependency>
             <dependency>
                 <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-agent-registry-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-agent-registry</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
+                <artifactId>mc-agent-registry-admin-ui-rest</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.mindconnect</groupId>
                 <artifactId>mc-mcp-proxy</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/agents/pom.xml
+++ b/agents/pom.xml
@@ -63,6 +63,8 @@
         <module>core/mc-agent-tools-web</module>
         <module>core/mc-agent-tools-web-browser</module>
         <module>core/mc-agent-tools-workflow</module>
+        <module>core/mc-agent-registry-core</module>
+        <module>core/mc-agent-registry</module>
         <module>mcp/mc-mcp-proxy</module>
         <module>mcp/mc-mcp-gateway-core</module>
         <module>mcp/mc-mcp-gateway-local</module>
@@ -73,6 +75,7 @@
         <module>server/mc-agent-api-responses-rest</module>
         <module>server/mc-agent-api-app</module>
         <module>server/mc-agent-chat-ui-rest</module>
+        <module>server/mc-agent-registry-admin-ui-rest</module>
         <module>server/mc-agent-admin-ui-rest</module>
         <module>server/mc-agent-admin-ui-app</module>
         <module>client/mc-agent-cli</module>

--- a/agents/server/mc-agent-admin-ui-app/pom.xml
+++ b/agents/server/mc-agent-admin-ui-app/pom.xml
@@ -72,6 +72,14 @@
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-registry-admin-ui-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
             <artifactId>mc-agent-tools-workflow</artifactId>
         </dependency>
         <dependency>

--- a/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/AdminSameUrlFilter.java
+++ b/agents/server/mc-agent-admin-ui-app/src/main/java/ai/mindconnect/adminui/AdminSameUrlFilter.java
@@ -21,7 +21,8 @@ import java.util.List;
  *       event bus then fetches the same URL as JSON.</li>
  *   <li>GET without HTML on a <em>legacy</em> section whose controller still
  *       lives under {@code /admin/api/**} → forward there server-side.</li>
- *   <li>Same-URL sections ({@code /workflow-admin}, {@code /admin/vector-stores})
+ *   <li>Same-URL sections ({@code /workflow-admin}, {@code /admin/vector-stores},
+ *       {@code /registry})
  *       serve JSON on the page URL directly — new sections should follow that
  *       pattern; the legacy list below shrinks as controllers migrate.</li>
  * </ul>
@@ -32,7 +33,7 @@ public class AdminSameUrlFilter extends org.springframework.web.filter.OncePerRe
 
     /** Sections whose controllers already serve JSON on the page URL. */
     private static final List<String> SAME_URL_SECTIONS = List.of(
-            "/workflow-admin", "/admin/vector-stores", "/mcp-gateway");
+            "/workflow-admin", "/admin/vector-stores", "/mcp-gateway", "/registry");
 
     /** Sections whose controllers still live under /admin/api/<section>. */
     private static final List<String> LEGACY_SECTIONS = List.of(

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/registries/mindconnect-ai-mc-registry.json
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/registries/mindconnect-ai-mc-registry.json
@@ -1,0 +1,8 @@
+{
+  "name": "Mindconnect registry",
+  "owner": "mindconnect-ai",
+  "repo": "mc-registry",
+  "ref": "main",
+  "indexPath": "registry.json",
+  "enabled": true
+}

--- a/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/AdminLayoutReachesEveryScreenTest.java
+++ b/agents/server/mc-agent-admin-ui-app/src/test/java/ai/mindconnect/adminui/AdminLayoutReachesEveryScreenTest.java
@@ -2,6 +2,7 @@ package ai.mindconnect.adminui;
 
 import ai.mindconnect.adminui.ui.AdminLayoutAdvice;
 import ai.mindconnect.adminui.ui.controller.AgentUiController;
+import ai.mindconnect.agent.registry.admin.ui.RegistryUiController;
 import ai.mindconnect.mcp.gateway.admin.ui.McpGatewayUiController;
 import ai.mindconnect.workflow.admin.ui.WorkflowAdminUiController;
 import org.junit.jupiter.api.Test;
@@ -39,5 +40,6 @@ class AdminLayoutReachesEveryScreenTest {
     void the_other_embedded_screens_keep_it_too() {
         assertThat(WRAPPED.test(AgentUiController.class)).as("admin UI").isTrue();
         assertThat(WRAPPED.test(WorkflowAdminUiController.class)).as("workflow admin").isTrue();
+        assertThat(WRAPPED.test(RegistryUiController.class)).as("registry").isTrue();
     }
 }

--- a/agents/server/mc-agent-admin-ui-rest/pom.xml
+++ b/agents/server/mc-agent-admin-ui-rest/pom.xml
@@ -86,6 +86,10 @@
         </dependency>
         <dependency>
             <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-registry-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
             <artifactId>mc-initial-data</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
@@ -33,6 +33,8 @@ public final class AdminLayout {
     private final UiPage.ActiveStream taskStream;
     /** Whether this host has an MCP gateway to administer; false hides its entry. */
     private final boolean mcpGateway;
+    /** Whether this host can browse registries — same idea as {@link #mcpGateway}. */
+    private final boolean registry;
 
     /**
      * @param userName    display name of the current user (e.g. {@code "mc_user"})
@@ -66,12 +68,25 @@ public final class AdminLayout {
      */
     public AdminLayout(String userName, boolean authEnabled, String versionLabel,
                        UiNode taskBadge, UiPage.ActiveStream taskStream, boolean mcpGateway) {
+        this(userName, authEnabled, versionLabel, taskBadge, taskStream, mcpGateway, false);
+    }
+
+    /**
+     * @param registry whether this host can browse registries. Conditional for
+     *                 the same reason as {@code mcpGateway}: the screen is
+     *                 contributed by a module, and a nav item to a route
+     *                 nobody serves is a 404 with a label.
+     */
+    public AdminLayout(String userName, boolean authEnabled, String versionLabel,
+                       UiNode taskBadge, UiPage.ActiveStream taskStream, boolean mcpGateway,
+                       boolean registry) {
         this.userName = userName;
         this.authEnabled = authEnabled;
         this.versionLabel = versionLabel;
         this.taskBadge = taskBadge;
         this.taskStream = taskStream;
         this.mcpGateway = mcpGateway;
+        this.registry = registry;
     }
 
     /**
@@ -153,6 +168,9 @@ public final class AdminLayout {
             menu.item(navItem("nav-mcp", "MCP Servers", "/mcp-gateway", "plug", navigate));
         }
         menu.item(navItem("nav-vector-stores", "Vector Stores", "/admin/vector-stores", "database", navigate));
+        if (registry) {
+            menu.item(navItem("nav-registry", "Registry", "/registry", "download", navigate));
+        }
         menu.item(navItem("nav-migrations", "Migrations", "/admin/migrations", "refresh", navigate));
         menu.item(navItem("nav-api", "API", "/admin/api-explorer", "code", navigate));
         // The build's version as the last entry, pushed to the bottom by the

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayout.java
@@ -169,7 +169,7 @@ public final class AdminLayout {
         }
         menu.item(navItem("nav-vector-stores", "Vector Stores", "/admin/vector-stores", "database", navigate));
         if (registry) {
-            menu.item(navItem("nav-registry", "Registry", "/registry", "download", navigate));
+            menu.item(navItem("nav-registry", "Registry", "/registry", "package", navigate));
         }
         menu.item(navItem("nav-migrations", "Migrations", "/admin/migrations", "refresh", navigate));
         menu.item(navItem("nav-api", "API", "/admin/api-explorer", "code", navigate));

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutAdvice.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutAdvice.java
@@ -28,7 +28,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
  */
 @ControllerAdvice(basePackages = {"ai.mindconnect.adminui.ui.controller",
         "ai.mindconnect.chatui.ui.controller", "ai.mindconnect.workflow.admin",
-        "ai.mindconnect.mcp.gateway.admin.ui"})
+        "ai.mindconnect.mcp.gateway.admin.ui", "ai.mindconnect.agent.registry.admin.ui"})
 public class AdminLayoutAdvice implements ResponseBodyAdvice<Object> {
 
     /** Root-node id used by {@link AdminLayout#withLayout}; marks a wrapped page. */

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/AdminLayoutFactory.java
@@ -3,6 +3,7 @@ package ai.mindconnect.adminui.ui;
 import ai.mindconnect.adminui.service.TaskMonitor;
 import ai.mindconnect.adminui.service.UserStream;
 import ai.mindconnect.adminui.ui.component.TaskMonitorComponent;
+import ai.mindconnect.agent.registry.service.RegistryService;
 import ai.mindconnect.mcp.gateway.McpRegistryAdmin;
 import ai.mindconnect.ui.model.UiPage;
 import org.springframework.beans.factory.ObjectProvider;
@@ -36,15 +37,19 @@ public class AdminLayoutFactory {
      * that can see it.
      */
     private final ObjectProvider<McpRegistryAdmin> mcpRegistryAdmin;
+    /** Present when this host has registries to browse — same shape as the two above. */
+    private final ObjectProvider<RegistryService> registryService;
 
     public AdminLayoutFactory(@Value("${mindconnect.auth.enabled:false}") boolean authEnabled,
                               BuildInfo buildInfo,
                               Optional<TaskMonitor> taskMonitor,
-                              ObjectProvider<McpRegistryAdmin> mcpRegistryAdmin) {
+                              ObjectProvider<McpRegistryAdmin> mcpRegistryAdmin,
+                              ObjectProvider<RegistryService> registryService) {
         this.authEnabled = authEnabled;
         this.buildInfo = buildInfo;
         this.taskMonitor = taskMonitor.orElse(null);
         this.mcpRegistryAdmin = mcpRegistryAdmin;
+        this.registryService = registryService;
     }
 
     /**
@@ -57,7 +62,8 @@ public class AdminLayoutFactory {
                 taskMonitor == null ? null : TaskMonitorComponent.badge(taskMonitor.counts()),
                 UiPage.ActiveStream.of(UserStream.CHANNEL_ID, UserStream.STREAM_URL,
                         "Live updates", "/admin/agents"),
-                mcpRegistryAdmin.getIfAvailable() != null);
+                mcpRegistryAdmin.getIfAvailable() != null,
+                registryService.getIfAvailable() != null);
     }
 
     private String currentUserName() {

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/app.css
@@ -530,19 +530,70 @@ body {
 }
 .llm-test-result--err .llm-test-body { color: var(--sui-color-danger); }
 
-/* ── Grouped catalogs: tools, agents ───────────────────────────────────────
-   The collapsed summary line is the primary reading surface here — it is the
-   group heading, not a detail toggle — so the framework default (12px, subtle
-   gray, meant for background activity) is too quiet for it. */
-.tool-catalog .sui-activity-summary,
-#agent-list .sui-activity-summary {
+/* ── Collapsible summaries ─────────────────────────────────────────────────
+   The framework styles a collapsible's summary as a quiet detail toggle (12px,
+   subtle gray, meant for background activity). In this app the summary is
+   nearly always what you read — a catalog's group heading, a migration row, a
+   trace card — so every one reads at body size in the theme's own ink. */
+.sui-activity-summary {
     font-size: var(--sui-text-md, 14px);
+    font-weight: 500;
     color: var(--sui-color-text);
     padding: 6px 0;
 }
-/* The nested per-group list needs no header block of its own. */
+
+/* ── Grouped catalogs: tools, agents, registry entries ─────────────────────
+   The nested per-group list needs no header block of its own. */
 .tool-catalog .sui-activity-body .sui-list-header,
-#agent-list .sui-activity-body .sui-list-header { display: none; }
+#agent-list .sui-activity-body .sui-list-header,
+.registry-catalog .sui-activity-body .sui-list-header { display: none; }
+
+/* A package's Contents tab: what importing each entry would do here. An entry
+   that is already here is the one to look at twice — Import and overwrite
+   replaces it — so it takes the warning ink; a new one stays quiet. */
+.registry-member-state { font-size: var(--sui-text-sm, 13px); font-weight: 500; }
+.registry-member-state--present { color: var(--sui-color-warning, #d97706); }
+.registry-member-state--new { color: var(--sui-color-success, #16a34a); }
+.registry-member-state--unavailable { color: var(--sui-color-text-subtle); }
+.registry-member-desc { font-size: var(--sui-text-sm, 13px); color: var(--sui-color-text-subtle); }
+.registry-member-used-by { font-size: var(--sui-text-sm, 13px); color: var(--sui-color-text); }
+.registry-package-legend {
+    display: block;
+    margin: 4px 0 12px;
+    font-size: var(--sui-text-sm, 13px);
+    color: var(--sui-color-text-subtle);
+}
+/* The Import box sits in the row's top right corner, on the line of the name.
+   It lives in the row body rather than in the label (the label is the link to
+   the entry), so the row becomes a two-column grid: the body's own layout is
+   dissolved and its parts placed — the box beside the name, the state and the
+   description under both. A long name wraps in its column instead of running
+   under the box. */
+/* Full row width at every level — the rubric and the row in it — and no empty
+   actions column, so every box lines up on the same right edge. */
+.registry-catalog .sui-list-item-main { flex: 1 1 auto; min-width: 0; }
+.registry-catalog .sui-list-item-actions:empty { display: none; }
+.sui-list-item-main:has(> .registry-member-body) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: 12px;
+    align-items: start;
+}
+.sui-list-item-main:has(> .registry-member-body) > .sui-list-item-label { grid-column: 1; grid-row: 1; }
+.registry-member-body { display: contents; }
+.registry-member-body > * { grid-column: 1 / -1; }
+.registry-member-body > .registry-member-include { grid-column: 2; grid-row: 1; justify-self: end; }
+.registry-member-include .sui-field {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+}
+.registry-member-include .sui-field label {
+    margin: 0;
+    font-size: var(--sui-text-sm, 13px);
+    color: var(--sui-color-text-subtle);
+}
 
 /* ── Theme picker ─────────────────────────────────────────────────────────
    Injected into the header by js/theme-switch.js in the framework's own

--- a/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/workflow-admin.css
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/resources/static/css/workflow-admin.css
@@ -357,16 +357,3 @@
   word-break: break-word;
   max-width: 40vw;
 }
-
-/* Every row in the migration list is a collapsible; its summary is the row.
-   The framework's muted 12px summary style is fine for secondary detail
-   toggles, but here it IS the content — make it read like a list entry. */
-#migration-list .sui-activity-summary,
-#agent-list .sui-activity-summary,
-.tool-catalog .sui-activity-summary {
-  font-size: var(--sui-text-md);
-  font-weight: 500;
-  /* The theme's own ink, not a literal: a hard-coded slate was invisible
-     on the dark themes' surfaces. */
-  color: var(--sui-color-text);
-}

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/AdminLayoutRegistryNavTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/AdminLayoutRegistryNavTest.java
@@ -1,0 +1,48 @@
+package ai.mindconnect.adminui.ui;
+
+import ai.mindconnect.ui.model.UiPage;
+import ai.mindconnect.ui.model.UiStack;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The registry screen is contributed by a module and only wired when the host
+ * has a registry service. Its nav entry follows the same condition — the
+ * sidebar must not offer a route nobody serves.
+ */
+class AdminLayoutRegistryNavTest {
+
+    private static String menuJson(boolean registry) throws Exception {
+        AdminLayout layout = new AdminLayout("mc_user", false, "0.8.2", null, null, false, registry);
+        UiPage page = UiPage.of("/admin/agents", UiStack.of("body"));
+        return new ObjectMapper().writeValueAsString(layout.withLayout(page));
+    }
+
+    @Test
+    void with_a_registry_service_the_entry_is_there() throws Exception {
+        String json = menuJson(true);
+
+        assertThat(json).contains("nav-registry");
+        assertThat(json).contains("/registry");
+    }
+
+    @Test
+    void without_one_the_entry_stays_away_and_the_rest_of_the_menu_is_untouched() throws Exception {
+        String json = menuJson(false);
+
+        assertThat(json).doesNotContain("nav-registry");
+        assertThat(json).contains("nav-tools");
+        assertThat(json).contains("nav-workflows");
+    }
+
+    @Test
+    void the_older_constructor_leaves_the_entry_away() throws Exception {
+        AdminLayout layout = new AdminLayout("mc_user", false, "0.8.2", null, null, true);
+        UiPage page = UiPage.of("/admin/agents", UiStack.of("body"));
+
+        assertThat(new ObjectMapper().writeValueAsString(layout.withLayout(page)))
+                .doesNotContain("nav-registry");
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/pom.xml
+++ b/agents/server/mc-agent-registry-admin-ui-rest/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.mindconnect</groupId>
+        <artifactId>mc-agents-parent</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../../mc-agents-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mc-agent-registry-admin-ui-rest</artifactId>
+    <name>mc-agent-registry-admin-ui-rest</name>
+    <packaging>jar</packaging>
+    <description>
+        The registry's own screen, under /registry: the registries this
+        installation knows, what each of them offers, and the import. Embeds
+        itself into a host application through Spring Boot autoconfiguration,
+        the way the MCP gateway screen and the workflow admin do. Talks to the
+        service only, so it works with any client and any set of installers.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-agent-registry-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ai.mindconnect</groupId>
+            <artifactId>mc-semantic-ui-core</artifactId>
+            <version>${semantic-ui.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryAdminAutoConfiguration.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryAdminAutoConfiguration.java
@@ -1,0 +1,30 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.service.RegistryService;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Adds the registry screen to a host application that has a registry service.
+ * Without one there is nothing to browse, and the screen stays away rather
+ * than rendering an empty shell.
+ *
+ * <p>The ordering hint names the adapter module's configuration by string:
+ * {@code @ConditionalOnBean} only sees what has been registered by the time it
+ * runs, and this module must not depend on any particular implementation to
+ * say so.
+ */
+@AutoConfiguration
+@AutoConfigureAfter(name = "ai.mindconnect.agent.registry.spring.RegistryAutoConfiguration")
+public class RegistryAdminAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(RegistryService.class)
+    @ConditionalOnMissingBean
+    public RegistryUiController registryUiController(RegistryService registry) {
+        return new RegistryUiController(registry);
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryBrowseView.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryBrowseView.java
@@ -1,0 +1,142 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.service.RegistryService;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiField;
+import ai.mindconnect.ui.model.UiForm;
+import ai.mindconnect.ui.model.UiList;
+import ai.mindconnect.ui.model.UiNode;
+import ai.mindconnect.ui.model.UiStack;
+import ai.mindconnect.ui.model.UiTrigger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * What one registry offers: search, filter by kind, and import.
+ *
+ * <p>Each row says what this installation would do with it — already here, or
+ * a kind this installation cannot install at all — because the alternative is
+ * an operator pressing Import and reading the answer afterwards.
+ */
+final class RegistryBrowseView {
+
+    static final String STACK_ID = "registry-browse-stack";
+    private static final String FORM_ID = "registry-browse-search";
+
+    private final RegistrySource source;
+    private final RegistryIndex index;
+    private final List<RegistryEntry> entries;
+    private final String query;
+    private final RegistryItemType type;
+    /** What the installation would do with an entry — the service answers, the view draws. */
+    private final Function<RegistryEntry, RegistryService.EntryStatus> status;
+
+    RegistryBrowseView(RegistrySource source, RegistryIndex index, List<RegistryEntry> entries,
+                       String query, RegistryItemType type,
+                       Function<RegistryEntry, RegistryService.EntryStatus> status) {
+        this.source = source;
+        this.index = index;
+        this.entries = entries;
+        this.query = query;
+        this.type = type;
+        this.status = status;
+    }
+
+    UiNode render() {
+        String base = RegistryListView.BASE + "/api/" + source.id().value();
+
+        UiForm search = UiForm.of(FORM_ID, null);
+        search.field(UiField.text("q", "", query)
+                .asEditable()
+                .icon("search")
+                .placeholder("Search " + title() + "…")
+                .onChange(UiTrigger.api("POST", base + "/search", FORM_ID)));
+        search.field(UiField.select("type", "", type == null ? "" : type.wireName(), typeOptions())
+                .asEditable()
+                .onChange(UiTrigger.api("POST", base + "/search", FORM_ID)));
+
+        UiList list = UiList.of("registry-entries", title()).icon("box");
+        list.headerExtra(search);
+        list.action(UiAction.secondary("refresh", "Refresh").icon("refresh")
+                .dispatch("POST", base + "/refresh"));
+        list.action(UiAction.secondary("back", "All registries").icon("back")
+                .dispatch("GET", RegistryListView.BASE + "/api"));
+
+        if (entries.isEmpty()) {
+            list.item(UiList.Item.of("none", index.entries().isEmpty()
+                            ? "This registry is empty"
+                            : "Nothing matches")
+                    .description(index.entries().isEmpty()
+                            ? "Its index lists no entries. "
+                                    + (source.repositoryUrl() != null
+                                            ? source.repositoryUrl() : source.coordinates())
+                            : "Try a shorter search term, or another kind."));
+            return UiStack.of(STACK_ID).child(list);
+        }
+
+        for (RegistryEntry entry : entries) {
+            RegistryService.EntryStatus entryStatus = status.apply(entry);
+            UiList.Item item = UiList.Item.of("entry-" + entry.id(), entry.name())
+                    .icon(iconFor(entry.type()))
+                    .description(describe(entry, entryStatus))
+                    .dispatch("GET", base + "/entry/" + entry.id());
+            if (entryStatus.installable()) {
+                item.action(UiAction.primary("import-" + entry.id(),
+                                entryStatus.present() ? "Re-import" : "Import")
+                        .icon("download")
+                        .dispatch("GET", base + "/entry/" + entry.id()));
+            }
+            list.item(item);
+        }
+        return UiStack.of(STACK_ID).child(list);
+    }
+
+    private String title() {
+        String registryName = index.name() != null && !index.name().isBlank()
+                ? index.name() : source.name();
+        return registryName + " — " + source.coordinates();
+    }
+
+    /** Kind, version, author — then what this installation would do with it. */
+    private static String describe(RegistryEntry entry, RegistryService.EntryStatus status) {
+        StringBuilder text = new StringBuilder(entry.subtitle());
+        if (!status.installable()) {
+            text.append(" · this installation cannot import this kind");
+        } else if (status.present()) {
+            text.append(" · already here");
+        }
+        if (entry.description() != null && !entry.description().isBlank()) {
+            String description = entry.description().strip();
+            if (description.length() > 180) {
+                description = description.substring(0, 180) + "…";
+            }
+            text.append(" · ").append(description);
+        }
+        return text.toString();
+    }
+
+    private static List<UiField.Option> typeOptions() {
+        List<UiField.Option> options = new ArrayList<>();
+        options.add(UiField.Option.of("", "Everything"));
+        for (RegistryItemType value : RegistryItemType.values()) {
+            options.add(UiField.Option.of(value.wireName(), value.label()));
+        }
+        return options;
+    }
+
+    /** A kind reads faster as a symbol than as a word repeated down a column. */
+    static String iconFor(RegistryItemType type) {
+        return switch (type) {
+            case LLM_CONFIG -> "ai";
+            case AGENT -> "bot";
+            case WORKFLOW -> "branch";
+            case PACKAGE -> "box";
+        };
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryBrowseView.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryBrowseView.java
@@ -14,11 +14,15 @@ import ai.mindconnect.ui.model.UiStack;
 import ai.mindconnect.ui.model.UiTrigger;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
- * What one registry offers: search, filter by kind, and import.
+ * What one registry offers: search, filter by kind, and import, with the
+ * entries filed under their kind the way the agent list files agents under
+ * their group.
  *
  * <p>Each row says what this installation would do with it — already here, or
  * a kind this installation cannot install at all — because the alternative is
@@ -28,6 +32,12 @@ final class RegistryBrowseView {
 
     static final String STACK_ID = "registry-browse-stack";
     private static final String FORM_ID = "registry-browse-search";
+    static final String CATALOG_CSS_CLASS = "registry-catalog";
+
+    /** The rubrics in the order they earn attention: what you chat with, what it runs on, then the rest. */
+    static final List<RegistryItemType> GROUP_ORDER = List.of(
+            RegistryItemType.AGENT, RegistryItemType.LLM_CONFIG,
+            RegistryItemType.WORKFLOW, RegistryItemType.PACKAGE);
 
     private final RegistrySource source;
     private final RegistryIndex index;
@@ -80,21 +90,71 @@ final class RegistryBrowseView {
             return UiStack.of(STACK_ID).child(list);
         }
 
-        for (RegistryEntry entry : entries) {
-            RegistryService.EntryStatus entryStatus = status.apply(entry);
-            UiList.Item item = UiList.Item.of("entry-" + entry.id(), entry.name())
-                    .icon(iconFor(entry.type()))
-                    .description(describe(entry, entryStatus))
-                    .dispatch("GET", base + "/entry/" + entry.id());
-            if (entryStatus.installable()) {
-                item.action(UiAction.primary("import-" + entry.id(),
-                                entryStatus.present() ? "Re-import" : "Import")
-                        .icon("download")
-                        .dispatch("GET", base + "/entry/" + entry.id()));
-            }
-            list.item(item);
-        }
+        // A search or a kind filter asks to see the matches, so their rubrics
+        // open; unfiltered, the rubrics are the map and start closed, like the
+        // agent list and the tool catalog.
+        boolean open = type != null || (query != null && !query.isBlank());
+        addGrouped(list, "registry-group-", entries, open, entry -> row(base, entry));
         return UiStack.of(STACK_ID).child(list);
+    }
+
+    private UiList.Item row(String base, RegistryEntry entry) {
+        RegistryService.EntryStatus entryStatus = status.apply(entry);
+        UiList.Item item = UiList.Item.of("entry-" + entry.id(), entry.name())
+                .icon(iconFor(entry.type()))
+                .description(describe(entry, entryStatus))
+                .dispatch("GET", base + "/entry/" + entry.id());
+        // Both open the entry, where the warning and the confirmation sit; the
+        // label says what the import would do to this installation.
+        if (entryStatus.installable() && entryStatus.present()) {
+            item.action(UiAction.danger("overwrite-" + entry.id(), "Overwrite")
+                    .icon("refresh")
+                    .dispatch("GET", base + "/entry/" + entry.id()));
+        } else if (entryStatus.installable()) {
+            item.action(UiAction.primary("import-" + entry.id(), "Import")
+                    .icon("download")
+                    .dispatch("GET", base + "/entry/" + entry.id()));
+        }
+        return item;
+    }
+
+    /**
+     * Files {@code entries} into {@code list} as one collapsible rubric per kind,
+     * in {@link #GROUP_ORDER}; within a kind they keep the order they came in.
+     * A kind with no entries gets no rubric.
+     */
+    static void addGrouped(UiList list, String idPrefix, List<RegistryEntry> entries, boolean open,
+                           Function<RegistryEntry, UiList.Item> row) {
+        // The admin UI's stylesheet gives grouped catalogs readable rubric
+        // headings; the framework's summary style is a quiet detail toggle.
+        list.withCssClass(CATALOG_CSS_CLASS);
+        Map<RegistryItemType, List<RegistryEntry>> byType = new LinkedHashMap<>();
+        for (RegistryItemType kind : GROUP_ORDER) {
+            List<RegistryEntry> ofKind = entries.stream().filter(e -> e.type() == kind).toList();
+            if (!ofKind.isEmpty()) {
+                byType.put(kind, ofKind);
+            }
+        }
+        for (Map.Entry<RegistryItemType, List<RegistryEntry>> group : byType.entrySet()) {
+            String gid = idPrefix + group.getKey().wireName();
+            UiList groupList = UiList.of(gid + "-list", "");
+            group.getValue().forEach(entry -> groupList.item(row.apply(entry)));
+            // The empty label keeps the kind from being repeated inside the
+            // rubric it already titles.
+            list.item(UiList.Item.of(gid, "")
+                    .content(groupList)
+                    .collapsible(groupTitle(group.getKey()) + "  (" + group.getValue().size() + ")",
+                            open, gid + "-sum"));
+        }
+    }
+
+    static String groupTitle(RegistryItemType type) {
+        return switch (type) {
+            case AGENT -> "Agents";
+            case LLM_CONFIG -> "LLM configs";
+            case WORKFLOW -> "Workflows";
+            case PACKAGE -> "Packages";
+        };
     }
 
     private String title() {
@@ -111,14 +171,19 @@ final class RegistryBrowseView {
         } else if (status.present()) {
             text.append(" · already here");
         }
-        if (entry.description() != null && !entry.description().isBlank()) {
-            String description = entry.description().strip();
-            if (description.length() > 180) {
-                description = description.substring(0, 180) + "…";
-            }
-            text.append(" · ").append(description);
+        return text.append(shortDescription(entry)).toString();
+    }
+
+    /** {@code " · "} and the description cut to a line or two, or nothing without one. */
+    static String shortDescription(RegistryEntry entry) {
+        if (entry.description() == null || entry.description().isBlank()) {
+            return "";
         }
-        return text.toString();
+        String description = entry.description().strip();
+        if (description.length() > 180) {
+            description = description.substring(0, 180) + "…";
+        }
+        return " · " + description;
     }
 
     private static List<UiField.Option> typeOptions() {

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryEntryView.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryEntryView.java
@@ -3,16 +3,27 @@ package ai.mindconnect.agent.registry.admin.ui;
 import ai.mindconnect.agent.registry.domain.ImportReport;
 import ai.mindconnect.agent.registry.domain.ImportedItem;
 import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
 import ai.mindconnect.agent.registry.domain.RegistrySource;
 import ai.mindconnect.agent.registry.service.RegistryService;
 import ai.mindconnect.ui.model.UiAction;
 import ai.mindconnect.ui.model.UiDetail;
 import ai.mindconnect.ui.model.UiField;
+import ai.mindconnect.ui.model.UiList;
 import ai.mindconnect.ui.model.UiNode;
+import ai.mindconnect.ui.model.UiSection;
 import ai.mindconnect.ui.model.UiStack;
 import ai.mindconnect.ui.model.UiText;
+import ai.mindconnect.ui.model.UiTrigger;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 /**
  * One entry, and the decision: what it is, what it drags in, what it would do
@@ -22,30 +33,236 @@ import java.util.Locale;
  * agent is a system prompt and a tool list that somebody else wrote, and it
  * runs on this installation's models with this installation's tools. That is
  * worth one sentence before the click, not a line in a log after it.
+ *
+ * <p>A package is two tabs, like an agent's detail page: its details, and the
+ * entries it installs, filed under their kinds the way the registry lists
+ * them. The import buttons then sit in the bar above the tabs, so they are
+ * there whichever tab is open.
  */
 final class RegistryEntryView {
 
     static final String STACK_ID = "registry-entry-stack";
+    /** The Contents tab's container — its checkboxes are what the import buttons send. */
+    static final String SELECTION_ID = "registry-package-selection";
+    /** Checkbox name prefix; the rest of the name is the entry id. */
+    static final String INCLUDE_PREFIX = "include-";
+    /** How many users a "used by" line names before it counts the rest. */
+    private static final int USED_BY_SHOWN = 3;
 
     private final RegistrySource source;
+    private final RegistryIndex index;
     private final RegistryEntry entry;
-    private final RegistryService.EntryStatus status;
+    /** What the installation would do with an entry — this one, or a package's member. */
+    private final Function<RegistryEntry, RegistryService.EntryStatus> status;
+    /** What a package's import installs; null for any other kind, or when it could not be read. */
+    private final RegistryService.PackageContents contents;
+    /** Why a package's contents could not be read. */
+    private final String contentsError;
+    /**
+     * Entry ids unticked in the last import or removal, so a re-rendered tab
+     * keeps the choice; {@code null} when nobody has chosen yet, and then what
+     * something outside the package uses starts unticked.
+     */
+    private final Set<String> excluded;
     /** Set once an import has run — what happened, member by member. */
     private final ImportReport report;
     private final String error;
 
-    RegistryEntryView(RegistrySource source, RegistryEntry entry,
-                      RegistryService.EntryStatus status, ImportReport report, String error) {
+    RegistryEntryView(RegistrySource source, RegistryIndex index, RegistryEntry entry,
+                      Function<RegistryEntry, RegistryService.EntryStatus> status,
+                      RegistryService.PackageContents contents, String contentsError,
+                      Set<String> excluded, ImportReport report, String error) {
         this.source = source;
+        this.index = index;
         this.entry = entry;
         this.status = status;
+        this.contents = contents;
+        this.contentsError = contentsError;
+        this.excluded = excluded == null ? null : Set.copyOf(excluded);
         this.report = report;
         this.error = error;
     }
 
     UiNode render() {
         String base = RegistryListView.BASE + "/api/" + source.id().value();
+        UiDetail detail = details();
+        List<UiAction> actions = actions(base);
 
+        UiStack stack = UiStack.of(STACK_ID);
+        stack.child(warning());
+        if (entry.type() == RegistryItemType.PACKAGE) {
+            // The section's own title is escaped text and cannot carry an icon;
+            // a header-only list draws the bar with one, as on the agent page.
+            UiList header = UiList.of("registry-entry-header", entry.name())
+                    .icon(RegistryBrowseView.iconFor(entry.type()));
+            actions.forEach(header::action);
+            stack.child(header);
+            stack.child(UiSection.of("registry-entry-tabs", null)
+                    .section("details", "Details", detail)
+                    .section("contents", contentsTitle(), contentsList(base)));
+        } else {
+            actions.forEach(detail::action);
+            stack.child(detail);
+        }
+        if (error != null) {
+            stack.child(note("registry-entry-error", "✗ " + error));
+        }
+        if (report != null) {
+            stack.child(reportNode());
+        }
+        return stack;
+    }
+
+    private String contentsTitle() {
+        return contents == null ? "Contents" : "Contents (" + contents.members().size() + ")";
+    }
+
+    /**
+     * Everything the package's import would install, by kind, each with
+     * whether it is already here and an Include checkbox. The container's id is
+     * the payload of the Import and Remove buttons, so the checkboxes travel
+     * with the click from either tab — a hidden tab stays in the page.
+     */
+    private UiStack contentsList(String base) {
+        UiList list = UiList.of("registry-package-contents", "");
+        UiStack selection = UiStack.of(SELECTION_ID);
+        if (contents != null && !contents.members().isEmpty()) {
+            selection.child(UiText.of("registry-package-legend",
+                            "Import installs the included entries that are new; Import and overwrite "
+                                    + "also replaces those already here; Remove deletes the included "
+                                    + "entries that are here. What is not included is left alone — and "
+                                    + "what something outside the package still uses starts not included.")
+                    .<UiText>withCssClass("registry-package-legend"));
+        }
+        selection.child(list);
+        if (contents == null) {
+            list.item(UiList.Item.of("contents-unreadable", "The package manifest could not be read")
+                    .description(contentsError != null ? contentsError : entry.path()));
+            return selection;
+        }
+        if (contents.members().isEmpty() && contents.unresolved().isEmpty()) {
+            list.item(UiList.Item.of("contents-empty", "The package lists nothing"));
+            return selection;
+        }
+        // A package is a handful of entries and this tab exists to show them,
+        // so the rubrics start open.
+        RegistryBrowseView.addGrouped(list, "registry-package-group-", contents.members(), true,
+                member -> member(base, member));
+        for (String missing : contents.unresolved()) {
+            list.item(UiList.Item.of("unresolved-" + missing, missing)
+                    .icon("warning")
+                    .description("Named by the package, but not in this registry's index — "
+                            + "an import skips it"));
+        }
+        return selection;
+    }
+
+    private UiList.Item member(String base, RegistryEntry member) {
+        UiList.Item item = UiList.Item.of("member-" + member.id(), member.name())
+                .icon(RegistryBrowseView.iconFor(member.type()));
+        // Members written into the manifest itself have no entry page to open.
+        if (index.find(member.id()).isPresent()) {
+            item.dispatch("GET", base + "/entry/" + member.id());
+        }
+        RegistryService.EntryStatus memberStatus = status.apply(member);
+        String state;
+        String stateClass;
+        if (!memberStatus.installable()) {
+            state = "This installation cannot import this kind";
+            stateClass = "registry-member-state registry-member-state--unavailable";
+        } else if (memberStatus.present()) {
+            state = "Already here";
+            stateClass = "registry-member-state registry-member-state--present";
+        } else {
+            state = "New";
+            stateClass = "registry-member-state registry-member-state--new";
+        }
+        List<String> usedBy = contents.usedBy(member.id());
+        UiStack body = UiStack.of("member-body-" + member.id())
+                .<UiStack>withCssClass("registry-member-body");
+        if (memberStatus.installable()) {
+            // Not inside the label: that is the link to the entry, and a click
+            // on the box would follow it. The stylesheet lifts the wrapper into
+            // the row's top right corner, beside the name.
+            boolean included = excluded == null ? usedBy.isEmpty() : !excluded.contains(member.id());
+            body.child(UiStack.of("member-include-" + member.id())
+                    .<UiStack>withCssClass("registry-member-include")
+                    .child(UiField.bool(INCLUDE_PREFIX + member.id(), "Include", included).asEditable()));
+        }
+        body.child(UiText.of("member-state-" + member.id(), state).<UiText>withCssClass(stateClass));
+        if (!usedBy.isEmpty()) {
+            body.child(UiText.of("member-used-by-" + member.id(), usedByLine(usedBy))
+                    .<UiText>withCssClass("registry-member-used-by"));
+        }
+        body.child(UiText.of("member-desc-" + member.id(),
+                        member.subtitle() + RegistryBrowseView.shortDescription(member))
+                .<UiText>withCssClass("registry-member-desc"));
+        return item.content(body);
+    }
+
+    /** "Used by Agent 'a', Agent 'b' and 14 more" — the first few, then a count. */
+    static String usedByLine(List<String> users) {
+        int shown = Math.min(users.size(), USED_BY_SHOWN);
+        String line = "Used by " + String.join(", ", users.subList(0, shown));
+        return users.size() > shown ? line + " and " + (users.size() - shown) + " more" : line;
+    }
+
+    /** The entry ids left unticked in a submitted Contents tab. */
+    static Set<String> excludedFrom(Map<String, Object> body) {
+        Set<String> excluded = new LinkedHashSet<>();
+        if (body == null) {
+            return excluded;
+        }
+        body.forEach((key, value) -> {
+            if (key.startsWith(INCLUDE_PREFIX) && Boolean.FALSE.equals(asBoolean(value))) {
+                excluded.add(key.substring(INCLUDE_PREFIX.length()));
+            }
+        });
+        return excluded;
+    }
+
+    /** A checkbox arrives as a boolean from the page and as text from a plain form post. */
+    private static Boolean asBoolean(Object value) {
+        if (value instanceof Boolean b) return b;
+        if (value == null) return null;
+        String text = value.toString().strip();
+        return text.equalsIgnoreCase("true") || text.equalsIgnoreCase("on") ? Boolean.TRUE
+                : text.equalsIgnoreCase("false") ? Boolean.FALSE : null;
+    }
+
+    private List<UiAction> actions(String base) {
+        List<UiAction> actions = new ArrayList<>();
+        RegistryService.EntryStatus entryStatus = status.apply(entry);
+        // A package's buttons carry the Contents tab's checkboxes along.
+        String payload = entry.type() == RegistryItemType.PACKAGE ? SELECTION_ID : null;
+        if (entryStatus.installable()) {
+            actions.add(UiAction.primary("import", entryStatus.present() ? "Import, keep mine" : "Import")
+                    .icon("download")
+                    .confirm(confirmation(entryStatus))
+                    .onClick(UiTrigger.api("POST",
+                            base + "/import/" + entry.id() + "?mode=SKIP_EXISTING", payload)));
+            actions.add(UiAction.danger("overwrite", "Import and overwrite")
+                    .icon("refresh")
+                    .confirm("Replace what is here with '" + entry.name() + "' from "
+                            + source.coordinates() + "? Entities of the same name are "
+                            + "overwritten, keeping their local ids.")
+                    .onClick(UiTrigger.api("POST",
+                            base + "/import/" + entry.id() + "?mode=OVERWRITE", payload)));
+        }
+        if (entry.type() == RegistryItemType.PACKAGE) {
+            actions.add(UiAction.danger("remove", "Remove")
+                    .icon("delete")
+                    .confirm("Delete the included entries of '" + entry.name() + "' from this "
+                            + "installation? Entries that are not included stay. Anything else "
+                            + "that uses a deleted agent, workflow or LLM config stops working.")
+                    .onClick(UiTrigger.api("POST", base + "/remove/" + entry.id(), payload)));
+        }
+        actions.add(UiAction.secondary("back", "Back to " + source.name()).icon("back")
+                .dispatch("GET", base));
+        return actions;
+    }
+
+    private UiDetail details() {
         UiDetail detail = UiDetail.of("registry-entry", entry.name())
                 .icon(RegistryBrowseView.iconFor(entry.type()));
         detail.field(UiField.text("type", "Kind", entry.type().label()));
@@ -72,40 +289,17 @@ final class RegistryEntryView {
             detail.field(UiField.text("homepage", "Homepage", entry.homepage()));
         }
 
-        if (!status.installable()) {
+        if (!status.apply(entry).installable()) {
             detail.field(UiField.text("state", "State",
                             "This installation cannot import " + entry.type().label().toLowerCase(Locale.ROOT) + "s")
                     .hint("No installer for this kind is wired in — the module that owns the "
                             + "entity contributes one."));
-        } else {
-            detail.action(UiAction.primary("import", status.present() ? "Import, keep mine" : "Import")
-                    .icon("download")
-                    .confirm(confirmation())
-                    .dispatch("POST", base + "/import/" + entry.id() + "?mode=SKIP_EXISTING"));
-            detail.action(UiAction.danger("overwrite", "Import and overwrite")
-                    .icon("refresh")
-                    .confirm("Replace what is here with '" + entry.name() + "' from "
-                            + source.coordinates() + "? Entities of the same name are "
-                            + "overwritten, keeping their local ids.")
-                    .dispatch("POST", base + "/import/" + entry.id() + "?mode=OVERWRITE"));
         }
-        detail.action(UiAction.secondary("back", "Back to " + source.name()).icon("back")
-                .dispatch("GET", base));
-
-        UiStack stack = UiStack.of(STACK_ID);
-        stack.child(warning());
-        stack.child(detail);
-        if (error != null) {
-            stack.child(note("registry-entry-error", "✗ " + error));
-        }
-        if (report != null) {
-            stack.child(reportNode());
-        }
-        return stack;
+        return detail;
     }
 
-    private String confirmation() {
-        return status.present()
+    private String confirmation(RegistryService.EntryStatus entryStatus) {
+        return entryStatus.present()
                 ? "Import '" + entry.name() + "' from " + source.coordinates()
                         + "? What is already here of the same name is kept."
                 : "Import '" + entry.name() + "' from " + source.coordinates() + "?";

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryEntryView.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryEntryView.java
@@ -1,0 +1,147 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.ImportReport;
+import ai.mindconnect.agent.registry.domain.ImportedItem;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.service.RegistryService;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiDetail;
+import ai.mindconnect.ui.model.UiField;
+import ai.mindconnect.ui.model.UiNode;
+import ai.mindconnect.ui.model.UiStack;
+import ai.mindconnect.ui.model.UiText;
+
+import java.util.Locale;
+
+/**
+ * One entry, and the decision: what it is, what it drags in, what it would do
+ * to what is already here — and, after an import, what it actually did.
+ *
+ * <p>The warning above the buttons is the point of the screen. An imported
+ * agent is a system prompt and a tool list that somebody else wrote, and it
+ * runs on this installation's models with this installation's tools. That is
+ * worth one sentence before the click, not a line in a log after it.
+ */
+final class RegistryEntryView {
+
+    static final String STACK_ID = "registry-entry-stack";
+
+    private final RegistrySource source;
+    private final RegistryEntry entry;
+    private final RegistryService.EntryStatus status;
+    /** Set once an import has run — what happened, member by member. */
+    private final ImportReport report;
+    private final String error;
+
+    RegistryEntryView(RegistrySource source, RegistryEntry entry,
+                      RegistryService.EntryStatus status, ImportReport report, String error) {
+        this.source = source;
+        this.entry = entry;
+        this.status = status;
+        this.report = report;
+        this.error = error;
+    }
+
+    UiNode render() {
+        String base = RegistryListView.BASE + "/api/" + source.id().value();
+
+        UiDetail detail = UiDetail.of("registry-entry", entry.name())
+                .icon(RegistryBrowseView.iconFor(entry.type()));
+        detail.field(UiField.text("type", "Kind", entry.type().label()));
+        if (entry.version() != null) {
+            detail.field(UiField.text("version", "Version", entry.version()));
+        }
+        if (entry.author() != null) {
+            detail.field(UiField.text("author", "Author", entry.author()));
+        }
+        if (entry.description() != null) {
+            detail.field(UiField.textarea("description", "Description", entry.description()));
+        }
+        if (!entry.tags().isEmpty()) {
+            detail.field(UiField.text("tags", "Tags", String.join(", ", entry.tags())));
+        }
+        if (!entry.requires().isEmpty()) {
+            detail.field(UiField.text("requires", "Also imports",
+                            String.join(", ", entry.requires()))
+                    .hint("Installed first, in this order."));
+        }
+        detail.field(UiField.text("origin", "From",
+                source.coordinates() + " · " + entry.path()));
+        if (entry.homepage() != null) {
+            detail.field(UiField.text("homepage", "Homepage", entry.homepage()));
+        }
+
+        if (!status.installable()) {
+            detail.field(UiField.text("state", "State",
+                            "This installation cannot import " + entry.type().label().toLowerCase(Locale.ROOT) + "s")
+                    .hint("No installer for this kind is wired in — the module that owns the "
+                            + "entity contributes one."));
+        } else {
+            detail.action(UiAction.primary("import", status.present() ? "Import, keep mine" : "Import")
+                    .icon("download")
+                    .confirm(confirmation())
+                    .dispatch("POST", base + "/import/" + entry.id() + "?mode=SKIP_EXISTING"));
+            detail.action(UiAction.danger("overwrite", "Import and overwrite")
+                    .icon("refresh")
+                    .confirm("Replace what is here with '" + entry.name() + "' from "
+                            + source.coordinates() + "? Entities of the same name are "
+                            + "overwritten, keeping their local ids.")
+                    .dispatch("POST", base + "/import/" + entry.id() + "?mode=OVERWRITE"));
+        }
+        detail.action(UiAction.secondary("back", "Back to " + source.name()).icon("back")
+                .dispatch("GET", base));
+
+        UiStack stack = UiStack.of(STACK_ID);
+        stack.child(warning());
+        stack.child(detail);
+        if (error != null) {
+            stack.child(note("registry-entry-error", "✗ " + error));
+        }
+        if (report != null) {
+            stack.child(reportNode());
+        }
+        return stack;
+    }
+
+    private String confirmation() {
+        return status.present()
+                ? "Import '" + entry.name() + "' from " + source.coordinates()
+                        + "? What is already here of the same name is kept."
+                : "Import '" + entry.name() + "' from " + source.coordinates() + "?";
+    }
+
+    /** What importing somebody else's repository means, above the buttons. */
+    private UiNode warning() {
+        String text = switch (entry.type()) {
+            case AGENT -> "An agent is a system prompt and a tool list somebody else wrote. "
+                    + "Imported, it runs on this installation's models with this installation's "
+                    + "tools. Read its prompt before you let it run.";
+            case WORKFLOW -> "A workflow is executable: its steps call tools, agents and scripts "
+                    + "on this installation. Read it before you run it.";
+            case LLM_CONFIG -> "An LLM config names a provider and a base URL — the address this "
+                    + "installation would send prompts to. An API key in the file is dropped on "
+                    + "import; set your own, or point the config at a ${ENV_VAR}.";
+            case PACKAGE -> "A package installs several entities at once — agents with their "
+                    + "prompts, workflows that run, the LLM configs they point at. Nothing is "
+                    + "run by importing it, but everything in it is here afterwards.";
+        };
+        String origin = source.repositoryUrl() != null ? source.repositoryUrl() : source.coordinates();
+        return note("registry-entry-warning", text + "\nFrom " + origin + ".");
+    }
+
+    private UiNode reportNode() {
+        StringBuilder text = new StringBuilder(report.ok() ? "✓ " : "⚠ ")
+                .append(report.summary());
+        for (ImportedItem item : report.items()) {
+            text.append('\n').append(item);
+        }
+        return note("registry-entry-report", text.toString());
+    }
+
+    private static UiNode note(String id, String text) {
+        return UiStack.of(id)
+                .<UiStack>withCssClass("llm-test-result")
+                .child(UiText.of(id + "-text", text).<UiText>withCssClass("llm-test-body"));
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryListView.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryListView.java
@@ -1,0 +1,70 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiList;
+
+import java.util.List;
+
+/**
+ * The registries this installation knows, one row each: what it is called,
+ * which repository and ref it reads, and whether it is switched on.
+ *
+ * <p>An installation starts with none. That is the honest default — a registry
+ * is somebody's repository of agents and prompts, and which ones to trust is
+ * not a decision this software can make on an operator's behalf.
+ */
+final class RegistryListView {
+
+    static final String BASE = "/registry";
+
+    private final List<RegistrySource> sources;
+
+    RegistryListView(List<RegistrySource> sources) {
+        this.sources = sources;
+    }
+
+    UiList render() {
+        UiList list = UiList.of("registry-list", "Registries")
+                .icon("box")
+                .action(UiAction.primary("add", "Add registry").icon("add")
+                        .dispatch("GET", BASE + "/api/new"));
+
+        if (sources.isEmpty()) {
+            list.item(UiList.Item.of("none", "No registry configured")
+                    .description("A registry is a GitHub project holding an index of LLM configs, "
+                            + "agents, workflows and packages. Add one by its owner/repo — "
+                            + "pin a tag for a registry you do not control."));
+            return list;
+        }
+
+        for (RegistrySource source : sources) {
+            list.item(UiList.Item.of(source.id().value(), source.name())
+                    .icon("box")
+                    .description(describe(source))
+                    .href(BASE + "/" + source.id().value())
+                    .action(UiAction.secondary("edit-" + source.id().value(), "Edit").icon("edit")
+                            .dispatch("GET", BASE + "/api/" + source.id().value() + "/edit"))
+                    .action(UiAction.danger("delete-" + source.id().value(), "Remove").icon("delete")
+                            .confirm("Remove the registry '" + source.name() + "'? "
+                                    + "What was imported from it stays.")
+                            .dispatch("DELETE", BASE + "/api/" + source.id().value())));
+        }
+        return list;
+    }
+
+    /** "owner/repo@main · registry.json · private (GH_TOKEN)" — or why it is not read. */
+    private static String describe(RegistrySource source) {
+        StringBuilder text = new StringBuilder(source.coordinates());
+        if (!RegistrySource.DEFAULT_INDEX_PATH.equals(source.indexPath())) {
+            text.append(" · ").append(source.indexPath());
+        }
+        if (source.tokenEnvVar() != null) {
+            text.append(" · private (").append(source.tokenEnvVar()).append(')');
+        }
+        if (!source.enabled()) {
+            text.append(" · disabled");
+        }
+        return text.toString();
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistrySourceDraft.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistrySourceDraft.java
@@ -1,0 +1,69 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+
+import java.util.Map;
+
+/**
+ * What the add/edit form holds — every field a string, because that is what a
+ * form posts back. Turning it into a {@link RegistrySource} happens in one
+ * place, so the form and the API agree on what an empty field means.
+ */
+record RegistrySourceDraft(
+        String id,
+        String name,
+        String repository,
+        String ref,
+        String indexPath,
+        String tokenEnvVar,
+        String baseUrl,
+        boolean enabled
+) {
+
+    static RegistrySourceDraft empty() {
+        return new RegistrySourceDraft(null, null, null, null, null, null, null, true);
+    }
+
+    static RegistrySourceDraft of(RegistrySource source) {
+        return new RegistrySourceDraft(source.id().value(), source.name(),
+                source.owner() + "/" + source.repo(), source.ref(), source.indexPath(),
+                source.tokenEnvVar(), source.baseUrl(), source.enabled());
+    }
+
+    /** The draft as a form posts it back. */
+    static RegistrySourceDraft fromForm(Map<String, Object> body) {
+        return new RegistrySourceDraft(
+                text(body.get("id")), text(body.get("name")), text(body.get("repository")),
+                text(body.get("ref")), text(body.get("indexPath")), text(body.get("tokenEnvVar")),
+                text(body.get("baseUrl")), bool(body.get("enabled")));
+    }
+
+    /**
+     * The source this draft describes, keeping the id and version of
+     * {@code existing} when there is one — an edit must not turn into a second
+     * registry, and the version check is what stops two edits from both
+     * winning.
+     *
+     * @throws IllegalArgumentException when the repository field names no repository
+     */
+    RegistrySource toSource(RegistrySource existing) {
+        RegistrySource parsed = RegistrySource.of(repository);
+        RegistrySourceId sourceId = existing != null ? existing.id()
+                : id != null && !id.isBlank() ? RegistrySourceId.of(id) : parsed.id();
+        String effectiveRef = ref != null && !ref.isBlank() ? ref : parsed.ref();
+        return new RegistrySource(sourceId, name, parsed.owner(), parsed.repo(), effectiveRef,
+                indexPath, tokenEnvVar, baseUrl, enabled,
+                existing != null ? existing.version() : null);
+    }
+
+    private static String text(Object value) {
+        return value == null || value.toString().isBlank() ? null : value.toString().strip();
+    }
+
+    private static boolean bool(Object value) {
+        if (value == null) return true;
+        if (value instanceof Boolean flag) return flag;
+        return !"false".equalsIgnoreCase(value.toString());
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistrySourceFormView.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistrySourceFormView.java
@@ -1,0 +1,83 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiField;
+import ai.mindconnect.ui.model.UiForm;
+import ai.mindconnect.ui.model.UiNode;
+import ai.mindconnect.ui.model.UiStack;
+import ai.mindconnect.ui.model.UiText;
+
+/** The form for adding or editing a registry. */
+final class RegistrySourceFormView {
+
+    private static final String FORM_ID = "registry-source-form";
+    static final String STACK_ID = FORM_ID + "-stack";
+
+    private final RegistrySourceDraft draft;
+    private final boolean isNew;
+    private final String error;
+
+    RegistrySourceFormView(RegistrySourceDraft draft, boolean isNew, String error) {
+        this.draft = draft == null ? RegistrySourceDraft.empty() : draft;
+        this.isNew = isNew;
+        this.error = error;
+    }
+
+    UiNode render() {
+        UiForm form = UiForm.of(FORM_ID, isNew ? "Add registry" : "Registry " + draft.name());
+
+        form.field(UiField.text("repository", "Repository", draft.repository())
+                .asEditable().asRequired()
+                .icon("box")
+                .placeholder("owner/repo")
+                .hint("The GitHub project holding the registry — 'owner/repo', or the URL from "
+                        + "the browser's address bar. Shorthands work too: "
+                        + "'owner/repo@v1.2.0' pins a tag."));
+
+        form.field(UiField.text("name", "Name", draft.name())
+                .asEditable()
+                .hint("What to call it in this list. Defaults to owner/repo."));
+
+        form.field(UiField.text("ref", "Branch, tag or commit", draft.ref())
+                .asEditable()
+                .placeholder(RegistrySource.DEFAULT_REF)
+                .hint("What is read. A branch is whatever its owner pushed last — for a registry "
+                        + "you do not control, pin a tag and move it deliberately."));
+
+        form.field(UiField.text("indexPath", "Index path", draft.indexPath())
+                .asEditable()
+                .placeholder(RegistrySource.DEFAULT_INDEX_PATH)
+                .hint("Where the index sits inside the repository."));
+
+        form.field(UiField.text("tokenEnvVar", "Token variable", draft.tokenEnvVar())
+                .asEditable()
+                .hint("For a private repository: the name of the environment variable holding the "
+                        + "token — the name, not the token. This installation reads it at request "
+                        + "time, so nothing secret is ever stored here."));
+
+        form.field(UiField.text("baseUrl", "Raw content URL", draft.baseUrl())
+                .asEditable()
+                .placeholder(RegistrySource.GITHUB_RAW_BASE_URL)
+                .hint("Only for GitHub Enterprise. Leave empty for github.com."));
+
+        form.field(UiField.bool("enabled", "Enabled", draft.enabled())
+                .asEditable()
+                .hint("A disabled registry stays configured but is not read."));
+
+        form.action(UiAction.primary("save", "Save").icon("save")
+                        .dispatch("POST", RegistryListView.BASE + "/api/save", FORM_ID))
+                .action(UiAction.secondary("back", "All registries").icon("back")
+                        .dispatch("GET", RegistryListView.BASE + "/api"));
+
+        UiStack stack = UiStack.of(STACK_ID);
+        stack.child(form);
+        if (error != null) {
+            stack.child(UiStack.of(FORM_ID + "-error")
+                    .<UiStack>withCssClass("llm-test-result")
+                    .child(UiText.of(FORM_ID + "-error-text", "✗ " + error)
+                            .<UiText>withCssClass("llm-test-body")));
+        }
+        return stack;
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryUiController.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryUiController.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The registry screen: the registries this installation knows, what each of
@@ -139,7 +140,8 @@ public class RegistryUiController {
 
     @GetMapping("/api/{id}/entry/{entryId}")
     public UiPage entry(@PathVariable String id, @PathVariable String entryId) {
-        return entryPage(id, entryId, null, null);
+        // Nobody has chosen yet: the view unticks what something else still uses.
+        return entryPage(id, entryId, null, null, null);
     }
 
     /**
@@ -147,42 +149,81 @@ public class RegistryUiController {
      * an import changes the agents, workflows and configs of this installation,
      * and the report is the record of it — it should survive a click, not
      * vanish with the next one.
+     *
+     * <p>For a package the body is its Contents tab: an unticked Import box
+     * leaves that entry out.
      */
     @PostMapping("/api/{id}/import/{entryId}")
     public UiPage importEntry(@PathVariable String id, @PathVariable String entryId,
-                              @RequestParam(defaultValue = "SKIP_EXISTING") String mode) {
+                              @RequestParam(defaultValue = "SKIP_EXISTING") String mode,
+                              @RequestBody(required = false) Map<String, Object> body) {
         Optional<RegistrySource> found = source(id);
         if (found.isEmpty()) {
             return list();
         }
+        Set<String> excluded = RegistryEntryView.excludedFrom(body);
         try {
-            ImportReport report = registry.importEntry(found.get().id(), entryId, modeOf(mode));
-            return entryPage(id, entryId, report, null);
+            ImportReport report = registry.importEntry(found.get().id(), entryId, modeOf(mode), excluded);
+            return entryPage(id, entryId, excluded, report, null);
         } catch (RuntimeException e) {
             log.warn("Importing '{}' from registry '{}' failed: {}", entryId, id, e.getMessage());
-            return entryPage(id, entryId, null, message(e));
+            return entryPage(id, entryId, excluded, null, message(e));
         }
     }
 
-    private UiPage entryPage(String id, String entryId, ImportReport report, String error) {
+    /**
+     * Removes a package: deletes the entries included on its Contents tab that
+     * are here, and shows what happened on the same page.
+     */
+    @PostMapping("/api/{id}/remove/{entryId}")
+    public UiPage removeEntry(@PathVariable String id, @PathVariable String entryId,
+                              @RequestBody(required = false) Map<String, Object> body) {
+        Optional<RegistrySource> found = source(id);
+        if (found.isEmpty()) {
+            return list();
+        }
+        Set<String> kept = RegistryEntryView.excludedFrom(body);
+        try {
+            ImportReport report = registry.removeEntry(found.get().id(), entryId, kept);
+            return entryPage(id, entryId, kept, report, null);
+        } catch (RuntimeException e) {
+            log.warn("Removing '{}' of registry '{}' failed: {}", entryId, id, e.getMessage());
+            return entryPage(id, entryId, kept, null, message(e));
+        }
+    }
+
+    private UiPage entryPage(String id, String entryId, Set<String> excluded,
+                             ImportReport report, String error) {
         Optional<RegistrySource> found = source(id);
         if (found.isEmpty()) {
             return list();
         }
         RegistrySource source = found.get();
-        Optional<RegistryEntry> entry;
+        RegistryIndex index;
         try {
-            entry = registry.index(source.id()).find(entryId);
+            index = registry.index(source.id());
         } catch (RuntimeException e) {
             return UiPage.of(RegistryListView.BASE + "/" + id,
                     new RegistryUnreadableView(source, message(e)).render());
         }
+        Optional<RegistryEntry> entry = index.find(entryId);
         if (entry.isEmpty()) {
             return browse(id, null, null);
         }
+        RegistryService.PackageContents contents = null;
+        String contentsError = null;
+        if (entry.get().type() == RegistryItemType.PACKAGE) {
+            try {
+                contents = registry.packageContents(source.id(), entry.get());
+            } catch (RuntimeException e) {
+                // The details and the import still work; only the list tab says why it is empty.
+                log.warn("Reading package '{}' from {} failed: {}", entryId, source.coordinates(), e.getMessage());
+                contentsError = message(e);
+            }
+        }
         return UiPage.of(RegistryListView.BASE + "/" + id + "/entry/" + entryId,
-                new RegistryEntryView(source, entry.get(), registry.status(entry.get()),
-                        report, error).render());
+                new RegistryEntryView(source, index, entry.get(), registry::status,
+                        contents, contentsError, excluded, report, error).render());
     }
 
     // ----------------------------------------------------------------- helpers

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryUiController.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryUiController.java
@@ -1,0 +1,229 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.ImportMode;
+import ai.mindconnect.agent.registry.domain.ImportReport;
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.domain.RegistrySourceId;
+import ai.mindconnect.agent.registry.service.RegistryService;
+import ai.mindconnect.ui.model.UiPage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The registry screen: the registries this installation knows, what each of
+ * them offers, and the import.
+ *
+ * <p>Pages live under {@code /registry}, the actions behind them under
+ * {@code /registry/api} — the split the MCP gateway and the workflow admin
+ * use, so a host's layout advice can wrap the pages and leave the rest alone.
+ */
+@RestController
+@RequestMapping(RegistryListView.BASE)
+public class RegistryUiController {
+
+    private static final Logger log = LoggerFactory.getLogger(RegistryUiController.class);
+
+    private final RegistryService registry;
+
+    public RegistryUiController(RegistryService registry) {
+        this.registry = registry;
+    }
+
+    // ----------------------------------------------------------- the registries
+
+    @GetMapping
+    public UiPage page() {
+        return list();
+    }
+
+    @GetMapping("/api")
+    public UiPage list() {
+        return UiPage.of(RegistryListView.BASE, new RegistryListView(registry.sources()).render());
+    }
+
+    @GetMapping({"/api/new", "/new"})
+    public UiPage newSource() {
+        return UiPage.of(RegistryListView.BASE + "/new",
+                new RegistrySourceFormView(RegistrySourceDraft.empty(), true, null).render());
+    }
+
+    @GetMapping("/api/{id}/edit")
+    public UiPage edit(@PathVariable String id) {
+        return source(id)
+                .map(source -> UiPage.of(RegistryListView.BASE + "/" + id + "/edit",
+                        new RegistrySourceFormView(RegistrySourceDraft.of(source), false, null).render()))
+                .orElseGet(this::list);
+    }
+
+    @PostMapping("/api/save")
+    public UiPage save(@RequestBody Map<String, Object> body) {
+        RegistrySourceDraft draft = RegistrySourceDraft.fromForm(body);
+        RegistrySource existing = draft.id() == null ? null
+                : source(draft.id()).orElse(null);
+        try {
+            registry.saveSource(draft.toSource(existing));
+        } catch (RuntimeException e) {
+            log.warn("Saving the registry '{}' failed: {}", draft.repository(), e.getMessage());
+            return UiPage.of(RegistryListView.BASE + (existing == null ? "/new" : "/" + draft.id() + "/edit"),
+                    new RegistrySourceFormView(draft, existing == null, message(e)).render());
+        }
+        return list();
+    }
+
+    @DeleteMapping("/api/{id}")
+    public UiPage delete(@PathVariable String id) {
+        sourceId(id).ifPresent(registry::deleteSource);
+        return list();
+    }
+
+    // --------------------------------------------------------------- browsing
+
+    @GetMapping("/{id}")
+    public UiPage browsePage(@PathVariable String id) {
+        return browse(id, null, null);
+    }
+
+    @GetMapping("/api/{id}")
+    public UiPage browse(@PathVariable String id) {
+        return browse(id, null, null);
+    }
+
+    @PostMapping("/api/{id}/search")
+    public UiPage search(@PathVariable String id, @RequestBody Map<String, Object> body) {
+        Object query = body.get("q");
+        return browse(id, query == null ? null : query.toString(), typeOf(body.get("type")));
+    }
+
+    @PostMapping("/api/{id}/refresh")
+    public UiPage refresh(@PathVariable String id) {
+        sourceId(id).ifPresent(registry::refresh);
+        return browse(id, null, null);
+    }
+
+    private UiPage browse(String id, String query, RegistryItemType type) {
+        Optional<RegistrySource> found = source(id);
+        if (found.isEmpty()) {
+            return list();
+        }
+        RegistrySource source = found.get();
+        RegistryIndex index;
+        try {
+            index = registry.index(source.id());
+        } catch (RuntimeException e) {
+            log.warn("Reading the registry {} failed: {}", source.coordinates(), e.getMessage());
+            return UiPage.of(RegistryListView.BASE + "/" + id,
+                    new RegistryUnreadableView(source, message(e)).render());
+        }
+        List<RegistryEntry> entries = index.search(query, type);
+        return UiPage.of(RegistryListView.BASE + "/" + id,
+                new RegistryBrowseView(source, index, entries, query, type, registry::status).render());
+    }
+
+    // --------------------------------------------------------------- one entry
+
+    @GetMapping("/api/{id}/entry/{entryId}")
+    public UiPage entry(@PathVariable String id, @PathVariable String entryId) {
+        return entryPage(id, entryId, null, null);
+    }
+
+    /**
+     * Imports the entry and shows what happened. A page rather than a patch:
+     * an import changes the agents, workflows and configs of this installation,
+     * and the report is the record of it — it should survive a click, not
+     * vanish with the next one.
+     */
+    @PostMapping("/api/{id}/import/{entryId}")
+    public UiPage importEntry(@PathVariable String id, @PathVariable String entryId,
+                              @RequestParam(defaultValue = "SKIP_EXISTING") String mode) {
+        Optional<RegistrySource> found = source(id);
+        if (found.isEmpty()) {
+            return list();
+        }
+        try {
+            ImportReport report = registry.importEntry(found.get().id(), entryId, modeOf(mode));
+            return entryPage(id, entryId, report, null);
+        } catch (RuntimeException e) {
+            log.warn("Importing '{}' from registry '{}' failed: {}", entryId, id, e.getMessage());
+            return entryPage(id, entryId, null, message(e));
+        }
+    }
+
+    private UiPage entryPage(String id, String entryId, ImportReport report, String error) {
+        Optional<RegistrySource> found = source(id);
+        if (found.isEmpty()) {
+            return list();
+        }
+        RegistrySource source = found.get();
+        Optional<RegistryEntry> entry;
+        try {
+            entry = registry.index(source.id()).find(entryId);
+        } catch (RuntimeException e) {
+            return UiPage.of(RegistryListView.BASE + "/" + id,
+                    new RegistryUnreadableView(source, message(e)).render());
+        }
+        if (entry.isEmpty()) {
+            return browse(id, null, null);
+        }
+        return UiPage.of(RegistryListView.BASE + "/" + id + "/entry/" + entryId,
+                new RegistryEntryView(source, entry.get(), registry.status(entry.get()),
+                        report, error).render());
+    }
+
+    // ----------------------------------------------------------------- helpers
+
+    private Optional<RegistrySource> source(String id) {
+        return sourceId(id).flatMap(registry::findSource);
+    }
+
+    /**
+     * The id from a URL, or empty when the text could not address a registry at
+     * all. Empty rather than thrown: an address nobody could have configured is
+     * simply not found, and a form being re-rendered must not fail again on the
+     * same text.
+     */
+    private Optional<RegistrySourceId> sourceId(String value) {
+        try {
+            return Optional.of(RegistrySourceId.of(value));
+        } catch (IllegalArgumentException notAnId) {
+            return Optional.empty();
+        }
+    }
+
+    private static RegistryItemType typeOf(Object value) {
+        if (value == null || value.toString().isBlank()) return null;
+        try {
+            return RegistryItemType.fromWire(value.toString());
+        } catch (IllegalArgumentException unknown) {
+            return null;
+        }
+    }
+
+    private static ImportMode modeOf(String value) {
+        try {
+            return ImportMode.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException | NullPointerException unknown) {
+            return ImportMode.SKIP_EXISTING;
+        }
+    }
+
+    /** What to put on screen for a failure — the exception's words, or its name. */
+    private static String message(RuntimeException e) {
+        return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryUnreadableView.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/java/ai/mindconnect/agent/registry/admin/ui/RegistryUnreadableView.java
@@ -1,0 +1,38 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.ui.model.UiAction;
+import ai.mindconnect.ui.model.UiList;
+import ai.mindconnect.ui.model.UiNode;
+
+/**
+ * A registry that could not be read — the wrong ref, a moved index, a private
+ * repository whose token is not set, no outbound access at all.
+ *
+ * <p>Its own screen rather than a toast: the reason is the whole message, and
+ * the two useful next steps (edit the registry, try again) belong next to it.
+ */
+final class RegistryUnreadableView {
+
+    private final RegistrySource source;
+    private final String reason;
+
+    RegistryUnreadableView(RegistrySource source, String reason) {
+        this.source = source;
+        this.reason = reason;
+    }
+
+    UiNode render() {
+        String base = RegistryListView.BASE + "/api/" + source.id().value();
+        return UiList.of("registry-unreadable", source.name())
+                .icon("box")
+                .action(UiAction.primary("retry", "Try again").icon("refresh")
+                        .dispatch("POST", base + "/refresh"))
+                .action(UiAction.secondary("edit", "Edit registry").icon("edit")
+                        .dispatch("GET", base + "/edit"))
+                .action(UiAction.secondary("back", "All registries").icon("back")
+                        .dispatch("GET", RegistryListView.BASE + "/api"))
+                .item(UiList.Item.of("reason", "Cannot read " + source.coordinates())
+                        .description(reason == null ? "No reason given." : reason));
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ai.mindconnect.agent.registry.admin.ui.RegistryAdminAutoConfiguration

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/test/java/ai/mindconnect/agent/registry/admin/ui/RegistrySourceDraftTest.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/test/java/ai/mindconnect/agent/registry/admin/ui/RegistrySourceDraftTest.java
@@ -1,0 +1,91 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The form's half of the screen: what an operator types becomes a registry,
+ * and an edit stays the same registry.
+ */
+class RegistrySourceDraftTest {
+
+    private static Map<String, Object> form(String repository, Object... pairs) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("repository", repository);
+        for (int i = 0; i + 1 < pairs.length; i += 2) {
+            body.put(pairs[i].toString(), pairs[i + 1]);
+        }
+        return body;
+    }
+
+    @Test
+    void a_typed_repository_becomes_a_source_with_the_defaults_filled_in() {
+        RegistrySource source = RegistrySourceDraft.fromForm(form("acme/agents")).toSource(null);
+
+        assertThat(source.owner()).isEqualTo("acme");
+        assertThat(source.ref()).isEqualTo(RegistrySource.DEFAULT_REF);
+        assertThat(source.indexPath()).isEqualTo(RegistrySource.DEFAULT_INDEX_PATH);
+        assertThat(source.enabled()).isTrue();
+    }
+
+    @Test
+    void a_ref_typed_in_its_own_field_wins_over_the_shorthands_default() {
+        RegistrySource source = RegistrySourceDraft.fromForm(form("acme/agents", "ref", "v2"))
+                .toSource(null);
+
+        assertThat(source.ref()).isEqualTo("v2");
+    }
+
+    @Test
+    void a_ref_in_the_shorthand_survives_an_empty_ref_field() {
+        RegistrySource source = RegistrySourceDraft.fromForm(form("acme/agents@v9", "ref", " "))
+                .toSource(null);
+
+        assertThat(source.ref()).isEqualTo("v9");
+    }
+
+    @Test
+    void an_edit_keeps_the_id_and_the_version_so_it_stays_the_same_registry() {
+        RegistrySource existing = RegistrySource.of("acme/agents").withVersion(3L);
+
+        RegistrySource edited = RegistrySourceDraft.fromForm(
+                        form("acme/other-repo", "name", "Renamed"))
+                .toSource(existing);
+
+        assertThat(edited.id()).isEqualTo(existing.id());
+        assertThat(edited.version()).isEqualTo(3L);
+        assertThat(edited.repo()).isEqualTo("other-repo");
+        assertThat(edited.name()).isEqualTo("Renamed");
+    }
+
+    @Test
+    void the_enabled_checkbox_reads_both_shapes_a_form_posts() {
+        assertThat(RegistrySourceDraft.fromForm(form("a/b", "enabled", false)).enabled()).isFalse();
+        assertThat(RegistrySourceDraft.fromForm(form("a/b", "enabled", "false")).enabled()).isFalse();
+        assertThat(RegistrySourceDraft.fromForm(form("a/b", "enabled", true)).enabled()).isTrue();
+        assertThat(RegistrySourceDraft.fromForm(form("a/b")).enabled()).isTrue();
+    }
+
+    @Test
+    void an_empty_repository_field_is_refused_rather_than_saved() {
+        assertThatThrownBy(() -> RegistrySourceDraft.fromForm(form("")).toSource(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void an_existing_source_fills_the_form_back_in() {
+        RegistrySource source = RegistrySource.of("acme/agents@v1:catalog/index.json");
+
+        RegistrySourceDraft draft = RegistrySourceDraft.of(source);
+
+        assertThat(draft.repository()).isEqualTo("acme/agents");
+        assertThat(draft.ref()).isEqualTo("v1");
+        assertThat(draft.indexPath()).isEqualTo("catalog/index.json");
+    }
+}

--- a/agents/server/mc-agent-registry-admin-ui-rest/src/test/java/ai/mindconnect/agent/registry/admin/ui/RegistryViewsTest.java
+++ b/agents/server/mc-agent-registry-admin-ui-rest/src/test/java/ai/mindconnect/agent/registry/admin/ui/RegistryViewsTest.java
@@ -1,0 +1,173 @@
+package ai.mindconnect.agent.registry.admin.ui;
+
+import ai.mindconnect.agent.registry.domain.RegistryEntry;
+import ai.mindconnect.agent.registry.domain.RegistryIndex;
+import ai.mindconnect.agent.registry.domain.RegistryItemType;
+import ai.mindconnect.agent.registry.domain.RegistrySource;
+import ai.mindconnect.agent.registry.service.RegistryService;
+import ai.mindconnect.ui.model.UiNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The registry screens file entries under their kind, and a package shows what
+ * it contains on a tab of its own.
+ */
+class RegistryViewsTest {
+
+    private static final RegistrySource SOURCE = RegistrySource.of("acme/registry");
+    private static final RegistryService.EntryStatus NEW = new RegistryService.EntryStatus(true, false);
+
+    private static final RegistryEntry WORKFLOW = entry("greeting", RegistryItemType.WORKFLOW);
+    private static final RegistryEntry AGENT = entry("researcher", RegistryItemType.AGENT);
+    private static final RegistryEntry CONFIG = entry("default-llm", RegistryItemType.LLM_CONFIG);
+    private static final RegistryEntry KIT = entry("kit", RegistryItemType.PACKAGE);
+    private static final RegistryEntry OTHER_AGENT = entry("writer", RegistryItemType.AGENT);
+
+    private static final RegistryIndex INDEX = new RegistryIndex(1, "Acme", null,
+            List.of(WORKFLOW, AGENT, CONFIG, KIT, OTHER_AGENT));
+
+    @Test
+    void the_registry_lists_its_entries_under_one_rubric_per_kind_in_a_fixed_order() throws Exception {
+        String json = json(new RegistryBrowseView(SOURCE, INDEX, INDEX.entries(), null, null, e -> NEW)
+                .render());
+
+        assertThat(json).containsSubsequence("Agents  (2)", "LLM configs  (1)", "Workflows  (1)", "Packages  (1)");
+        // Inside a rubric, the index's order.
+        assertThat(json).containsSubsequence("\"researcher\"", "\"writer\"");
+    }
+
+    @Test
+    void a_kind_with_nothing_in_it_gets_no_rubric() throws Exception {
+        String json = json(new RegistryBrowseView(SOURCE, INDEX, List.of(AGENT), "res", null, e -> NEW)
+                .render());
+
+        assertThat(json).contains("Agents  (1)").doesNotContain("Workflows").doesNotContain("Packages");
+    }
+
+    @Test
+    void a_package_has_a_details_tab_and_a_tab_with_its_members_by_kind() throws Exception {
+        RegistryService.PackageContents contents = new RegistryService.PackageContents(
+                List.of(WORKFLOW, AGENT), List.of("gone"));
+
+        String json = json(new RegistryEntryView(SOURCE, INDEX, KIT, e -> NEW, contents, null, Set.of(), null, null)
+                .render());
+
+        assertThat(json).contains("registry-entry-tabs").contains("\"Details\"").contains("\"Contents (2)\"");
+        assertThat(json).containsSubsequence("Agents  (1)", "Workflows  (1)");
+        assertThat(json).contains("/registry/api/" + SOURCE.id().value() + "/entry/greeting");
+        assertThat(json).contains("\"gone\"");
+    }
+
+    @Test
+    void each_member_says_whether_it_is_already_here_and_carries_an_include_box_ticked_unless_left_out()
+            throws Exception {
+        RegistryService.PackageContents contents = new RegistryService.PackageContents(
+                List.of(CONFIG, AGENT), List.of());
+        RegistryService.EntryStatus here = new RegistryService.EntryStatus(true, true);
+
+        UiNode page = new RegistryEntryView(SOURCE, INDEX, KIT, e -> e == CONFIG ? here : NEW,
+                contents, null, Set.of("researcher"), null, null).render();
+        JsonNode tree = new ObjectMapper().valueToTree(page);
+
+        assertThat(tree.toString()).contains("\"Already here\"").contains("\"New\"");
+        assertThat(checkbox(tree, "include-default-llm").path("value").asBoolean()).isTrue();
+        assertThat(checkbox(tree, "include-researcher").path("value").asBoolean()).isFalse();
+        // Import, overwrite and remove all send the Contents tab along.
+        assertThat(tree.toString()).contains("/remove/kit")
+                .contains("\"payload\":\"" + RegistryEntryView.SELECTION_ID + "\"");
+    }
+
+    @Test
+    void what_something_else_uses_starts_unticked_until_somebody_chooses() throws Exception {
+        RegistryService.EntryStatus here = new RegistryService.EntryStatus(true, true);
+        RegistryService.PackageContents contents = new RegistryService.PackageContents(
+                List.of(CONFIG, AGENT), List.of(),
+                Map.of("default-llm", List.of("Agent 'default-chat'", "Agent 'planner'")));
+
+        JsonNode fresh = new ObjectMapper().valueToTree(new RegistryEntryView(SOURCE, INDEX, KIT,
+                e -> here, contents, null, null, null, null).render());
+        JsonNode chosen = new ObjectMapper().valueToTree(new RegistryEntryView(SOURCE, INDEX, KIT,
+                e -> here, contents, null, Set.of(), null, null).render());
+
+        assertThat(fresh.toString()).contains("Used by Agent 'default-chat', Agent 'planner'");
+        assertThat(checkbox(fresh, "include-default-llm").path("value").asBoolean()).isFalse();
+        assertThat(checkbox(fresh, "include-researcher").path("value").asBoolean()).isTrue();
+        // Once a choice came back from the page, it is the choice.
+        assertThat(checkbox(chosen, "include-default-llm").path("value").asBoolean()).isTrue();
+    }
+
+    @Test
+    void a_long_used_by_list_names_a_few_and_counts_the_rest() {
+        assertThat(RegistryEntryView.usedByLine(List.of("A", "B")))
+                .isEqualTo("Used by A, B");
+        assertThat(RegistryEntryView.usedByLine(List.of("A", "B", "C", "D", "E")))
+                .isEqualTo("Used by A, B, C and 2 more");
+    }
+
+    @Test
+    void only_unticked_boxes_leave_an_entry_out() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("include-default-llm", true);
+        body.put("include-researcher", false);
+        body.put("include-writer", "false");
+        body.put("unrelated", false);
+
+        assertThat(RegistryEntryView.excludedFrom(body)).containsExactlyInAnyOrder("researcher", "writer");
+        assertThat(RegistryEntryView.excludedFrom(null)).isEmpty();
+    }
+
+    @Test
+    void a_package_whose_manifest_cannot_be_read_still_offers_the_import() throws Exception {
+        String json = json(new RegistryEntryView(SOURCE, INDEX, KIT, e -> NEW, null, "404 Not Found", Set.of(), null, null)
+                .render());
+
+        assertThat(json).contains("\"Contents\"").contains("404 Not Found").contains("?mode=SKIP_EXISTING");
+    }
+
+    @Test
+    void any_other_kind_stays_a_single_detail_without_tabs() throws Exception {
+        String json = json(new RegistryEntryView(SOURCE, INDEX, AGENT, e -> NEW, null, null, Set.of(), null, null)
+                .render());
+
+        assertThat(json).doesNotContain("registry-entry-tabs").doesNotContain(RegistryEntryView.SELECTION_ID)
+                .doesNotContain("/remove/")
+                .contains("?mode=SKIP_EXISTING");
+    }
+
+    @Test
+    void a_registry_row_offers_import_for_what_is_new_and_overwrite_for_what_is_here() throws Exception {
+        RegistryService.EntryStatus here = new RegistryService.EntryStatus(true, true);
+
+        String json = json(new RegistryBrowseView(SOURCE, INDEX, List.of(AGENT, CONFIG), null, null,
+                e -> e == AGENT ? here : NEW).render());
+
+        assertThat(json).contains("\"overwrite-researcher\"").contains("\"Overwrite\"")
+                .contains("\"import-default-llm\"").doesNotContain("Re-import");
+    }
+
+    /** The field node with that id, wherever it sits in the tree. */
+    private static JsonNode checkbox(JsonNode tree, String id) {
+        List<JsonNode> found = tree.findParents("id").stream()
+                .filter(n -> id.equals(n.path("id").asText()))
+                .toList();
+        assertThat(found).as("field " + id).hasSize(1);
+        return found.get(0);
+    }
+
+    private static RegistryEntry entry(String id, RegistryItemType type) {
+        return new RegistryEntry(id, type, id, null, null, id + ".json", List.of(), null, null, List.of());
+    }
+
+    private static String json(UiNode node) throws Exception {
+        return new ObjectMapper().writeValueAsString(node);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,8 @@
         <module>agents/core/mc-agent-tools-web</module>
         <module>agents/core/mc-agent-tools-web-browser</module>
         <module>agents/core/mc-agent-tools-workflow</module>
+        <module>agents/core/mc-agent-registry-core</module>
+        <module>agents/core/mc-agent-registry</module>
         <module>agents/mcp/mc-mcp-proxy</module>
         <module>agents/mcp/mc-mcp-gateway-core</module>
         <module>agents/mcp/mc-mcp-gateway-local</module>
@@ -128,6 +130,7 @@
         <module>agents/server/mc-agent-security</module>
         <module>agents/server/mc-agent-api-app</module>
         <module>agents/server/mc-agent-chat-ui-rest</module>
+        <module>agents/server/mc-agent-registry-admin-ui-rest</module>
         <module>agents/server/mc-agent-admin-ui-rest</module>
         <module>agents/server/mc-agent-api-responses-rest</module>
         <module>agents/server/mc-agent-admin-ui-app</module>

--- a/website/docs/agents/registry.md
+++ b/website/docs/agents/registry.md
@@ -29,9 +29,31 @@ by its `owner/repo`:
 Pin a tag for a registry you do not control: a branch is whatever its owner
 pushed last.
 
-Open a registry to see what it offers, filter by kind, and import an entry. Each
+Open a registry to see what it offers — filed under *Agents*, *LLM configs*,
+*Workflows* and *Packages* — search or filter by kind, and import an entry. Each
 row says what this installation would do with it — *already here*, or a kind this
-installation cannot install at all — before you press anything.
+installation cannot install at all — before you press anything; its button reads
+**Import** for something new and **Overwrite** for something already here.
+
+A package opens on two tabs: its details, and *Contents* — everything importing
+it would install, the entries its members require included, each marked *New*
+or *Already here*. Every entry has an **Include** box, ticked by default; untick
+one to leave it out. A left-out entry is not installed at all, not even as what
+another entry requires, and the report lists it as skipped.
+
+**Remove** takes a package out again: it deletes the included entries that are
+here — workflows first, then agents, then the LLM configs they run on — and
+leaves the unticked ones in place.
+
+An entry that something outside the package still uses says so — *Used by Agent
+'default-chat', Agent 'planner' and 13 more* — and starts unticked, so that
+removing a package does not take the model away from every other agent. The
+check follows the chain: when a shared alias stays, the config it delegates to
+stays too. What counts as a use: an agent's LLM config, the agents it calls and
+its reviewers, an alias's target, and a workflow's agent calls, inline agents
+and called workflows. A reference kept anywhere else — a tool setting, an
+application property naming a default agent — is not seen, so read the list
+before you press Remove.
 
 Importing has two modes:
 

--- a/website/docs/agents/registry.md
+++ b/website/docs/agents/registry.md
@@ -1,0 +1,200 @@
+---
+title: Registry
+sidebar_position: 9
+---
+
+# Registry
+
+A **registry** is a GitHub project holding an index of things you can import
+into a Mindconnect installation: LLM configs, agents, workflows, and packages
+that bundle all of them.
+
+There is no registry server. A registry is a repository — fork it, send a pull
+request, pin a tag — and everything a hosted catalogue would need (review,
+history, ownership) is what Git already does. Reading one is a plain HTTPS GET
+of raw files, so a private registry needs nothing but a token.
+
+## Using one
+
+`Registry` in the admin UI lists the registries this installation knows. Add one
+by its `owner/repo`:
+
+| Typed | Reads |
+|-------|-------|
+| `acme/agent-registry` | `main`, `registry.json` |
+| `acme/agent-registry@v1.2.0` | the tag `v1.2.0` |
+| `acme/agent-registry@main:catalog/index.json` | another index path |
+| `https://github.com/acme/agent-registry` | same as the first row |
+
+Pin a tag for a registry you do not control: a branch is whatever its owner
+pushed last.
+
+Open a registry to see what it offers, filter by kind, and import an entry. Each
+row says what this installation would do with it — *already here*, or a kind this
+installation cannot install at all — before you press anything.
+
+Importing has two modes:
+
+- **Import** keeps what is already here under the same name, and installs the
+  rest. The default; it cannot destroy anything.
+- **Import and overwrite** replaces entities of the same name, keeping their
+  local ids — so the agents, aliases and sessions pointing at them keep working.
+
+Nothing is rolled back if one member of a package fails: the others are
+installed, and the report says line by line what happened.
+
+## What a registry repository looks like
+
+```
+registry.json               ← the index
+llm-configs/
+  default.json
+agents/
+  web-researcher.json
+  research-lead.json
+workflows/
+  summarize.json
+packages/
+  research-kit.json         ← a package manifest
+```
+
+### `registry.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "Acme agent registry",
+  "description": "Agents and workflows we use in-house",
+  "entries": [
+    {
+      "id": "default-llm",
+      "type": "llm-config",
+      "name": "default",
+      "description": "Claude Sonnet, our house default",
+      "version": "1.0.0",
+      "path": "llm-configs/default.json"
+    },
+    {
+      "id": "web-researcher",
+      "type": "agent",
+      "name": "web-researcher",
+      "description": "Searches the web and reports with citations",
+      "version": "1.2.0",
+      "path": "agents/web-researcher.json",
+      "tags": ["research"],
+      "author": "acme",
+      "homepage": "https://github.com/acme/agent-registry",
+      "requires": ["default-llm"]
+    },
+    {
+      "id": "research-kit",
+      "type": "package",
+      "name": "Research kit",
+      "description": "A research lead, its sub-agents and the model they share",
+      "path": "packages/research-kit.json"
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `id` | the entry's address inside this registry — what `requires` and packages refer to |
+| `type` | `llm-config`, `agent`, `workflow` or `package` |
+| `name` | the name the entity is installed under; the screen warns when it is taken |
+| `path` | where the entity's file sits in the repository |
+| `version`, `author`, `homepage`, `tags`, `description` | for the person deciding |
+| `requires` | ids of entries installed **first**, in order |
+
+Unknown fields are ignored, so an index written against a later schema still
+reads.
+
+### Entity files
+
+An entity file is exactly what the installation stores — the same JSON the admin
+UI shows under *Agents* and *LLM configs*, and the same file the workflow admin
+writes. Two fields are taken away on the way in:
+
+- **Ids.** A new entity gets a fresh local id; re-importing over an existing one
+  keeps the local id, so nothing pointing at it breaks.
+- **A literal API key in an LLM config.** A registry config is meant to carry
+  `${ANTHROPIC_API_KEY}`, which resolves against *this* installation's
+  environment at call time. A key that is not a placeholder is somebody else's
+  credential — it is dropped, and the import report says so.
+
+### Packages
+
+A package manifest names everything that has to arrive together. A useful agent
+is rarely one file: it points at an LLM config by name, calls two sub-agents, and
+one of those runs a workflow.
+
+```json
+{
+  "name": "Research kit",
+  "description": "A research lead, its sub-agents and the model they share",
+  "version": "1.0.0",
+  "includes": ["default-llm", "web-researcher", "verifier"],
+  "items": [
+    {
+      "id": "research-lead",
+      "type": "agent",
+      "name": "research-lead",
+      "path": "agents/research-lead.json"
+    }
+  ]
+}
+```
+
+`includes` are ids from the same index — reuse, so the same agent can be a member
+of three packages and exist once. `items` are entries written into the manifest
+itself, for parts that are only ever this package's. They install in that order,
+each with its own `requires`, and an entry reached twice is installed once.
+
+## Private registries
+
+Set **Token variable** on the registry to the *name* of an environment variable
+holding a GitHub token — the name, never the token. The installation reads it at
+request time, so the store that holds the registry can never hold a secret.
+
+```bash
+export ACME_REGISTRY_TOKEN=ghp_…
+```
+
+## Configuration
+
+| Property | Default | What it does |
+|----------|---------|--------------|
+| `mindconnect.registry.enabled` | `true` | `false` takes the whole feature away, screen included |
+| `mindconnect.registry.default-source` | — | `owner/repo[@ref][:index-path]`, added on first start when no registry is configured yet |
+| `mindconnect.registry.cache-ttl` | `PT10M` | how long a fetched index or file is reused; the screen's *Refresh* drops it |
+| `mindconnect.registry.timeout` | `PT20S` | per-request HTTP timeout |
+
+Registries are stored per namespace under
+`<data-base-dir>/<namespace>/system/registries/<id>.json`, so an installation can
+ship one the way it ships a seed agent: drop the file in.
+
+## What importing means
+
+A registry is somebody else's repository. Nothing runs by being imported, but
+everything imported is here afterwards:
+
+- **An agent** is a system prompt and a tool list somebody else wrote. Imported,
+  it runs on your models with your tools. Read its prompt before you let it run.
+- **A workflow** is executable — its steps call tools, agents and scripts.
+- **An LLM config** names a provider and a base URL: the address this
+  installation would send prompts to.
+
+The import screen says this above the buttons, once, before the click.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `mc-agent-registry-core` | What a registry is: domain, the three ports, the import service that walks packages and dependencies |
+| `mc-agent-registry` | The GitHub client, the file-backed store of registries, the installers for LLM configs and agents |
+| `mc-agent-registry-admin-ui-rest` | The `/registry` screen |
+
+Installers are contributed by the module that owns the entity, so an installation
+that has no workflow engine simply has no workflow installer — its registry then
+lists workflows it cannot import, and says so, instead of dragging the engine in
+as a dependency. The workflow installer lives in `mc-agent-tools-workflow`.

--- a/website/docs/agents/registry.md
+++ b/website/docs/agents/registry.md
@@ -192,8 +192,29 @@ export ACME_REGISTRY_TOKEN=ghp_…
 | `mindconnect.registry.timeout` | `PT20S` | per-request HTTP timeout |
 
 Registries are stored per namespace under
-`<data-base-dir>/<namespace>/system/registries/<id>.json`, so an installation can
-ship one the way it ships a seed agent: drop the file in.
+`<data-base-dir>/<namespace>/system/registries/<id>.json`.
+
+### Shipping a registry with an application
+
+An application ships its registries the way it ships its seed agents and MCP
+servers: one file per registry under `initial-data/registries/` on its
+classpath. On start, every registry not configured yet is installed; one that
+is — pinned to a tag, disabled — is left as the operator made it, and one that
+was deleted comes back on the next start (disable it instead to keep it quiet).
+
+```json title="initial-data/registries/mindconnect-ai-mc-registry.json"
+{
+  "name": "Mindconnect registry",
+  "owner": "mindconnect-ai",
+  "repo": "mc-registry",
+  "ref": "main"
+}
+```
+
+The file name is the registry's id — `owner-repo`, as the screen names a
+registry you add by hand, so the two cannot end up as duplicates. The admin UI
+ships [mindconnect-ai/mc-registry](https://github.com/mindconnect-ai/mc-registry)
+this way.
 
 ## What importing means
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -43,6 +43,7 @@ const sidebars = {
             'agents/prompt-renderer',
             'agents/vector-store',
             'agents/persistence',
+            'agents/registry',
             'agents/creating-a-tool',
           ],
         },


### PR DESCRIPTION
## What

A **Registry** screen in the admin UI that installs LLM configs, agents, workflows and whole packages from a GitHub project — and takes a package out again.

A registry is a repository, not a server: an index (`registry.json`) and the entity files it points at. Reading one is a plain HTTPS GET of raw files; fork it, send a pull request, pin a tag. The public one is [mindconnect-ai/mc-registry](https://github.com/mindconnect-ai/mc-registry): the defaults every installation seeds itself with, plus a *Release notes kit* as an example of an all-new package.

## How it works

- **Browse** — entries filed under *Agents*, *LLM configs*, *Workflows* and *Packages*; a row offers **Import** for what is new and **Overwrite** for what is already here.
- **Import** — an entry brings what it `requires`; a package walks its members. Dependencies first, every entry once, cycles broken. The report says line by line what was imported, updated, skipped or failed. Ids are local (a re-import keeps the local id), and a literal API key in a registry file is dropped.
- **Package page** — two tabs. *Contents* lists everything the import would install (members and their requirements, computed by the same walk the import runs), marks each *New* or *Already here*, and has an **Include** box per entry. Unticked entries are not installed at all, not even as another entry's requirement.
- **Remove** — deletes the included entries that are here, workflows before agents before LLM configs, and keeps the rest.
- **Used by** — every installer can say what refers to an entity (agents → LLM config, callees, reviewers; aliases → target; workflows → agent calls, inline agents, called workflows). An entry used from outside the package says *Used by …* and starts unticked, following the chain: the shared `agent-default` alias stays, and so does `openai-default` behind it.

- **Shipped registries** — an application puts one file per registry under `initial-data/registries/`; a start installs those not configured yet (id = file name, configured ones are left alone). The admin UI ships `mindconnect-ai/mc-registry`.

## Commits

1. **Import agents, workflows and LLM configs from a registry** — domain, ports, import service, GitHub client, installers, the screen, docs.
2. **Wire the registry installers after the stores they write to** — without an `afterName` order the installers' `@ConditionalOnBean` ran before the persistence starters and the workflow store, so the service had no installers and the screen marked every entry as not importable.
3. **Show a registry by kind, and let a package be chosen from and removed** — grouping, package tabs, Include boxes, Remove, Used by. Also: the admin UI's collapsible summaries now read at body size globally (replacing the per-screen overrides for tools, agents and migrations), and the nav item uses the `package` icon.
4. **Ship registries as initial data, and the admin UI with mc-registry** — `InitialRegistrySources`, the seed file, docs.

## Modules

| Module | |
|---|---|
| `mc-agent-registry-core` | domain, ports, `RegistryService` (walk, import, remove, contents, used-by) |
| `mc-agent-registry` | GitHub client, file-backed sources, LLM-config and agent installers, auto-config |
| `mc-agent-registry-admin-ui-rest` | the `/registry` screen |
| `mc-agent-tools-workflow` | the workflow installer |

## Testing

- Unit tests in all four modules (walk and exclusion, removal order, used-by incl. the chain, per-installer remove and references, the views) — green.
- Manually in the admin UI against `mindconnect-ai/mc-registry` with a fresh data directory: imported the *Release notes kit* with one entry unticked (3 imported, 1 skipped), removed it with the config unticked (3 removed, 1 kept), re-imported; *Document kit* shows `agent-default`, `openai-default` and `document-analyst` as used and unticked.
- Not covered: references kept outside the entities themselves (a tool setting or an application property naming a default agent, the vector tools' `embeddings` config) are not detected — the docs say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

