### PR TITLE
Fix skill review findings: tool binding, Skills screen, unique names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,22 @@ fresh empty one, so nothing has to be moved by hand at release time.
   migration rows, trace cards — read at body size in the theme's text colour
   instead of the framework's small grey detail style.
 
+### Fixed
+
+- **agents:** an agent reaches only the skills its setting allows. The `skill`
+  tool could also be found with `tool_search` or assigned by hand from the tool
+  catalog, and that copy carried no names — it offered every skill, even to an
+  agent with skills switched off, and sat beside the injected one as a second
+  tool of the same name, which a provider can reject. The setting is now the
+  only way an agent gets the tool.
+- **agents:** the **Skills** screen lists every stored skill again, including
+  one switched off or hidden behind a user's `SKILL.md` of the same name —
+  before, such a skill disappeared from the list and could only be reached by
+  its URL. Saving a second stored skill under a name one already has is
+  refused (a toast in the admin UI, `409` from `/api/skills`), since an agent
+  looks skills up by name and would silently get only one of them; a name no
+  model could type is a `400` from the API instead of a `500`.
+
 ## [0.8.1] - 2026-09-12
 
 ### Fixed

--- a/agents/client/mc-agent-cli/src/main/resources/initial-data/skills/pull-request-review.md
+++ b/agents/client/mc-agent-cli/src/main/resources/initial-data/skills/pull-request-review.md
@@ -5,8 +5,8 @@ tools: bash, file_read, grep
 ---
 # Reviewing a change
 
-An example skill, and a working one — edit it, or delete it, to make the
-screen yours. It shows the shape a skill has: a description that says WHEN,
+An example skill, and a working one — edit it, or switch it off, to make the
+screen yours (deleted, it comes back with the next start). It shows the shape a skill has: a description that says WHEN,
 and instructions long enough to be worth loading.
 
 ## Read the change before judging it

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/skill/SkillCatalog.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/skill/SkillCatalog.java
@@ -113,6 +113,17 @@ public final class SkillCatalog {
     }
 
     /**
+     * The {@code SKILL.md} files in this user's own skills directory, as they
+     * are — not merged with the stored skills. What a screen that manages
+     * skills lists beside the store: {@link #all} answers what an agent can
+     * load, and leaves out exactly the skills such a screen must still show,
+     * a stored one switched off or hidden behind a file of the same name.
+     */
+    public List<Skill> userSkills(UserId userId) {
+        return FileSkills.list(userDir(userId), SkillSource.USER);
+    }
+
+    /**
      * The skills a binding may load: everything {@link #all} found when it
      * names none, and only the ones it names otherwise. This is the form the
      * {@code skill} tool works in — it knows the names its binding carries,

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/tools/toolsearch/DynamicToolActivations.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/tools/toolsearch/DynamicToolActivations.java
@@ -75,7 +75,10 @@ public final class DynamicToolActivations {
      *   <li>the {@code skill} tool when the agent enables skills and there
      *       are any to load, carrying the names its setting names for the same
      *       reason. A tool that would find nothing is left away, so the switch
-     *       costs nothing until somebody writes a skill.</li>
+     *       costs nothing until somebody writes a skill. This is the only way
+     *       an agent gets it: a {@code skill} row among its tools or found by
+     *       a search is dropped, since it would carry no names and reach
+     *       every skill, whatever the setting says.</li>
      * </ul>
      */
     public List<AgentTool> effectiveRefs(ai.mindconnect.agent.runtime.domain.AgentDefinition def, SessionId sessionId) {
@@ -83,6 +86,9 @@ public final class DynamicToolActivations {
         List<AgentTool> refs = new ArrayList<>();
         List<String> deferredNames = new ArrayList<>();
         for (AgentTool tool : def.tools()) {
+            // The skill tool follows the agent's skills setting alone (below): a
+            // row assigned by hand would carry no names and reach every skill.
+            if (SkillTool.NAME.equals(tool.name())) continue;
             if (!tool.deferred()) {
                 refs.add(tool);
                 continue;
@@ -93,6 +99,9 @@ public final class DynamicToolActivations {
             }
         }
         for (String name : activated) {
+            // Same for an activation: a session that searched its way to the
+            // skill tool before this was closed off must not keep a second one.
+            if (SkillTool.NAME.equals(name)) continue;
             if (def.tools().stream().noneMatch(t -> name.equals(t.name()))) {
                 refs.add(AgentTool.of(name));
             }
@@ -104,9 +113,7 @@ public final class DynamicToolActivations {
                     "groups", List.copyOf(search.groups()))));
         }
         var skillsConfig = def.skillsOrOff();
-        if (skillsConfig.enabled()
-                && def.tools().stream().noneMatch(t -> SkillTool.NAME.equals(t.name()))
-                && hasSkills(def, sessionId)) {
+        if (skillsConfig.enabled() && hasSkills(def, sessionId)) {
             refs.add(AgentTool.of(SkillTool.NAME, null, Map.of(
                     SkillToolFactory.NAMES, List.copyOf(skillsConfig.names()))));
         }

--- a/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/tools/toolsearch/ToolSearchTool.java
+++ b/agents/core/mc-agent-runtime-core/src/main/java/ai/mindconnect/agent/runtime/tools/toolsearch/ToolSearchTool.java
@@ -2,6 +2,7 @@ package ai.mindconnect.agent.runtime.tools.toolsearch;
 
 import ai.mindconnect.agent.tool.ToolCallScope;
 import ai.mindconnect.agent.SessionId;
+import ai.mindconnect.agent.runtime.skill.SkillTool;
 import ai.mindconnect.agent.tool.ToolRegistryRef;
 import ai.mindconnect.agent.tool.AgentTool;
 import ai.mindconnect.agent.tool.Tool;
@@ -159,6 +160,8 @@ public final class ToolSearchTool implements Tool {
                     .findFirst().orElse("assigned"));
         }
         candidates.remove(name());   // searching for the search tool helps nobody
+        // The skill tool comes with the agent's skills setting, never from a search.
+        candidates.remove(SkillTool.NAME);
         return candidates;
     }
 

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/skill/SkillToolBindingTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/skill/SkillToolBindingTest.java
@@ -87,6 +87,48 @@ class SkillToolBindingTest {
         assertThat(refs(agent(null))).extracting(AgentTool::name).containsExactly("file_read");
     }
 
+    /** A session repository holding one session that a search has already given {@code names}. */
+    private static AgentSessionRepository sessionThatActivated(AgentSession session) {
+        return new AgentSessionRepository() {
+            @Override public AgentSession create(AgentSession s) { return s; }
+            @Override public Optional<AgentSession> update(SessionId id, UnaryOperator<AgentSession> change) {
+                return Optional.of(change.apply(session));
+            }
+            @Override public Optional<AgentSession> findById(SessionId id) { return Optional.of(session); }
+            @Override public List<AgentSession> findByAgent(AgentId agent, UserId user) { return List.of(); }
+            @Override public List<AgentSession> findByUser(UserId user) { return List.of(); }
+            @Override public List<AgentSession> findByParentSession(SessionId parent) { return List.of(); }
+            @Override public void deleteById(SessionId id) { }
+        };
+    }
+
+    @Test
+    void aSkillToolFoundBySearchIsNeitherASecondToolNorAWayPastTheSetting() {
+        AgentSession session = AgentSession.start(AgentId.random(), UserId.of("alice"), ConversationId.random())
+                .withActivatedTools(List.of(SkillTool.NAME));
+        var activations = new DynamicToolActivations(sessionThatActivated(session), catalog());
+
+        var narrowed = activations.effectiveRefs(
+                agent(new AgentDefinition.SkillsConfig(true, List.of("release"))), session.id());
+        assertThat(narrowed).extracting(AgentTool::name).containsExactly("file_read", SkillTool.NAME);
+        assertThat(narrowed.get(1).overrides()).containsEntry(SkillToolFactory.NAMES, List.of("release"));
+
+        assertThat(activations.effectiveRefs(agent(AgentDefinition.SkillsConfig.OFF), session.id()))
+                .as("switched off, a search result does not bring the tool back")
+                .extracting(AgentTool::name).containsExactly("file_read");
+    }
+
+    @Test
+    void aSkillToolAssignedByHandIsDroppedInFavourOfTheSetting() {
+        AgentDefinition off = agent(AgentDefinition.SkillsConfig.OFF)
+                .withTools(List.of(AgentTool.of("file_read"), AgentTool.of(SkillTool.NAME)));
+        assertThat(refs(off)).extracting(AgentTool::name).containsExactly("file_read");
+
+        var refs = refs(off.withSkills(new AgentDefinition.SkillsConfig(true, List.of("release"))));
+        assertThat(refs).extracting(AgentTool::name).containsExactly("file_read", SkillTool.NAME);
+        assertThat(refs.get(1).overrides()).containsEntry(SkillToolFactory.NAMES, List.of("release"));
+    }
+
     @Test
     void theFactoryBuildsTheToolAgainstTheBindingAndTheCallersDirectory() {
         var factory = new SkillToolFactory();

--- a/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/tools/toolsearch/ToolSearchToolTest.java
+++ b/agents/core/mc-agent-runtime-core/src/test/java/ai/mindconnect/agent/runtime/tools/toolsearch/ToolSearchToolTest.java
@@ -146,6 +146,25 @@ class ToolSearchToolTest {
     }
 
     @Test
+    void theSkillToolIsNeverAMatch() {
+        ToolRegistry withSkill = new ToolRegistry() {
+            @Override public Optional<Tool> resolve(AgentTool agentTool, ToolCallScope scope) {
+                return Optional.of(stubTool(agentTool.name(), "Loads the full instructions of one skill."));
+            }
+            @Override public Map<String, Set<String>> toolNamesByGroup() {
+                return Map.of("skills", Set.of(ai.mindconnect.agent.runtime.skill.SkillTool.NAME));
+            }
+        };
+        ref.set(withSkill);
+
+        String result = tool(Set.of(), Set.of("*")).execute(Map.of("query", "skill instructions"));
+
+        assertThat(result).as("the skill tool comes with the agent's skills setting, not from a search")
+                .startsWith("No tools found");
+        assertThat(activations.activated(sessionId)).isEmpty();
+    }
+
+    @Test
     void assignedDeferredToolsAreSearchableWithoutAnyGroupGrant() {
         String result = tool(Set.of("code_execute"), Set.of())
                 .execute(Map.of("query", "execute a program"));

--- a/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/skills/pull-request-review.md
+++ b/agents/server/mc-agent-admin-ui-app/src/main/resources/initial-data/skills/pull-request-review.md
@@ -5,8 +5,8 @@ tools: bash, file_read, grep
 ---
 # Reviewing a change
 
-An example skill, and a working one — edit it, or delete it, to make the
-screen yours. It shows the shape a skill has: a description that says WHEN,
+An example skill, and a working one — edit it, or switch it off, to make the
+screen yours (deleted, it comes back with the next start). It shows the shape a skill has: a description that says WHEN,
 and instructions long enough to be worth loading.
 
 ## Read the change before judging it

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/SkillUiController.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/SkillUiController.java
@@ -32,8 +32,9 @@ import java.util.Optional;
 /**
  * The skills screens. Ids in paths are their plain values.
  *
- * <p>The list shows what an agent could actually load: the stored skills and
- * the {@code SKILL.md} files in the signed-in user's own skills directory. A
+ * <p>The list shows every stored skill — a switched-off one too, since this
+ * is where it is switched back on — and the {@code SKILL.md} files in the
+ * signed-in user's own skills directory. A
  * project's skills belong to a session's working directory and show up in
  * the chat that works there, not on this screen.
  *
@@ -135,6 +136,9 @@ public class SkillUiController {
         if (!skill.hasValidName()) {
             return ResponseEntity.ok(VersionedForms.unusableName("Skill", skill.name()));
         }
+        if (nameTaken(skill)) {
+            return ResponseEntity.ok(VersionedForms.nameTaken("Skill", skill.name()));
+        }
         Skill saved = repository().save(skill);
         return detail(saved.id().value(), user);
     }
@@ -157,6 +161,9 @@ public class SkillUiController {
                 .withVersion(VersionedForms.version(body));
         if (!updated.hasValidName()) {
             return ResponseEntity.ok(VersionedForms.unusableName("Skill", updated.name()));
+        }
+        if (nameTaken(updated)) {
+            return ResponseEntity.ok(VersionedForms.nameTaken("Skill", updated.name()));
         }
         try {
             repository().save(updated);
@@ -183,9 +190,22 @@ public class SkillUiController {
                         .findFirst());
     }
 
-    /** What this user can see: the stored skills plus their own files. */
+    /**
+     * What this user can see: every stored skill — switched off or hidden
+     * behind a file of the same name included, since this is where it is
+     * switched back on or deleted — then their own files.
+     */
     private List<Skill> visible(OidcUser user) {
-        return catalog().all(userIdOf(user), null);
+        List<Skill> skills = new java.util.ArrayList<>(repository().findAll());
+        skills.addAll(catalog().userSkills(userIdOf(user)));
+        return List.copyOf(skills);
+    }
+
+    /** Whether another stored skill already carries {@code skill}'s name. */
+    private boolean nameTaken(Skill skill) {
+        return repository().findByName(skill.name())
+                .filter(other -> !other.id().equals(skill.id()))
+                .isPresent();
     }
 
     /** The signed-in user as an id, or {@code null} when there is none to read. */

--- a/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VersionedForms.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/main/java/ai/mindconnect/adminui/ui/controller/VersionedForms.java
@@ -43,6 +43,17 @@ class VersionedForms {
                 .title(what + " not saved"));
     }
 
+    /**
+     * What the save answers to a name another stored entry already has — a
+     * skill's, which the runtime looks up by name, so two of them would leave
+     * one silently unreachable.
+     */
+    static UiPatch nameTaken(String what, String name) {
+        return UiPatch.of().toast(UiToast.error("There is already a " + what.toLowerCase(java.util.Locale.ROOT)
+                        + " named '" + name + "'. Choose another name, or edit that one.")
+                .title(what + " not saved"));
+    }
+
     /** What a save answers on a host that wires no store for what it is saving. */
     static UiPatch noStore() {
         return UiPatch.of().toast(UiToast.error("This installation stores no skills. A project or a "

--- a/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/SkillUiControllerTest.java
+++ b/agents/server/mc-agent-admin-ui-rest/src/test/java/ai/mindconnect/adminui/ui/controller/SkillUiControllerTest.java
@@ -1,0 +1,69 @@
+package ai.mindconnect.adminui.ui.controller;
+
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemorySkillRepository;
+import ai.mindconnect.agent.runtime.skill.Skill;
+import ai.mindconnect.agent.runtime.skill.SkillCatalog;
+import ai.mindconnect.agent.runtime.skill.SkillRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The skills screen manages the store, so it lists every stored skill —
+ * including one switched off, which an agent can no longer load but which
+ * still has to be found here to be switched back on — and it refuses a name
+ * another stored skill already carries.
+ */
+class SkillUiControllerTest {
+
+    private final InMemorySkillRepository repository = new InMemorySkillRepository();
+    private final SkillUiController controller = controller(repository);
+
+    private static SkillUiController controller(SkillRepository repository) {
+        var beans = new StaticListableBeanFactory();
+        beans.addBean("skillRepository", repository);
+        beans.addBean("skillCatalog", SkillCatalog.of(repository, SkillCatalog.OFF));
+        return new SkillUiController(beans.getBeanProvider(SkillRepository.class),
+                beans.getBeanProvider(SkillCatalog.class));
+    }
+
+    private static Skill stored(String name, boolean enabled) {
+        Skill skill = Skill.create(name, "Use when " + name, "Do it.", List.of());
+        return enabled ? skill : skill.withFields(name, skill.description(), skill.instructions(), List.of(), false);
+    }
+
+    @Test
+    void aSkillSwitchedOffStaysOnTheList() throws Exception {
+        repository.save(stored("release", true));
+        repository.save(stored("hotfix", false));
+
+        String list = json(controller.list(null));
+
+        assertThat(list).contains("release").contains("hotfix (off)");
+    }
+
+    @Test
+    void aNameAnotherStoredSkillHasIsRefused_onCreateAndOnRename() throws Exception {
+        repository.save(stored("release", true));
+        Skill hotfix = repository.save(stored("hotfix", true));
+
+        String created = json(controller.create(Map.of("name", "Release", "description", "d",
+                "instructions", "i"), null).getBody());
+        assertThat(created).contains("already a skill named 'release'");
+
+        String renamed = json(controller.update(hotfix.id().value(), Map.of("name", "release",
+                "description", "d", "instructions", "i"), null).getBody());
+        assertThat(renamed).contains("already a skill named 'release'");
+
+        assertThat(repository.findAll()).extracting(Skill::name).containsExactly("hotfix", "release");
+    }
+
+    private static String json(Object node) throws Exception {
+        return new ObjectMapper().findAndRegisterModules().writeValueAsString(node);
+    }
+}

--- a/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/SkillApiController.java
+++ b/agents/server/mc-agent-api-rest/src/main/java/ai/mindconnect/agentrest/controller/SkillApiController.java
@@ -77,16 +77,39 @@ public class SkillApiController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @Operation(summary = "Create a skill")
+    @Operation(summary = "Create a skill",
+            description = "Refused with 400 when the name is not lower-case letters, digits and "
+                    + "dashes, and with 409 when a stored skill already has it.")
     @PostMapping
-    public ResponseEntity<Skill> create(@RequestBody SkillRequest req) {
+    public ResponseEntity<?> create(@RequestBody SkillRequest req) {
         log.info("POST /api/skills name={}", req.name());
         Skill skill = Skill.create(req.name(), req.description(), req.instructions(), req.tools());
         if (req.enabled() != null && !req.enabled()) {
             skill = skill.withFields(skill.name(), skill.description(), skill.instructions(),
                     skill.tools(), false);
         }
-        return ResponseEntity.ok(repository.save(skill));
+        ResponseEntity<String> refused = refusal(skill);
+        return refused != null ? refused : ResponseEntity.ok(repository.save(skill));
+    }
+
+    /**
+     * Why {@code skill} cannot be saved as it is, or {@code null} when it can:
+     * a name no model could type is the caller's mistake (400), and a name
+     * another stored skill has is a conflict (409) — the runtime looks skills
+     * up by name, so the second one would never be reached.
+     */
+    private ResponseEntity<String> refusal(Skill skill) {
+        if (!skill.hasValidName()) {
+            return ResponseEntity.badRequest().body("Skill name '" + skill.name() + "' is not usable: use "
+                    + "lower-case letters, digits and dashes, starting with a letter or digit, at most "
+                    + "64 characters");
+        }
+        boolean taken = repository.findByName(skill.name())
+                .filter(other -> !other.id().equals(skill.id()))
+                .isPresent();
+        return taken
+                ? ResponseEntity.status(HttpStatus.CONFLICT).body("A skill named '" + skill.name() + "' already exists")
+                : null;
     }
 
     @Operation(summary = "Update a skill",
@@ -104,6 +127,8 @@ public class SkillApiController {
                         req.tools() == null ? existing.tools() : req.tools(),
                         req.enabled() == null ? existing.enabled() : req.enabled())
                 .withVersion(req.version());
+        ResponseEntity<String> refused = refusal(updated);
+        if (refused != null) return refused;
         try {
             return ResponseEntity.ok(repository.save(updated));
         } catch (StaleVersionException e) {

--- a/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SkillApiControllerTest.java
+++ b/agents/server/mc-agent-api-rest/src/test/java/ai/mindconnect/agentrest/controller/SkillApiControllerTest.java
@@ -1,0 +1,53 @@
+package ai.mindconnect.agentrest.controller;
+
+import ai.mindconnect.agent.runtime.adapter.repo.memory.InMemorySkillRepository;
+import ai.mindconnect.agent.runtime.skill.Skill;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A skill is looked up by name, so the API refuses a name no model could type
+ * as the caller's mistake and a name another skill already has as a conflict —
+ * instead of failing with 500, or storing a second skill nobody can reach.
+ */
+class SkillApiControllerTest {
+
+    private final InMemorySkillRepository repository = new InMemorySkillRepository();
+    private final SkillApiController controller = new SkillApiController(repository);
+
+    private static SkillApiController.SkillRequest request(String name) {
+        return new SkillApiController.SkillRequest(name, "Use when releasing", "Tag, then push.",
+                List.of(), null, null);
+    }
+
+    @Test
+    void anUnusableNameIsABadRequest() {
+        assertThat(controller.create(request("Weekly Report")).getStatusCode().value()).isEqualTo(400);
+        assertThat(controller.create(request(null)).getStatusCode().value()).isEqualTo(400);
+        assertThat(repository.findAll()).isEmpty();
+    }
+
+    @Test
+    void aNameAnotherSkillHasIsAConflict_onCreateAndOnRename() {
+        assertThat(controller.create(request("release")).getStatusCode().value()).isEqualTo(200);
+        assertThat(controller.create(request("Release")).getStatusCode().value()).isEqualTo(409);
+
+        Skill other = (Skill) controller.create(request("hotfix")).getBody();
+        assertThat(controller.update(other.id().value(), request("release")).getStatusCode().value())
+                .isEqualTo(409);
+        assertThat(repository.findAll()).extracting(Skill::name).containsExactly("hotfix", "release");
+    }
+
+    @Test
+    void savingASkillUnderItsOwnNameIsNoConflict() {
+        Skill saved = (Skill) controller.create(request("release")).getBody();
+
+        var updated = controller.update(saved.id().value(), new SkillApiController.SkillRequest(
+                null, "Use when cutting a release", null, null, null, null));
+
+        assertThat(updated.getStatusCode().value()).isEqualTo(200);
+    }
+}

--- a/website/docs/agents/admin-ui/skills.md
+++ b/website/docs/agents/admin-ui/skills.md
@@ -13,13 +13,15 @@ concept — the three sources, the file format, how one is written — is
 
 ## The list
 
-It shows what an agent could actually load: the skills this installation
-stores, plus the `SKILL.md` files in the signed-in user's own skills directory.
+It shows every skill this installation stores, plus the `SKILL.md` files in the
+signed-in user's own skills directory.
 A skill a project keeps in its `.mindconnect/skills/` belongs to a session's
 working directory and shows up in the chat that works there, not here.
 
-- **New Skill** — create one.
-- **Delete** — on a stored skill's row.
+- **New Skill** — create one. A name another stored skill already has is
+  refused: an agent looks skills up by name.
+- **Delete** — on a stored skill's row. A skill the app ships comes back on
+  the next start; switch it off instead to keep it away.
 - A row from a file says so and has no buttons: it is edited where it lies,
   and this screen has no business writing into somebody's repository or home
   directory.

--- a/website/docs/agents/skills.md
+++ b/website/docs/agents/skills.md
@@ -104,18 +104,22 @@ may load — so a model cannot invent one, and a wrong guess costs no round.
 
 ## Managing skills
 
-The **Skills** screen lists what an agent could load: the stored skills plus
-the files in the signed-in user's own skills directory. Stored skills are
-created, edited, switched off and deleted there; a skill read from a file is
-shown read-only and edited where it lies. Every stored skill can be fetched as
+The **Skills** screen lists every stored skill — one switched off included,
+marked `(off)` — plus the files in the signed-in user's own skills directory.
+Stored skills are created, edited, switched off and deleted there; a skill read
+from a file is shown read-only and edited where it lies. A stored name is
+unique: saving a second skill under a name one already has is refused, since
+an agent looks skills up by name. Every stored skill can be fetched as
 a `SKILL.md` (`/admin/api/skills/{id}/markdown`, or `/api/skills/{id}/markdown`)
 — drop that file into a repository's `.mindconnect/skills/` and it travels with
 the code.
 
-Skills shipped with the app are imported once on first start from
-`initial-data/skills/*.md`; see [Initial data](./initial-data.md). A stored
-skill is never overwritten by the shipped version — it is prose someone has
-since made their own.
+Skills shipped with the app are imported on start from
+`initial-data/skills/*.md` whenever no stored skill carries their name; see
+[Initial data](./initial-data.md). A stored skill is never overwritten by the
+shipped version — it is prose someone has since made their own. Deleting a
+shipped skill therefore brings it back on the next start; to be rid of one,
+switch it off.
 
 ## Configuration
 


### PR DESCRIPTION
Follow-up to #83, from a code review of the skills feature. The fixes below
landed after #83 was merged.

## Fixes

- **The `skill` tool comes from the skills setting alone** (`60c955d`).
  - `tool_search` could find and activate it, and it could be assigned by hand
    from the tool catalog.
  - That copy carried no names, so it offered every skill, even with skills
    switched off. It also sat beside the injected tool as a second tool of the
    same name, which a provider can reject.
  - `tool_search` no longer offers it, and a `skill` row among an agent's tools
    or activations is dropped.
- **Skills screen and names** (`718ef99`).
  - The list was built from what agents can load, so a stored skill that is
    switched off, or hidden behind a user's file of the same name, disappeared
    from it. It now lists every stored skill, then the user's own files.
  - A second stored skill under an existing name is refused: a toast in the
    admin UI, `409` from `/api/skills`.
  - A name no model could type is `400` from the API instead of `500`.
- **Docs** (`6e8535c`). Shipped skills are re-imported whenever their name is
  missing, like every other seed. The skills page and the example skill no
  longer claim otherwise, and they point to switching a skill off instead of
  deleting it.

The changelog has entries under *Fixed*.

## Verification

- New tests:
  - `SkillToolBindingTest`: a search-activated and a hand-assigned `skill`
    tool.
  - `ToolSearchToolTest`: the `skill` tool is never a match.
  - `SkillUiControllerTest`: a switched-off skill stays listed, and a taken
    name is refused.
  - `SkillApiControllerTest`: `400` / `409`.
- CI-equivalent build (`mc-java-parent`, `workflow` without tests, `agents`
  `clean install`): 1216 tests in 46 modules, no failures. The build ran on
  code identical to this branch except for `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
